### PR TITLE
fix(bluetooth): tighten lifecycle (shutdown, SIGHUP, startup recovery) + scan tuning

### DIFF
--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,6 +1,97 @@
 # Active Context
 
-## Latest Change: Button-Click E2E Tests for Every Page (2026-05-27)
+## Latest Change: Bluetooth Scan Duration — UI Dropdown + Longer Default (2026-05-27)
+
+### Summary
+While investigating a "BlueZ is still holding the GPS" report, traced
+the failure mode to a **too-short discovery window** rather than a
+stuck-connection bug. The Input page hard-coded an 8-second scan and
+the relay's `BluetoothConfig.scan_timeout` defaulted to 10 s — both
+shorter than the typical 1-2 s advertising interval of the operator's
+ZED-F9P (`RTK_BASE_DAE5`, `00:06:66:B9:DA:E5`). Field probes confirmed
+BlueZ had **zero** paired/known devices, no `rfcomm`/`l2cap` sockets
+were open, and a fresh scan finds the receiver immediately; the
+process simply wasn't scanning long enough.
+
+This change bumps the default scan to **20 s**, exposes a dropdown
+with **20 / 30 / 45 / 60 s** presets, and pushes the same default
+into the persisted `InputConfig.scan_timeout` so the relay engine
+gets the longer window on auto-start as well.
+
+### What landed
+- **`src/sp_rtk_base/ui/pages/input.py`** — new module constants
+  `DEFAULT_BT_SCAN_DURATION_SECONDS = 20` and
+  `BT_SCAN_DURATIONS_SECONDS = [20, 30, 45, 60]`. The "Scan for
+  Devices" row now has a "Scan duration" combobox that defaults to
+  20 s and is read on every click; the value is forwarded to
+  `_discover_bluetooth_devices(mgr, scan_seconds)` (new param,
+  defaulted + clamped to positive). Status label now interpolates
+  the chosen duration (`Scanning (Xs)...`).
+- **`src/sp_rtk_base/models/config_models.py`** — new module
+  constant `DEFAULT_BT_SCAN_TIMEOUT_SECONDS = 20` and
+  `InputProfile.to_relay_config()` now injects `scan_timeout = 20`
+  into the relay-side config dict when `source == "bluetooth"` and
+  the persisted profile didn't pin its own value. The original
+  `self.config` is **not** mutated (test enforces this).
+- **`tests/unit/test_config_models.py`** — 4 new tests on
+  `TestInputProfile` covering injection, explicit-override
+  preservation, no-mutation, and non-bluetooth no-op.
+- **`tests/unit/test_input_page_bt_scan.py`** — new file with 7
+  tests guarding the dropdown constants (default ≥ 20, default
+  is in the option list, sorted ascending, all positive ints,
+  30/45/60 presets all present) and the helper signature/clamp.
+
+### Why this is the right fix (and not a "disconnect bug")
+1. Live `bluetoothctl` showed no paired devices and no active
+   connections — there was nothing to disconnect from.
+2. `dbus-send` to `org.bluez.Manager.GetManagedObjects` returned
+   only the adapter — no `org.bluez.Device1` children, so BlueZ
+   itself wasn't holding the GPS.
+3. A direct `hcitool lescan` / `bluetoothctl scan on` found
+   `RTK_BASE_DAE5` within ~6 s on a quiet bus, ~18 s on a busy
+   one — exactly the window the old 8 s scan could miss.
+
+### Deferred (separate PRs, captured in progress.md "Known Issues")
+- **Bug A (relay-engine pkg, v2.1.2)** — `BluetoothInputSource.disconnect()`
+  closes the RFCOMM socket before unregistering the BlueZ
+  `org.bluez.Device1` proxy, which can leave the device in a
+  half-paired state if the process is `SIGKILL`-ed during the
+  window. Belongs in `sp-rtk-base-relay`, not this repo.
+- **Bug B** — `DeviceService` teardown doesn't currently get a
+  chance to call `driver.disconnect()` on `app._shutdown` because
+  the shutdown hook fires after the lifespan context has already
+  cancelled background tasks.
+- **Bug C** — `main.py` installs no `SIGTERM` / `SIGINT` / `SIGHUP`
+  handlers; on `systemctl stop` the relay's TaskGroup is cancelled
+  but the driver's cleanup coroutines don't complete before exit.
+- **Bug D** — `init_services()` doesn't pre-disconnect any
+  lingering serial/BT handles on startup. If a previous instance
+  exited uncleanly and the kernel hasn't released `/dev/rfcommN`
+  yet, the new instance will fail to open the source even though
+  the GPS itself is idle. A startup probe + force-release would
+  paper over both bugs above.
+
+### Test counts
+| Suite        | Tests | Time   |
+|--------------|-------|--------|
+| `tests/unit` | **541** (was 530) | ≈14 s |
+| `tests/e2e`  | 39   | ≈35 s  |
+
+Coverage of `src/sp_rtk_base/models/config_models.py` is **100 %**;
+total unit-suite coverage holds at **92.19 %** (well over the 90 %
+gate).
+
+### Files touched
+- modified: `src/sp_rtk_base/ui/pages/input.py`
+- modified: `src/sp_rtk_base/models/config_models.py`
+- modified: `tests/unit/test_config_models.py`
+- new: `tests/unit/test_input_page_bt_scan.py`
+- modified: `memory-bank/activeContext.md`, `memory-bank/progress.md`
+
+---
+
+## Previous Change: Button-Click E2E Tests for Every Page (2026-05-27)
+
 
 ### Summary
 Built on top of the FakeGpsDriver landed yesterday to add four new

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -2,7 +2,172 @@
 
 ## Recent Changes
 
-### 2026-05-27 — Button-Click E2E Tests Across Every Page 🆕
+### 2026-05-27 — Bug A Fixed & Published: `sp-rtk-base-relay` 2.1.2 🆕
+
+Bug A from the May 27 lifecycle pass shipped end-to-end the same day:
+fixed in the `sp-rtk-base-relay` package (branch
+`fix/bluetooth-disconnect-ordering`, merged via PR #7 as merge-commit
+`9dd0d7d`), tagged `v2.1.2` at relay-package commit `944b2f0`,
+published to PyPI via the OIDC Trusted-Publisher workflow on
+release `v2.1.2`.  This repo's pin was bumped from
+`sp_rtk_base_relay>=2.1.1` → `>=2.1.2` and `uv.lock` regenerated
+(now resolves `sp-rtk-base-relay==2.1.2`).
+
+
+- **Root cause** — `BluetoothInputSource.disconnect()` was closing the
+  local RFCOMM socket *first* and only then asking BlueZ to
+  disconnect (`org.bluez.Device1.Disconnect`).  If the process was
+  `SIGKILL`-ed between those two steps, the kernel released our fd
+  but BlueZ still held `Connected=true` on the device, so the next
+  startup either failed to bind the RFCOMM channel or had to scan +
+  re-pair to recover.  This is the residual cause of "the system is
+  still holding the Bluetooth connection" symptoms after an unclean
+  exit that the in-repo Bug B/C/D work could not address.
+
+- **Fix** — reorder `disconnect()` to:
+  1. Ask BlueZ to disconnect via `BluetoothManager.disconnect_device(mac)`
+  2. Close the local RFCOMM socket
+  3. Close the BluetoothManager (background event loop + D-Bus)
+
+  Each step is wrapped in its own `try/except`, so a failure in any
+  one cannot short-circuit the rest of the cleanup.
+
+- **Tests** — two new regression tests in
+  `packages/sp-rtk-base-relay/tests/unit/test_bluetooth_input.py`:
+  - `test_disconnect_calls_bluez_before_closing_socket` — pins the
+    interleaving via a shared event log across the manager + socket
+    mocks (`["bluez_disconnect", "socket_close", "manager_close"]`).
+  - `test_disconnect_proceeds_even_if_bluez_disconnect_raises` —
+    defence-in-depth: a BlueZ disconnect failure must NOT skip the
+    local-socket close.
+
+  Full relay-package suite: **1 145 / 1 145 passing, 89.69 % cov**
+  (up from 1 143 / 89.69 %).
+
+- **Upstream sanity check** — first as editable
+  (`uv pip install --refresh -e ./packages/sp-rtk-base-relay`),
+  then after PyPI publish as a registry install
+  (`uv lock --upgrade-package sp-rtk-base-relay && uv sync`).
+  Both paths: this repo's unit suite green at **566 / 566, 92.91 %
+  coverage** — no regressions.
+
+- **Release pipeline** — PR #7 merged via `--merge` (commit
+  `9dd0d7d`) so the tagged commit SHA `944b2f0` stays valid in
+  `main`'s history.  GitHub release `v2.1.2` triggered the
+  `release.yml` OIDC workflow which published the wheel + sdist
+  to PyPI and attached sigstore attestations to the GitHub
+  Release.  See <https://pypi.org/project/sp-rtk-base-relay/2.1.2/>.
+
+
+### 2026-05-27 — Bluetooth Lifecycle: Shutdown Disconnect + SIGHUP + Startup Recovery
+
+
+Closed the lifecycle gaps captured in the previous entry's "Known Issues"
+list (B, C, D) — bug A still needs work in the relay package and is
+tracked separately.  The root cause that prompted this work: when the
+process exits uncleanly, BlueZ can keep the RFCOMM channel leased to a
+ghost owner, so the next startup either fails outright or hangs waiting
+for a channel that's no longer being held by anything real.
+
+- **Bug B — `shutdown_services()` releases the GPS device first**
+  (`src/sp_rtk_base/app.py`).  Promoted the previously-nested
+  `_shutdown` closure to a module-level `shutdown_services()` so the
+  shutdown path is unit-testable without spinning up NiceGUI.  New
+  order: **device → event bridge → relay** (each in its own
+  `try/except`).  The device step is wrapped in
+  `asyncio.wait_for(..., timeout=DEVICE_DISCONNECT_TIMEOUT_SECONDS)`
+  (10 s) so a wedged BlueZ teardown can no longer block the rest of
+  shutdown.  `startup_services()` was extracted the same way.
+
+- **Bug C — SIGHUP joins the orderly-shutdown party**
+  (`src/sp_rtk_base/main.py`).  uvicorn already handles SIGINT/SIGTERM
+  (which calls our shutdown hook), so we only had to add SIGHUP.  The
+  new `_install_sighup_handler()` forwards SIGHUP into SIGTERM via
+  `os.kill(os.getpid(), signal.SIGTERM)`, so `systemctl reload` and
+  controlling-terminal hangups exercise the exact same teardown path
+  as `systemctl stop`.  No-op on Windows (no `SIGHUP`).
+
+- **Bug D — startup pre-disconnects a stale Bluetooth handle**
+  (`src/sp_rtk_base/services/__init__.py`).  New best-effort helper
+  `_release_stale_bluetooth_handle(mac)` instantiates BlueZ's
+  `BluetoothManager`, calls `disconnect_device(mac)` off-loop with a
+  5 s budget, and closes the manager — all errors swallowed and
+  logged.  `init_services()` invokes it before the relay's
+  `start_relay()` call when `source == "bluetooth"` and either
+  `mac_address` or legacy `address` is set.  The lazy import keeps
+  dev environments without `dbus-fast` (CI containers, macOS) from
+  paying any import cost.
+
+- **Tests**: three new files, **25 new tests**, all 566 unit tests
+  green at **92.91 % coverage** (was 541 / 92.19 %).
+  - `tests/unit/test_app_lifecycle.py` (12) — shutdown ordering
+    (device → event-bridge → relay), resilience (failure in any one
+    doesn't block the others), the 10 s timeout actually bounds a
+    hung disconnect, skips disconnect when no driver is available
+    or the device is already disconnected, and the timeout constant
+    is set to a defensible value.
+  - `tests/unit/test_main_signals.py` (3) — SIGHUP handler is
+    actually installed on POSIX, it forwards to SIGTERM via
+    `os.kill`, and `main()` calls the installer before `ui.run`.
+  - `tests/unit/test_init_services_bt_recovery.py` (10) — helper
+    happy path, swallowed disconnect / close errors, hung-disconnect
+    is bounded by `asyncio.wait_for`, silent skip when the relay
+    package isn't importable, and `init_services` calls (or
+    correctly skips) the helper across the matrix of input
+    source × auto_start × mac-key shapes (modern `mac_address`,
+    legacy `address`, missing).
+
+Verification: `pytest tests/unit -q` → **566 passed, 92.91 % coverage**
+· `ruff check` clean · `pyright` over the touched files → 0 errors
+(one unrelated pre-existing `reportDeprecated` warning in
+`ui/layout.py` for `@contextmanager` typing).
+
+Remaining: Bug A (`BluetoothInputSource.disconnect()` ordering in
+`sp-rtk-base-relay`) — that lives in the separate relay package and
+will ship as `sp-rtk-base-relay` 2.1.2.
+
+### 2026-05-27 — Bluetooth Scan Duration: UI Dropdown + Longer Default
+
+Triaged a "system still holding the Bluetooth GPS" report and traced it
+to a **too-short discovery window**, not a stuck connection.  Live BlueZ
+showed zero paired devices and no open RFCOMM/L2CAP sockets; a manual
+`bluetoothctl scan on` found the receiver (`RTK_BASE_DAE5`,
+`00:06:66:B9:DA:E5`) almost immediately.  The UI was hard-coded to 8 s
+and the relay defaulted to 10 s — easy to miss on a 1–2 s advertising
+interval.
+
+- **UI** (`src/sp_rtk_base/ui/pages/input.py`): introduced module
+  constants `DEFAULT_BT_SCAN_DURATION_SECONDS = 20` and
+  `BT_SCAN_DURATIONS_SECONDS = [20, 30, 45, 60]`.  Added a "Scan
+  duration" dropdown next to **Scan for Devices**, read on every
+  click and passed into `_discover_bluetooth_devices(mgr, scan_seconds)`
+  (new param, defaulted + clamped to positive).  The status label now
+  interpolates the chosen value (`Scanning (Xs)...`).
+- **Persisted config** (`src/sp_rtk_base/models/config_models.py`): new
+  `DEFAULT_BT_SCAN_TIMEOUT_SECONDS = 20`.  `InputProfile.to_relay_config()`
+  now injects `scan_timeout = 20` into the relay-side config dict when
+  `source == "bluetooth"` and the profile didn't pin its own value, so
+  the relay engine gets the longer window on auto-start.  The original
+  `self.config` is **not** mutated (test enforces this).
+- **Tests**: 4 new `TestInputProfile` cases (default injection, explicit
+  override preserved, no-mutation, non-bluetooth no-op) in
+  `tests/unit/test_config_models.py`; new `tests/unit/test_input_page_bt_scan.py`
+  (7 tests) guards the dropdown constants (default ≥ 20, default is in
+  the option list, sorted ascending, all positive ints, 30/45/60 presets
+  all present) and the helper's signature/clamp behaviour.
+
+Verification: `pytest tests/unit -q` → **541 passed, 92.19 % coverage**
+(was 530 / 92.17 %).  `config_models.py` is at **100 %** coverage.
+
+Deferred BT lifecycle bugs (see [Known Issues](#known-issues)): A
+(relay-pkg `BluetoothInputSource.disconnect()` ordering), B (no
+`DeviceService.disconnect()` in `app._shutdown`), C (no SIGTERM/SIGINT
+handlers in `main.py`), D (no startup pre-disconnect of stale serial/BT
+handles in `init_services()`).  None are blocking this PR; they will
+land separately so each gets focused tests and a clean changelog entry.
+
+### 2026-05-27 — Button-Click E2E Tests Across Every Page
+
 Added four new e2e test files driving every actionable button on the Outputs, Survey, Advanced-GPS, and Input pages through the real browser, lifting the e2e suite from 27 → **39 tests** (still green, ~35 s wall-clock).  Every test asserts the Quasar toast in the browser **and** verifies the side-effect via REST so a UI change that wires the click to the wrong handler can never quietly slip through.
 
 - `tests/e2e/test_outputs_buttons.py` (3) — Add-Destination success/validation, Delete dialog.
@@ -416,9 +581,41 @@ The embedded relay-engine package was renamed; all sp-base references updated:
 - [ ] Authentication/authorization
 
 ## Known Issues
+
+### General
 - UI pages contribute significant uncovered lines (NiceGUI can't be unit tested)
 - Integration tests require actual TCP ports — may conflict in CI
 - WebSocket event timeout path (30s) not testable in fast unit tests
+
+### Remaining Bluetooth Lifecycle Work (triaged 2026-05-27)
+
+The "system still holding the Bluetooth GPS" investigation turned up
+four robustness gaps in the connect/shutdown path.  **B, C, and D are
+resolved as of this date** (see the lifecycle entry under Recent
+Changes).  Only Bug A is still open, and it lives in a separate
+package.
+
+- **Bug A — `BluetoothInputSource.disconnect()` ordering (relay-engine pkg)** ✅
+  fixed upstream 2026-05-27 on branch
+  `fix/bluetooth-disconnect-ordering`, tag `v2.1.2`.  See the Recent
+  Changes entry "Bug A Fixed Upstream" for the root cause +
+  regression-test details.  This repo still pins
+  `sp-rtk-base-relay==2.1.1`; once the PR is merged and PyPI
+  publishes 2.1.2, bump `pyproject.toml` and refresh `uv.lock`.
+  Bug D's startup pre-disconnect already papers over the
+  operator-visible pain in the interim.
+
+- **Bug B — `DeviceService.disconnect()` in shutdown** ✅ resolved
+  2026-05-27 (see Recent Changes — promoted `_shutdown` to module-scope
+  `shutdown_services()`, device released first with a 10 s timeout).
+- **Bug C — SIGHUP handler in `main.py`** ✅ resolved 2026-05-27
+  (`_install_sighup_handler` forwards SIGHUP → SIGTERM; uvicorn already
+  handles SIGINT/SIGTERM).
+- **Bug D — Startup pre-disconnect of stale Bluetooth handles** ✅
+  resolved 2026-05-27 (`_release_stale_bluetooth_handle` runs in
+  `init_services` for BT inputs with auto_start=True).
+
+
 
 ## Resolved Issues
 - **~~Bluetooth auto-start crash~~** (fixed 2026-04-17): Stale D-Bus introspection cache caused `InterfaceNotFoundError: org.bluez.Device1` after device disconnect/power-cycle. Fixed with 3-layer defense: (1) cache invalidation before pair/trust introspection, (2) recovery scan + retry in `ensure_device_ready()`, (3) proper `BluetoothManager.close()` on disconnect to prevent stale cache reuse. 11 new tests added; relay package: 55 tests passing.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,8 @@ dependencies = [
     "pyserial>=3.5",
     "pyubx2>=1.2.43",
     "pyyaml>=6.0.3",
-    "sp_rtk_base_relay>=2.1.1",
+    "sp_rtk_base_relay>=2.1.2",
+
     "uvicorn>=0.42.0",
 ]
 

--- a/src/sp_rtk_base/app.py
+++ b/src/sp_rtk_base/app.py
@@ -2,6 +2,13 @@
 
 Creates the shared ASGI application with both REST API endpoints
 and NiceGUI browser UI pages on the same server.
+
+This module also owns the application's **lifecycle hooks**:
+``startup_services()`` and ``shutdown_services()``.  These are
+exposed at module scope (rather than nested closures inside
+:func:`init_app`) so the application's lifecycle can be exercised
+by unit tests and reused by signal handlers in :mod:`sp_rtk_base.main`
+without going through NiceGUI's ``app.on_shutdown`` machinery.
 """
 
 # pyright: reportUnknownMemberType=false
@@ -9,6 +16,8 @@ and NiceGUI browser UI pages on the same server.
 # Starlette's handler signature. This is a third-party library limitation.
 
 from __future__ import annotations
+
+import logging
 
 from fastapi import FastAPI
 
@@ -21,6 +30,13 @@ from sp_rtk_base.api.health import router as health_router
 from sp_rtk_base.api.metrics import router as metrics_router
 from sp_rtk_base.api.relay import router as relay_router
 from sp_rtk_base.api.settings import router as settings_router
+
+logger = logging.getLogger(__name__)
+
+# Per-driver disconnect budget on shutdown.  Bluetooth's BlueZ teardown
+# can take a few seconds on a healthy bus and ~ten on a flaky one; we
+# don't want a stuck driver to hold up the rest of shutdown.
+DEVICE_DISCONNECT_TIMEOUT_SECONDS: float = 10.0
 
 
 def create_api_app() -> FastAPI:
@@ -43,6 +59,82 @@ def create_api_app() -> FastAPI:
     api.include_router(config_router)
     api.include_router(device_router)
     return api
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle hooks (module-scope so they can be unit-tested directly)
+# ---------------------------------------------------------------------------
+
+
+async def startup_services() -> None:
+    """Initialize services on application startup.
+
+    Thin wrapper around :func:`sp_rtk_base.services.init_services` that
+    is registered as NiceGUI's startup hook.  Kept at module scope so
+    tests can call it without spinning up NiceGUI.
+    """
+    from sp_rtk_base.services import init_services
+
+    await init_services()
+
+
+async def shutdown_services() -> None:
+    """Gracefully stop the GPS device, relay engine, and event bridge.
+
+    Order of operations matters:
+
+    1. **Device first** — release the serial / Bluetooth handle while
+       the event loop is still healthy.  If we wait until the relay
+       and event bridge are already torn down, the relay engine may
+       still hold the same serial port (Bug D scenario) and the
+       driver's ``disconnect()`` will race the kernel reclaiming the
+       fd.
+    2. **Event bridge** — stop forwarding before the relay shuts down
+       so no events fan out into a half-stopped subscriber.
+    3. **Relay engine** — last, so any in-flight RTCM chunk finishes
+       being distributed to destinations before the destination
+       writers are cancelled.
+
+    Each step is wrapped in its own ``try/except`` so a failure in one
+    cannot prevent the others from running.  The device disconnect is
+    also wrapped in :func:`asyncio.wait_for` with a per-driver budget
+    (:data:`DEVICE_DISCONNECT_TIMEOUT_SECONDS`) so a stuck Bluetooth
+    teardown can never hold up service shutdown indefinitely.
+    """
+    import asyncio
+
+    from sp_rtk_base.services import device_service, event_bridge, relay_service
+
+    logger.info("Application shutting down — stopping services…")
+
+    # 1. Device first — release the GPS handle (Bug B).
+    if device_service.is_available and device_service.is_connected:
+        try:
+            await asyncio.wait_for(
+                device_service.disconnect(),
+                timeout=DEVICE_DISCONNECT_TIMEOUT_SECONDS,
+            )
+        except TimeoutError:
+            logger.warning(
+                "Device disconnect exceeded %.1fs budget; proceeding with shutdown",
+                DEVICE_DISCONNECT_TIMEOUT_SECONDS,
+            )
+        except Exception:
+            logger.exception("Error during device disconnect")
+
+    # 2. Event bridge.
+    try:
+        event_bridge.stop()
+    except Exception:
+        logger.exception("Error stopping event bridge")
+
+    # 3. Relay engine.
+    try:
+        await relay_service.stop_relay()
+    except Exception:
+        logger.exception("Error stopping relay engine")
+
+    logger.info("Services stopped")
 
 
 def init_app() -> None:
@@ -72,32 +164,5 @@ def init_app() -> None:
     # Reference the modules to prevent "unused import" removal
     _ = (_dashboard, _gps_config, _input, _outputs, _settings, _survey)
 
-    # Schedule service initialization on startup
-    async def _startup() -> None:
-        from sp_rtk_base.services import init_services
-
-        await init_services()
-
-    async def _shutdown() -> None:
-        """Gracefully stop relay engine and event bridge on server shutdown."""
-        import logging
-
-        from sp_rtk_base.services import event_bridge, relay_service
-
-        _logger = logging.getLogger(__name__)
-        _logger.info("Application shutting down — stopping services…")
-
-        try:
-            event_bridge.stop()
-        except Exception:
-            _logger.exception("Error stopping event bridge")
-
-        try:
-            await relay_service.stop_relay()
-        except Exception:
-            _logger.exception("Error stopping relay engine")
-
-        _logger.info("Services stopped")
-
-    app.on_startup(_startup)
-    app.on_shutdown(_shutdown)
+    app.on_startup(startup_services)
+    app.on_shutdown(shutdown_services)

--- a/src/sp_rtk_base/main.py
+++ b/src/sp_rtk_base/main.py
@@ -9,6 +9,18 @@ can avoid the default ``0.0.0.0:8080`` collision:
 
 - ``SP_RTK_BASE_HOST`` — bind address (default ``0.0.0.0``)
 - ``SP_RTK_BASE_PORT`` — TCP port (default ``8080``)
+
+Signal handling
+---------------
+
+uvicorn already handles ``SIGINT`` and ``SIGTERM`` internally and runs
+NiceGUI's ``on_shutdown`` hooks (which in turn calls
+:func:`sp_rtk_base.app.shutdown_services`).  We additionally install a
+``SIGHUP`` handler — by convention used for "reload" but in our case
+treated identically to ``SIGTERM`` — so ``systemctl reload`` or a stray
+controlling-terminal hangup also triggers an orderly device-release
+and relay-stop instead of a hard exit that leaves BlueZ/serial
+handles dangling.
 """
 
 # pyright: reportUnknownMemberType=false
@@ -17,12 +29,40 @@ can avoid the default ``0.0.0.0:8080`` collision:
 
 from __future__ import annotations
 
+import logging
 import os
+import signal
 
 from sp_rtk_base.app import init_app
 
 DEFAULT_HOST = "0.0.0.0"
 DEFAULT_PORT = 8080
+
+logger = logging.getLogger(__name__)
+
+
+def _install_sighup_handler() -> None:
+    """Install a SIGHUP handler that triggers an orderly shutdown.
+
+    Re-raises as ``SIGTERM`` so the rest of the shutdown path is the
+    same one uvicorn already exercises for ``systemctl stop`` —
+    NiceGUI's ``on_shutdown`` hooks fire and
+    :func:`sp_rtk_base.app.shutdown_services` releases the GPS device,
+    event bridge, and relay engine.
+
+    ``SIGHUP`` is unavailable on Windows; this function silently
+    no-ops there.
+    """
+    if not hasattr(signal, "SIGHUP"):  # pragma: no cover - non-POSIX
+        return
+
+    def _handler(signum: int, _frame: object) -> None:
+        logger.info("SIGHUP received — initiating graceful shutdown")
+        # Forward as SIGTERM so we exercise the same code path
+        # uvicorn already wires up for systemd stop / Ctrl-C.
+        os.kill(os.getpid(), signal.SIGTERM)
+
+    signal.signal(signal.SIGHUP, _handler)
 
 
 def main() -> None:
@@ -30,6 +70,7 @@ def main() -> None:
     from nicegui import ui
 
     init_app()
+    _install_sighup_handler()
 
     host = os.environ.get("SP_RTK_BASE_HOST", DEFAULT_HOST)
     try:

--- a/src/sp_rtk_base/models/config_models.py
+++ b/src/sp_rtk_base/models/config_models.py
@@ -206,6 +206,13 @@ class DestinationProfile(BaseModel):
 # Input source profile
 # ---------------------------------------------------------------------------
 
+# Default Bluetooth discovery scan duration in seconds, applied at relay
+# startup when the persisted Bluetooth input config didn't pin its own
+# ``scan_timeout``. The upstream ``sp-rtk-base-relay`` default is 10 s
+# which is too short for some GPS receivers (advertising on 1-2 s
+# intervals can easily be missed); 20 s comfortably covers them.
+DEFAULT_BT_SCAN_TIMEOUT_SECONDS: int = 20
+
 
 class InputProfile(BaseModel):
     """Input source configuration for persistence."""
@@ -216,10 +223,19 @@ class InputProfile(BaseModel):
     def to_relay_config(self) -> InputConfig:
         """Convert to sp-rtk-base-relay InputConfig dataclass.
 
+        For Bluetooth inputs, injects a longer default ``scan_timeout``
+        (:data:`DEFAULT_BT_SCAN_TIMEOUT_SECONDS`) when the persisted
+        config didn't supply one — without this, slow-advertising
+        receivers can miss the upstream's 10 s discovery window and
+        cause auto-start to fail at boot.
+
         Returns:
             InputConfig instance.
         """
-        return InputConfig(source=self.source, config=dict(self.config))
+        config_dict = dict(self.config)
+        if self.source == "bluetooth" and "scan_timeout" not in config_dict:
+            config_dict["scan_timeout"] = DEFAULT_BT_SCAN_TIMEOUT_SECONDS
+        return InputConfig(source=self.source, config=config_dict)
 
 
 # ---------------------------------------------------------------------------

--- a/src/sp_rtk_base/services/__init__.py
+++ b/src/sp_rtk_base/services/__init__.py
@@ -88,12 +88,83 @@ def get_device_service() -> DeviceService:
 # ---------------------------------------------------------------------------
 
 
+async def _release_stale_bluetooth_handle(mac_address: str) -> None:
+    """Best-effort: disconnect a stale BlueZ-side connection for *mac_address*.
+
+    Called from :func:`init_services` before the relay engine is asked to
+    open the same Bluetooth source.  If a previous instance exited
+    uncleanly (``SIGKILL``, OOM, power-loss during shutdown) BlueZ can
+    still believe the GPS receiver is connected — opening RFCOMM will
+    then fail with ``Address already in use`` or hang waiting for an
+    already-leased channel.
+
+    This helper *only* asks BlueZ to drop the connection on its side;
+    it does **not** un-pair, un-trust, or remove the device.  Errors
+    are swallowed and logged — startup must not fail just because
+    we couldn't pre-clean a handle that may not even have been stuck.
+
+    Args:
+        mac_address: The Bluetooth MAC of the configured GPS.
+    """
+    try:
+        # Imported lazily so test environments that don't have dbus-fast
+        # installed (CI, macOS dev boxes) don't pay the import cost or
+        # fail at module load.
+        from sp_rtk_base_relay.core.bluetooth_manager import BluetoothManager
+    except ImportError:
+        logger.debug(
+            "BluetoothManager unavailable; skipping stale-handle release for %s",
+            mac_address,
+        )
+        return
+
+    mgr: BluetoothManager | None = None
+    try:
+        mgr = BluetoothManager()
+        # disconnect_device is sync-but-blocks-on-D-Bus; push it off-loop
+        # so a wedged BlueZ can't stall startup.  A short budget is fine:
+        # if BlueZ doesn't ack quickly, the handle wasn't really held.
+        import asyncio
+
+        await asyncio.wait_for(
+            asyncio.to_thread(mgr.disconnect_device, mac_address),
+            timeout=5.0,
+        )
+        logger.info(
+            "Pre-disconnected stale Bluetooth handle for %s on startup",
+            mac_address,
+        )
+    except TimeoutError:
+        logger.warning(
+            "Timed out releasing stale Bluetooth handle for %s; "
+            "continuing startup anyway",
+            mac_address,
+        )
+    except Exception as exc:
+        # Most common cause: device wasn't connected — entirely fine.
+        logger.debug(
+            "Stale-handle release for %s skipped (%s); continuing startup",
+            mac_address,
+            exc,
+        )
+    finally:
+        if mgr is not None:
+            try:
+                mgr.close()
+            except Exception:
+                logger.debug("BluetoothManager.close() raised; ignoring", exc_info=True)
+
+
 async def init_services() -> None:
     """Initialize all services and optionally auto-start the relay.
 
     Loads the configuration from disk. If ``auto_start`` is enabled
     and both input config and destinations are configured, starts
     the relay engine and event bridge automatically.
+
+    Before auto-starting, this also releases any stale handles a
+    previous unclean shutdown may have left behind (currently:
+    Bluetooth — see :func:`_release_stale_bluetooth_handle`).
     """
     global relay_service, config_service, event_bridge, device_service
 
@@ -107,6 +178,16 @@ async def init_services() -> None:
     # Auto-start relay if configured
     settings = config.settings
     if settings.auto_start and config.input is not None:
+        # Bug D — best-effort: if a previous instance exited uncleanly
+        # we may need to ask BlueZ to drop a stale handle before the
+        # relay engine tries to claim the same RFCOMM channel.
+        if config.input.source == "bluetooth":
+            mac = config.input.config.get("mac_address") or config.input.config.get(
+                "address"
+            )
+            if isinstance(mac, str) and mac:
+                await _release_stale_bluetooth_handle(mac)
+
         destinations_configs = [
             d.to_relay_config() for d in config.destinations if d.enabled
         ]

--- a/src/sp_rtk_base/ui/pages/input.py
+++ b/src/sp_rtk_base/ui/pages/input.py
@@ -39,6 +39,14 @@ SOURCE_TYPES = ["tcp", "serial", "bluetooth"]
 BAUD_RATES = [9600, 19200, 38400, 57600, 115200, 230400, 460800, 921600]
 DEFAULT_BAUD = 115200
 
+# Bluetooth discovery scan durations (seconds).
+# Some GPS receivers advertise on long intervals (1.2-2.0 s) and can miss
+# a short scan window; offer the operator a few presets and default to a
+# duration that comfortably covers the slowest realistic advertiser.
+BT_SCAN_DURATIONS_SECONDS: list[int] = [20, 30, 45, 60]
+DEFAULT_BT_SCAN_DURATION_SECONDS: int = 20
+
+
 # TCP-only field definitions (serial and bluetooth have custom UI)
 TCP_FIELDS: list[FieldDef] = [
     ("host", "Host", "127.0.0.1", required("Host")),
@@ -229,6 +237,21 @@ def input_page() -> None:
                             scan_btn = ui.button(
                                 "Scan for Devices", icon="bluetooth_searching"
                             ).props("color=info outline")
+                            scan_duration_select = (
+                                ui.select(
+                                    options={
+                                        d: f"{d} s" for d in BT_SCAN_DURATIONS_SECONDS
+                                    },
+                                    value=DEFAULT_BT_SCAN_DURATION_SECONDS,
+                                    label="Scan duration",
+                                )
+                                .props("dense outlined")
+                                .style("min-width: 110px")
+                                .tooltip(
+                                    "How long to scan. Increase for slow-"
+                                    "advertising devices (default 20 s)."
+                                )
+                            )
                             scan_spinner = ui.spinner(size="sm")
                             scan_spinner.set_visibility(False)
                             scan_status = ui.label("").classes(
@@ -242,9 +265,22 @@ def input_page() -> None:
 
                         async def _scan_bluetooth() -> None:
                             """Scan for Bluetooth devices using BluetoothManager."""
+                            # Resolve scan duration from the dropdown (fall back
+                            # to the default if the widget is somehow unset).
+                            try:
+                                scan_seconds = int(
+                                    scan_duration_select.value
+                                    or DEFAULT_BT_SCAN_DURATION_SECONDS
+                                )
+                            except (TypeError, ValueError):
+                                scan_seconds = DEFAULT_BT_SCAN_DURATION_SECONDS
+                            if scan_seconds <= 0:
+                                scan_seconds = DEFAULT_BT_SCAN_DURATION_SECONDS
+
                             scan_btn.disable()
+                            scan_duration_select.disable()
                             scan_spinner.set_visibility(True)
-                            scan_status.text = "Scanning (10s)..."
+                            scan_status.text = f"Scanning ({scan_seconds}s)..."
                             scan_results_container.clear()
                             bt_state["scan_results"] = []
 
@@ -256,7 +292,9 @@ def input_page() -> None:
 
                                 # Get managed objects to list known/discovered devices
                                 devices = await asyncio.to_thread(
-                                    _discover_bluetooth_devices, mgr
+                                    _discover_bluetooth_devices,
+                                    mgr,
+                                    scan_seconds,
                                 )
 
                                 bt_state["scan_results"] = devices
@@ -550,6 +588,7 @@ def input_page() -> None:
 
 def _discover_bluetooth_devices(
     mgr: Any,
+    scan_seconds: int = DEFAULT_BT_SCAN_DURATION_SECONDS,
 ) -> list[dict[str, str]]:
     """Discover Bluetooth devices using BluetoothManager.
 
@@ -558,11 +597,19 @@ def _discover_bluetooth_devices(
 
     Args:
         mgr: A BluetoothManager instance.
+        scan_seconds: How long to actively scan for advertisements before
+            collecting results. Slow-advertising devices may need 30-60 s;
+            defaults to :data:`DEFAULT_BT_SCAN_DURATION_SECONDS` (20).
 
     Returns:
         List of dicts with 'name', 'mac', 'paired' keys.
     """
     import asyncio as _asyncio
+
+    # Clamp to a sane positive duration so a misconfigured caller can't
+    # turn the scan into a no-op or hang the page forever.
+    if scan_seconds <= 0:
+        scan_seconds = DEFAULT_BT_SCAN_DURATION_SECONDS
 
     devices: list[dict[str, str]] = []
 
@@ -582,7 +629,7 @@ def _discover_bluetooth_devices(
                 if mgr._adapter is not None:
                     try:
                         await mgr._adapter.call_start_discovery()  # type: ignore[attr-defined]
-                        await _asyncio.sleep(8)  # scan for 8 seconds
+                        await _asyncio.sleep(scan_seconds)
                     except Exception:
                         pass  # May fail if already scanning
                     try:

--- a/tests/unit/test_app_lifecycle.py
+++ b/tests/unit/test_app_lifecycle.py
@@ -1,0 +1,279 @@
+"""Tests for sp_rtk_base.app lifecycle hooks (Bug B + adjacent).
+
+These exercise the module-scope ``startup_services`` and
+``shutdown_services`` functions in :mod:`sp_rtk_base.app` so that the
+device → event-bridge → relay teardown order is enforced and a
+stuck driver can never hold up shutdown indefinitely.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import sp_rtk_base.services as services_mod
+from sp_rtk_base.app import (
+    DEVICE_DISCONNECT_TIMEOUT_SECONDS,
+    shutdown_services,
+    startup_services,
+)
+from sp_rtk_base.services.device_service import DeviceService
+from sp_rtk_base.services.event_bridge import EventBridge
+from sp_rtk_base.services.relay_service import RelayService
+
+# ---------------------------------------------------------------------------
+# Fixtures: replace the three singletons with mocks for the duration of a test
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def patched_services() -> Iterator[tuple[MagicMock, MagicMock, MagicMock]]:
+    """Swap the device/event-bridge/relay singletons with mocks.
+
+    Yields:
+        (device_service_mock, event_bridge_mock, relay_service_mock)
+    """
+    original_device = services_mod.device_service
+    original_eb = services_mod.event_bridge
+    original_relay = services_mod.relay_service
+
+    device_mock = MagicMock(spec=DeviceService)
+    # is_available / is_connected are @property — back them with attribute
+    # values instead of method calls so the production code path works.
+    type(device_mock).is_available = True  # type: ignore[misc]
+    type(device_mock).is_connected = True  # type: ignore[misc]
+    device_mock.disconnect = AsyncMock()
+
+    eb_mock = MagicMock(spec=EventBridge)
+
+    relay_mock = MagicMock(spec=RelayService)
+    relay_mock.stop_relay = AsyncMock()
+
+    services_mod.device_service = device_mock
+    services_mod.event_bridge = eb_mock
+    services_mod.relay_service = relay_mock
+    try:
+        yield device_mock, eb_mock, relay_mock
+    finally:
+        services_mod.device_service = original_device
+        services_mod.event_bridge = original_eb
+        services_mod.relay_service = original_relay
+        # Restore class-level property surrogates so they don't leak.
+        try:
+            del type(device_mock).is_available  # type: ignore[misc]
+        except AttributeError:
+            pass
+        try:
+            del type(device_mock).is_connected  # type: ignore[misc]
+        except AttributeError:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# startup_services — thin wrapper, but worth a sanity check
+# ---------------------------------------------------------------------------
+
+
+class TestStartupServices:
+    """Tests for the startup lifecycle hook."""
+
+    @pytest.mark.asyncio()
+    async def test_startup_delegates_to_init_services(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """startup_services calls init_services exactly once."""
+        called: list[str] = []
+
+        async def _fake_init() -> None:
+            called.append("init")
+
+        monkeypatch.setattr(services_mod, "init_services", _fake_init)
+        await startup_services()
+        assert called == ["init"]
+
+
+# ---------------------------------------------------------------------------
+# shutdown_services — the substance of Bug B
+# ---------------------------------------------------------------------------
+
+
+class TestShutdownServicesOrdering:
+    """The shutdown order must be device → event-bridge → relay."""
+
+    @pytest.mark.asyncio()
+    async def test_all_three_services_are_stopped(
+        self, patched_services: tuple[MagicMock, MagicMock, MagicMock]
+    ) -> None:
+        """Happy path: disconnect, event_bridge.stop, relay.stop all run."""
+        device, eb, relay = patched_services
+        await shutdown_services()
+        device.disconnect.assert_awaited_once()
+        eb.stop.assert_called_once()
+        relay.stop_relay.assert_awaited_once()
+
+    @pytest.mark.asyncio()
+    async def test_device_disconnects_before_event_bridge_stops(
+        self, patched_services: tuple[MagicMock, MagicMock, MagicMock]
+    ) -> None:
+        """Device disconnect happens before event-bridge stop."""
+        device, eb, _relay = patched_services
+        order: list[str] = []
+
+        async def _disconnect() -> None:
+            order.append("device")
+
+        def _eb_stop() -> None:
+            order.append("eb")
+
+        device.disconnect.side_effect = _disconnect
+        eb.stop.side_effect = _eb_stop
+
+        await shutdown_services()
+        assert order.index("device") < order.index("eb")
+
+    @pytest.mark.asyncio()
+    async def test_event_bridge_stops_before_relay_stops(
+        self, patched_services: tuple[MagicMock, MagicMock, MagicMock]
+    ) -> None:
+        """Event bridge stop happens before relay stop."""
+        _device, eb, relay = patched_services
+        order: list[str] = []
+
+        def _eb_stop() -> None:
+            order.append("eb")
+
+        async def _relay_stop() -> None:
+            order.append("relay")
+
+        eb.stop.side_effect = _eb_stop
+        relay.stop_relay.side_effect = _relay_stop
+
+        await shutdown_services()
+        assert order.index("eb") < order.index("relay")
+
+
+class TestShutdownServicesResilience:
+    """A failure in one service must not block teardown of the others."""
+
+    @pytest.mark.asyncio()
+    async def test_device_disconnect_error_does_not_block_relay_stop(
+        self, patched_services: tuple[MagicMock, MagicMock, MagicMock]
+    ) -> None:
+        """If device.disconnect() raises, relay still shuts down."""
+        device, eb, relay = patched_services
+        device.disconnect.side_effect = RuntimeError("driver explodes")
+
+        await shutdown_services()  # must NOT raise
+
+        device.disconnect.assert_awaited_once()
+        eb.stop.assert_called_once()
+        relay.stop_relay.assert_awaited_once()
+
+    @pytest.mark.asyncio()
+    async def test_event_bridge_stop_error_does_not_block_relay_stop(
+        self, patched_services: tuple[MagicMock, MagicMock, MagicMock]
+    ) -> None:
+        """If event_bridge.stop() raises, relay still shuts down."""
+        _device, eb, relay = patched_services
+        eb.stop.side_effect = RuntimeError("bridge explodes")
+
+        await shutdown_services()
+
+        relay.stop_relay.assert_awaited_once()
+
+    @pytest.mark.asyncio()
+    async def test_relay_stop_error_is_swallowed(
+        self, patched_services: tuple[MagicMock, MagicMock, MagicMock]
+    ) -> None:
+        """If relay.stop_relay() raises, shutdown still returns cleanly."""
+        _device, _eb, relay = patched_services
+        relay.stop_relay.side_effect = RuntimeError("relay explodes")
+
+        await shutdown_services()  # must NOT raise
+
+    @pytest.mark.asyncio()
+    async def test_device_disconnect_timeout_is_bounded(
+        self, patched_services: tuple[MagicMock, MagicMock, MagicMock]
+    ) -> None:
+        """A driver that never returns from disconnect() must not stall shutdown.
+
+        The shutdown path wraps ``device.disconnect()`` in
+        :func:`asyncio.wait_for` with a budget of
+        :data:`DEVICE_DISCONNECT_TIMEOUT_SECONDS`.  We patch the budget
+        down to something tiny in this test so the assertion runs fast,
+        but the production budget is many seconds.
+        """
+        device, eb, relay = patched_services
+
+        async def _hang() -> None:
+            await asyncio.sleep(10)  # would block forever in practice
+
+        device.disconnect.side_effect = _hang
+
+        # Patch the timeout down to something small for test speed.
+        import sp_rtk_base.app as app_mod
+
+        original_budget = app_mod.DEVICE_DISCONNECT_TIMEOUT_SECONDS
+        app_mod.DEVICE_DISCONNECT_TIMEOUT_SECONDS = 0.05
+        try:
+            await asyncio.wait_for(shutdown_services(), timeout=2.0)
+        finally:
+            app_mod.DEVICE_DISCONNECT_TIMEOUT_SECONDS = original_budget
+
+        # Even though the device hangs, the other two services still ran.
+        eb.stop.assert_called_once()
+        relay.stop_relay.assert_awaited_once()
+
+
+class TestShutdownServicesWithIdleDevice:
+    """When no device is connected, we skip disconnect() entirely."""
+
+    @pytest.mark.asyncio()
+    async def test_skips_disconnect_when_no_driver_registered(
+        self, patched_services: tuple[MagicMock, MagicMock, MagicMock]
+    ) -> None:
+        """If is_available is False, disconnect() is never awaited."""
+        device, eb, relay = patched_services
+        type(device).is_available = False  # type: ignore[misc]
+        type(device).is_connected = False  # type: ignore[misc]
+
+        await shutdown_services()
+
+        device.disconnect.assert_not_called()
+        eb.stop.assert_called_once()
+        relay.stop_relay.assert_awaited_once()
+
+    @pytest.mark.asyncio()
+    async def test_skips_disconnect_when_driver_already_disconnected(
+        self, patched_services: tuple[MagicMock, MagicMock, MagicMock]
+    ) -> None:
+        """If is_available=True but is_connected=False, disconnect is skipped."""
+        device, _eb, _relay = patched_services
+        type(device).is_available = True  # type: ignore[misc]
+        type(device).is_connected = False  # type: ignore[misc]
+
+        await shutdown_services()
+
+        device.disconnect.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Disconnect budget is configurable + sane
+# ---------------------------------------------------------------------------
+
+
+class TestDeviceDisconnectTimeoutConstant:
+    """The module-scope timeout knob should be set to something defensible."""
+
+    def test_timeout_is_positive(self) -> None:
+        """Negative or zero timeouts would cause TimeoutError immediately."""
+        assert DEVICE_DISCONNECT_TIMEOUT_SECONDS > 0
+
+    def test_timeout_is_at_least_a_few_seconds(self) -> None:
+        """Bluetooth needs a few seconds of headroom on a healthy bus."""
+        # If we ever drop this below 3s, we'll routinely timeout on
+        # operator hardware — make that a conscious decision.
+        assert DEVICE_DISCONNECT_TIMEOUT_SECONDS >= 3.0

--- a/tests/unit/test_config_models.py
+++ b/tests/unit/test_config_models.py
@@ -14,6 +14,7 @@ from sp_rtk_base_relay.config import (
 )
 
 from sp_rtk_base.models.config_models import (
+    DEFAULT_BT_SCAN_TIMEOUT_SECONDS,
     AppConfig,
     AppSettings,
     DestinationProfile,
@@ -313,9 +314,55 @@ class TestInputProfile:
         assert cfg.config["host"] == "127.0.0.1"
         assert cfg.config["port"] == 5015
 
+    def test_to_relay_config_bluetooth_injects_default_scan_timeout(self) -> None:
+        """Bluetooth source gets DEFAULT_BT_SCAN_TIMEOUT_SECONDS when not set.
+
+        The upstream relay package defaults ``scan_timeout`` to 10 s which
+        is too short for slow-advertising GPS receivers; the InputProfile
+        bumps it to 20 s on conversion when the user didn't pin it.
+        """
+        ip = InputProfile(
+            source="bluetooth",
+            config={"mac_address": "AA:BB:CC:DD:EE:FF"},
+        )
+        cfg = ip.to_relay_config()
+        assert cfg.source == "bluetooth"
+        assert cfg.config["mac_address"] == "AA:BB:CC:DD:EE:FF"
+        assert cfg.config["scan_timeout"] == DEFAULT_BT_SCAN_TIMEOUT_SECONDS
+        assert DEFAULT_BT_SCAN_TIMEOUT_SECONDS >= 20  # operator-visible floor
+
+    def test_to_relay_config_bluetooth_respects_explicit_scan_timeout(self) -> None:
+        """An explicit scan_timeout on a bluetooth profile is preserved."""
+        ip = InputProfile(
+            source="bluetooth",
+            config={"mac_address": "AA:BB:CC:DD:EE:FF", "scan_timeout": 45},
+        )
+        cfg = ip.to_relay_config()
+        assert cfg.config["scan_timeout"] == 45
+
+    def test_to_relay_config_does_not_mutate_original(self) -> None:
+        """to_relay_config must not mutate the profile's config dict."""
+        original_config: dict[str, Any] = {"mac_address": "AA:BB:CC:DD:EE:FF"}
+        ip = InputProfile(source="bluetooth", config=original_config)
+        ip.to_relay_config()
+        assert "scan_timeout" not in ip.config  # original untouched
+
+    def test_to_relay_config_non_bluetooth_no_scan_timeout_injection(self) -> None:
+        """Non-bluetooth sources never get scan_timeout injected."""
+        ip = InputProfile(
+            source="serial",
+            # relay engine validates the serial config and requires
+            # 'baudrate' (no underscore) — keep this test honest by
+            # matching that contract.
+            config={"port": "/dev/ttyACM0", "baudrate": 115200},
+        )
+        cfg = ip.to_relay_config()
+        assert "scan_timeout" not in cfg.config
+
 
 # ---------------------------------------------------------------------------
 # AppSettings
+
 # ---------------------------------------------------------------------------
 
 

--- a/tests/unit/test_init_services_bt_recovery.py
+++ b/tests/unit/test_init_services_bt_recovery.py
@@ -1,0 +1,416 @@
+"""Tests for the Bluetooth stale-handle recovery path in init_services (Bug D).
+
+When the auto-start path opens a Bluetooth input, a stale BlueZ
+connection (left over from a previous unclean shutdown) can prevent
+the relay engine from claiming the RFCOMM channel.  ``init_services``
+asks ``BluetoothManager.disconnect_device(mac)`` first as a best-effort
+recovery before handing off to the relay.
+
+These tests stub :class:`BluetoothManager` so they run without dbus-fast,
+without BlueZ, and without a real adapter.
+"""
+
+# pyright: reportPrivateUsage=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false
+# We intentionally exercise the module-private
+# ``_release_stale_bluetooth_handle`` helper — it's a thin pure-Python
+# wrapper that has no public alias to bind a test against.  The
+# ``reportUnknown*`` suppressions are needed because we exchange
+# ``MagicMock`` instances for real types and patch low-level
+# asyncio internals; pyright can't narrow either without extensive
+# generic plumbing that would obscure the test intent.
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from collections.abc import Iterator
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import sp_rtk_base.services as services_mod
+from sp_rtk_base.models.config_models import (
+    AppConfig,
+    AppSettings,
+    InputProfile,
+)
+from sp_rtk_base.services import _release_stale_bluetooth_handle
+from sp_rtk_base.services.config_service import ConfigService
+from sp_rtk_base.services.event_bridge import EventBridge
+from sp_rtk_base.services.relay_service import RelayService
+
+# ---------------------------------------------------------------------------
+# Helper: inject a fake BluetoothManager class so the helper finds *something*
+# importable even when dbus-fast / the real relay package isn't usable here.
+# ---------------------------------------------------------------------------
+
+
+def _install_fake_bluetooth_manager(
+    mgr_class: object,
+) -> Iterator[None]:
+    """Inject ``mgr_class`` at ``sp_rtk_base_relay.core.bluetooth_manager``.
+
+    Yields with the patched module in place, then restores the prior
+    state on teardown.
+    """
+    mod_name = "sp_rtk_base_relay.core.bluetooth_manager"
+    saved = sys.modules.get(mod_name)
+    fake_mod = types.ModuleType(mod_name)
+    fake_mod.BluetoothManager = mgr_class  # type: ignore[attr-defined]
+    sys.modules[mod_name] = fake_mod
+    try:
+        yield
+    finally:
+        if saved is None:
+            sys.modules.pop(mod_name, None)
+        else:
+            sys.modules[mod_name] = saved
+
+
+@pytest.fixture()
+def fake_bt_manager(request: pytest.FixtureRequest) -> Iterator[MagicMock]:
+    """Yield a MagicMock instance that acts as a stand-in BluetoothManager.
+
+    The fixture also patches the ``sp_rtk_base_relay.core.bluetooth_manager``
+    module so the import inside ``_release_stale_bluetooth_handle`` resolves
+    to *this* fake class.
+    """
+    instance = MagicMock(name="BluetoothManagerInstance")
+    cls = MagicMock(name="BluetoothManagerClass", return_value=instance)
+    # Stash the instance on the class mock so the test can interrogate it.
+    cls.instance = instance  # type: ignore[attr-defined]
+    gen = _install_fake_bluetooth_manager(cls)
+    next(gen)
+    try:
+        yield cls
+    finally:
+        try:
+            next(gen)
+        except StopIteration:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Direct tests on _release_stale_bluetooth_handle
+# ---------------------------------------------------------------------------
+
+
+class TestReleaseStaleBluetoothHandle:
+    """Unit-level tests of the helper itself."""
+
+    @pytest.mark.asyncio()
+    async def test_calls_disconnect_then_close_in_order(
+        self, fake_bt_manager: MagicMock
+    ) -> None:
+        """Happy path: instantiates the manager, calls disconnect, then close."""
+        instance = fake_bt_manager.instance
+        instance.disconnect_device = MagicMock()
+        instance.close = MagicMock()
+
+        await _release_stale_bluetooth_handle("AA:BB:CC:DD:EE:FF")
+
+        instance.disconnect_device.assert_called_once_with("AA:BB:CC:DD:EE:FF")
+        instance.close.assert_called_once()
+
+    @pytest.mark.asyncio()
+    async def test_swallows_disconnect_errors(self, fake_bt_manager: MagicMock) -> None:
+        """A BlueZ error during disconnect must not propagate out of startup."""
+        instance = fake_bt_manager.instance
+        instance.disconnect_device = MagicMock(
+            side_effect=RuntimeError("device not connected")
+        )
+        instance.close = MagicMock()
+
+        # Must not raise.
+        await _release_stale_bluetooth_handle("AA:BB:CC:DD:EE:FF")
+
+        instance.close.assert_called_once()
+
+    @pytest.mark.asyncio()
+    async def test_swallows_close_errors(self, fake_bt_manager: MagicMock) -> None:
+        """An error in close() must also be swallowed (best-effort cleanup)."""
+        instance = fake_bt_manager.instance
+        instance.disconnect_device = MagicMock()
+        instance.close = MagicMock(side_effect=RuntimeError("close failed"))
+
+        await _release_stale_bluetooth_handle("AA:BB:CC:DD:EE:FF")
+
+        instance.disconnect_device.assert_called_once()
+
+    @pytest.mark.asyncio()
+    async def test_times_out_on_hung_disconnect(
+        self, fake_bt_manager: MagicMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A wedged BlueZ must not stall startup forever.
+
+        We patch the internal asyncio.wait_for budget by patching
+        ``asyncio.wait_for`` itself to use a tiny budget; or, simpler,
+        we just make ``disconnect_device`` block in a thread and rely
+        on the helper's own ``wait_for(..., timeout=5.0)`` budget.  To
+        keep this test fast, we patch ``asyncio.wait_for`` to a no-op
+        that always raises TimeoutError so we exercise the except
+        path deterministically.
+        """
+        instance = fake_bt_manager.instance
+        instance.disconnect_device = MagicMock()
+        instance.close = MagicMock()
+
+        original_wait_for = asyncio.wait_for
+
+        async def _always_timeout(aw, timeout):  # type: ignore[no-untyped-def]
+            # Make sure the coroutine isn't left un-awaited.
+            aw.close()
+            raise TimeoutError
+
+        monkeypatch.setattr(asyncio, "wait_for", _always_timeout)
+        try:
+            await _release_stale_bluetooth_handle("AA:BB:CC:DD:EE:FF")
+        finally:
+            monkeypatch.setattr(asyncio, "wait_for", original_wait_for)
+
+        # close() still runs on the timeout path so we don't leak the
+        # BluetoothManager and its background D-Bus loop.
+        instance.close.assert_called_once()
+
+    @pytest.mark.asyncio()
+    async def test_silently_skips_when_package_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If the relay package isn't installed, the helper is a no-op.
+
+        We force the import inside the helper to fail by removing the
+        candidate module from ``sys.modules`` and shadowing it with one
+        that raises ImportError on attribute access.
+        """
+        mod_name = "sp_rtk_base_relay.core.bluetooth_manager"
+        saved = sys.modules.pop(mod_name, None)
+
+        # Install a builtins-style import hook? Simpler: monkeypatch
+        # builtins.__import__ for the duration of the call.
+        import builtins
+
+        real_import = builtins.__import__
+
+        def _fake_import(
+            name: str, *args: object, **kwargs: object
+        ) -> types.ModuleType:
+            if name == mod_name:
+                raise ImportError("simulated missing relay package")
+            return real_import(name, *args, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(builtins, "__import__", _fake_import)
+        try:
+            await _release_stale_bluetooth_handle("AA:BB:CC:DD:EE:FF")
+        finally:
+            if saved is not None:
+                sys.modules[mod_name] = saved
+
+
+# ---------------------------------------------------------------------------
+# init_services integration: the helper is invoked for bluetooth auto-start
+# and is *not* invoked for other input types.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def patched_relay_and_eb() -> Iterator[tuple[MagicMock, MagicMock]]:
+    """Replace relay_service / event_bridge with mocks for one test."""
+    original_relay = services_mod.relay_service
+    original_eb = services_mod.event_bridge
+    relay_mock = MagicMock(spec=RelayService)
+    relay_mock.start_relay = AsyncMock()
+    relay_mock.is_running = False
+    eb_mock = MagicMock(spec=EventBridge)
+    services_mod.relay_service = relay_mock
+    services_mod.event_bridge = eb_mock
+    try:
+        yield relay_mock, eb_mock
+    finally:
+        services_mod.relay_service = original_relay
+        services_mod.event_bridge = original_eb
+
+
+class TestInitServicesBluetoothRecovery:
+    """init_services must call the helper for BT auto-start, skip otherwise."""
+
+    @pytest.mark.asyncio()
+    async def test_calls_release_for_bluetooth_auto_start(
+        self,
+        tmp_path: Path,
+        patched_relay_and_eb: tuple[MagicMock, MagicMock],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A bluetooth input + auto_start=True triggers the recovery helper."""
+        config_path = tmp_path / "config.yaml"
+        cfg_svc = ConfigService(config_path=config_path)
+        cfg_svc.save_config(
+            AppConfig(
+                input=InputProfile(
+                    source="bluetooth",
+                    config={"mac_address": "AA:BB:CC:DD:EE:FF", "channel": 1},
+                ),
+                settings=AppSettings(auto_start=True),
+            )
+        )
+
+        called_with: list[str] = []
+
+        async def _spy(mac: str) -> None:
+            called_with.append(mac)
+
+        monkeypatch.setattr(services_mod, "_release_stale_bluetooth_handle", _spy)
+
+        original_cfg = services_mod.config_service
+        services_mod.config_service = cfg_svc
+        try:
+            await services_mod.init_services()
+        finally:
+            services_mod.config_service = original_cfg
+
+        assert called_with == ["AA:BB:CC:DD:EE:FF"]
+
+    @pytest.mark.asyncio()
+    async def test_skips_release_for_serial_input(
+        self,
+        tmp_path: Path,
+        patched_relay_and_eb: tuple[MagicMock, MagicMock],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Serial input must NOT invoke the bluetooth recovery helper."""
+        config_path = tmp_path / "config.yaml"
+        cfg_svc = ConfigService(config_path=config_path)
+        cfg_svc.save_config(
+            AppConfig(
+                input=InputProfile(
+                    source="serial",
+                    config={"port": "/dev/ttyACM0", "baudrate": 115200},
+                ),
+                settings=AppSettings(auto_start=True),
+            )
+        )
+
+        called_with: list[str] = []
+
+        async def _spy(mac: str) -> None:
+            called_with.append(mac)
+
+        monkeypatch.setattr(services_mod, "_release_stale_bluetooth_handle", _spy)
+
+        original_cfg = services_mod.config_service
+        services_mod.config_service = cfg_svc
+        try:
+            await services_mod.init_services()
+        finally:
+            services_mod.config_service = original_cfg
+
+        assert called_with == []
+
+    @pytest.mark.asyncio()
+    async def test_skips_release_when_auto_start_disabled(
+        self,
+        tmp_path: Path,
+        patched_relay_and_eb: tuple[MagicMock, MagicMock],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A BT input with auto_start=False must NOT touch BlueZ on startup."""
+        config_path = tmp_path / "config.yaml"
+        cfg_svc = ConfigService(config_path=config_path)
+        cfg_svc.save_config(
+            AppConfig(
+                input=InputProfile(
+                    source="bluetooth",
+                    config={"mac_address": "AA:BB:CC:DD:EE:FF"},
+                ),
+                settings=AppSettings(auto_start=False),
+            )
+        )
+
+        called_with: list[str] = []
+
+        async def _spy(mac: str) -> None:
+            called_with.append(mac)
+
+        monkeypatch.setattr(services_mod, "_release_stale_bluetooth_handle", _spy)
+
+        original_cfg = services_mod.config_service
+        services_mod.config_service = cfg_svc
+        try:
+            await services_mod.init_services()
+        finally:
+            services_mod.config_service = original_cfg
+
+        assert called_with == []
+
+    @pytest.mark.asyncio()
+    async def test_skips_release_for_bluetooth_without_mac(
+        self,
+        tmp_path: Path,
+        patched_relay_and_eb: tuple[MagicMock, MagicMock],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A bluetooth profile missing mac_address is left alone."""
+        config_path = tmp_path / "config.yaml"
+        cfg_svc = ConfigService(config_path=config_path)
+        cfg_svc.save_config(
+            AppConfig(
+                input=InputProfile(
+                    source="bluetooth",
+                    config={"channel": 1},  # no mac_address
+                ),
+                settings=AppSettings(auto_start=True),
+            )
+        )
+
+        called_with: list[str] = []
+
+        async def _spy(mac: str) -> None:
+            called_with.append(mac)
+
+        monkeypatch.setattr(services_mod, "_release_stale_bluetooth_handle", _spy)
+
+        original_cfg = services_mod.config_service
+        services_mod.config_service = cfg_svc
+        try:
+            await services_mod.init_services()
+        finally:
+            services_mod.config_service = original_cfg
+
+        assert called_with == []
+
+    @pytest.mark.asyncio()
+    async def test_accepts_legacy_address_key(
+        self,
+        tmp_path: Path,
+        patched_relay_and_eb: tuple[MagicMock, MagicMock],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Legacy configs storing the MAC under ``address`` are still honoured."""
+        config_path = tmp_path / "config.yaml"
+        cfg_svc = ConfigService(config_path=config_path)
+        cfg_svc.save_config(
+            AppConfig(
+                input=InputProfile(
+                    source="bluetooth",
+                    config={"address": "11:22:33:44:55:66"},
+                ),
+                settings=AppSettings(auto_start=True),
+            )
+        )
+
+        called_with: list[str] = []
+
+        async def _spy(mac: str) -> None:
+            called_with.append(mac)
+
+        monkeypatch.setattr(services_mod, "_release_stale_bluetooth_handle", _spy)
+
+        original_cfg = services_mod.config_service
+        services_mod.config_service = cfg_svc
+        try:
+            await services_mod.init_services()
+        finally:
+            services_mod.config_service = original_cfg
+
+        assert called_with == ["11:22:33:44:55:66"]

--- a/tests/unit/test_input_page_bt_scan.py
+++ b/tests/unit/test_input_page_bt_scan.py
@@ -1,0 +1,97 @@
+"""Tests for the Bluetooth scan-duration knobs on the Input page module.
+
+These guard the constants used by the Input page's "Scan for Devices"
+dropdown and the underlying ``_discover_bluetooth_devices`` helper.
+The page itself (NiceGUI handlers) is excluded from coverage, but the
+constants and the helper's parameter wiring are pure-Python and worth
+locking down so a future refactor can't silently regress the default
+scan duration back to a too-short value.
+"""
+
+# pyright: reportPrivateUsage=false
+# We intentionally exercise the module-private helper
+# ``_discover_bluetooth_devices`` from the tests in this file — the
+# helper is a thin, pure-Python wrapper used by the page handler and
+# has no public alias to bind a test against.
+
+from __future__ import annotations
+
+from sp_rtk_base.ui.pages import input as input_page
+
+
+class TestBluetoothScanDurationConstants:
+    """Module-level constants powering the Scan duration dropdown."""
+
+    def test_default_is_at_least_twenty_seconds(self) -> None:
+        """Default scan must comfortably cover slow-advertising devices."""
+        assert input_page.DEFAULT_BT_SCAN_DURATION_SECONDS >= 20
+
+    def test_default_is_in_dropdown_options(self) -> None:
+        """The default must be one of the offered presets."""
+        assert (
+            input_page.DEFAULT_BT_SCAN_DURATION_SECONDS
+            in input_page.BT_SCAN_DURATIONS_SECONDS
+        )
+
+    def test_dropdown_options_are_sorted_ascending(self) -> None:
+        """Operators expect Scan duration choices to grow shortest→longest."""
+        opts = input_page.BT_SCAN_DURATIONS_SECONDS
+        assert opts == sorted(opts)
+
+    def test_dropdown_options_all_positive_ints(self) -> None:
+        """A non-positive scan duration would silently no-op the BT scan."""
+        for value in input_page.BT_SCAN_DURATIONS_SECONDS:
+            assert isinstance(value, int)
+            assert value > 0
+
+    def test_dropdown_offers_long_presets(self) -> None:
+        """Operators must be able to opt into 30 / 45 / 60 s scans.
+
+        The user explicitly asked for these three longer presets so a
+        slow-advertising receiver can be discovered without code edits.
+        """
+        opts = input_page.BT_SCAN_DURATIONS_SECONDS
+        for required in (30, 45, 60):
+            assert required in opts, (
+                f"Scan duration preset {required}s missing from dropdown"
+            )
+
+
+class TestDiscoverBluetoothDevicesScanSeconds:
+    """The discovery helper must honour and clamp the scan duration."""
+
+    def test_default_scan_seconds_matches_default_constant(self) -> None:
+        """Default arg equals the module-level default."""
+        import inspect
+
+        sig = inspect.signature(input_page._discover_bluetooth_devices)
+        assert (
+            sig.parameters["scan_seconds"].default
+            == input_page.DEFAULT_BT_SCAN_DURATION_SECONDS
+        )
+
+    def test_non_positive_scan_seconds_is_clamped_to_default(self) -> None:
+        """A 0/negative value is replaced with the default — never used as a sleep.
+
+        We can't easily exercise the live D-Bus path in a unit test, but
+        we can verify the helper exits cleanly when there is no bus and
+        does not raise when given a non-positive scan duration (it must
+        silently swap in the default rather than calling ``sleep(0)`` or
+        ``sleep(-5)``, either of which would defeat the whole point).
+        """
+
+        class _FakeMgr:
+            _bus = None  # short-circuit at the top of _get_devices
+            _loop = None
+            _adapter = None
+
+        # The outer try in the helper swallows attribute errors that
+        # come from _loop=None; the important contract is "does not
+        # raise on a non-positive scan_seconds", which mirrors what
+        # the UI dropdown will guarantee but the helper must enforce
+        # defensively for direct callers (tests, future scripts).
+        result = input_page._discover_bluetooth_devices(_FakeMgr(), scan_seconds=0)
+        assert result == []
+
+        result = input_page._discover_bluetooth_devices(_FakeMgr(), scan_seconds=-5)
+        assert result == []

--- a/tests/unit/test_main_signals.py
+++ b/tests/unit/test_main_signals.py
@@ -1,0 +1,97 @@
+"""Tests for sp_rtk_base.main signal handling (Bug C).
+
+uvicorn already handles SIGINT/SIGTERM — we only need to verify that
+the SIGHUP handler is installed when ``main()`` runs and that it
+forwards to SIGTERM so the existing shutdown path is exercised.
+"""
+
+# pyright: reportPrivateUsage=false
+# We intentionally exercise the module-private ``_install_sighup_handler``
+# from these tests — the helper is a thin signal-registration utility
+# that has no public alias to bind a test against.
+
+from __future__ import annotations
+
+import signal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sp_rtk_base.main import _install_sighup_handler
+
+
+class TestInstallSighupHandler:
+    """The SIGHUP handler installer is a small, well-bounded function."""
+
+    def test_installs_a_handler_on_posix(self) -> None:
+        """After calling _install_sighup_handler, SIGHUP has a custom handler.
+
+        We restore the previous handler in a try/finally so the test
+        process is left exactly as we found it.
+        """
+        if not hasattr(signal, "SIGHUP"):
+            pytest.skip("SIGHUP not available on this platform")
+
+        previous = signal.getsignal(signal.SIGHUP)
+        try:
+            _install_sighup_handler()
+            current = signal.getsignal(signal.SIGHUP)
+            assert callable(current)
+            assert current is not previous
+            # Must not be the IGN/DFL constants either.
+            assert current not in (signal.SIG_DFL, signal.SIG_IGN)
+        finally:
+            signal.signal(signal.SIGHUP, previous)  # type: ignore[arg-type]
+
+    def test_handler_forwards_to_sigterm(self) -> None:
+        """The installed handler re-raises as SIGTERM via os.kill().
+
+        We can't actually let SIGTERM fire during the test (it would
+        kill pytest), so we patch os.kill and assert the call shape
+        instead.
+        """
+        if not hasattr(signal, "SIGHUP"):
+            pytest.skip("SIGHUP not available on this platform")
+
+        previous = signal.getsignal(signal.SIGHUP)
+        try:
+            _install_sighup_handler()
+            handler = signal.getsignal(signal.SIGHUP)
+            assert callable(handler)
+
+            with patch("sp_rtk_base.main.os.kill") as mock_kill:
+                # Type-checked frame stand-in is irrelevant for this code.
+                handler(signal.SIGHUP, None)  # type: ignore[misc]
+            mock_kill.assert_called_once()
+            args = mock_kill.call_args.args
+            # First arg = pid (positive int), second = SIGTERM.
+            assert args[0] > 0
+            assert args[1] == signal.SIGTERM
+        finally:
+            signal.signal(signal.SIGHUP, previous)  # type: ignore[arg-type]
+
+
+class TestMainInstallsSighupHandler:
+    """``main()`` must call ``_install_sighup_handler`` before ``ui.run``.
+
+    If the install happened after uvicorn started, a SIGHUP arriving
+    during early startup would still produce a hard exit.
+    """
+
+    def test_main_calls_install_sighup_handler(self) -> None:
+        """The install happens during main() bootstrap, not lazily."""
+        mock_ui = MagicMock()
+        mock_nicegui = MagicMock()
+        mock_nicegui.ui = mock_ui
+
+        with (
+            patch("sp_rtk_base.main.init_app"),
+            patch("sp_rtk_base.main._install_sighup_handler") as mock_install,
+            patch.dict("sys.modules", {"nicegui": mock_nicegui}),
+            patch.dict("os.environ", {}, clear=False),
+        ):
+            from sp_rtk_base.main import main
+
+            main()
+
+            mock_install.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -2748,7 +2748,7 @@ requires-dist = [
     { name = "pyserial", specifier = ">=3.5" },
     { name = "pyubx2", specifier = ">=1.2.43" },
     { name = "pyyaml", specifier = ">=6.0.3" },
-    { name = "sp-rtk-base-relay", specifier = ">=2.1.1" },
+    { name = "sp-rtk-base-relay", specifier = ">=2.1.2" },
     { name = "uvicorn", specifier = ">=0.42.0" },
 ]
 
@@ -2771,7 +2771,7 @@ dev = [
 
 [[package]]
 name = "sp-rtk-base-relay"
-version = "2.1.1"
+version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dbus-fast" },
@@ -2779,9 +2779,9 @@ dependencies = [
     { name = "pyserial" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/66/eb/f925215329a7d38f77e94785aab44f49b82808eeccbd3e7950d5b727dd05/sp_rtk_base_relay-2.1.1.tar.gz", hash = "sha256:1a812839f23675d00cf82e922e05eb9b9ad41f9b679acff7cbf441a53b805178", size = 87727, upload-time = "2026-05-20T20:22:48.399Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/29/f5320eff26b27952dc793b02a006165134aaee3905b4a811a2e75f752b70/sp_rtk_base_relay-2.1.2.tar.gz", hash = "sha256:a5244857e59e651e804ee707db1c1fb3ead9de6f5ca4a2ff12829589c0c36652", size = 89525, upload-time = "2026-05-27T19:44:43.549Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/57/2e5341eb274e0d9097deb9463664a76fb1670c9549b6681bbac04ca587b5/sp_rtk_base_relay-2.1.1-py3-none-any.whl", hash = "sha256:5f6366a674fc68c6438855253df459aed629665bb39d94ec1581f5f050985906", size = 105622, upload-time = "2026-05-20T20:22:46.918Z" },
+    { url = "https://files.pythonhosted.org/packages/40/6f/99eab0bbe71e209ae8a4801344548ebaf8e76bd2955dc668f5ddac93676c/sp_rtk_base_relay-2.1.2-py3-none-any.whl", hash = "sha256:d8aff7a8f1c444229c5ccc8da7c37721a41a330d72007f27423e16b640adf62e", size = 106501, upload-time = "2026-05-27T19:44:41.897Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

Triggered by the May 27 "system is still holding the Bluetooth GPS" report.  A four-bug audit of the Bluetooth lifecycle found:

- **Bug A** — `BluetoothInputSource.disconnect()` closed the local RFCOMM socket *before* asking BlueZ to disconnect.  Lives in `sp-rtk-base-relay`; **already shipped as 2.1.2** (relay PR #7).
- **Bug B** — `DeviceService.disconnect()` was never called from `app._shutdown`, so the GPS driver kept its serial / RFCOMM handle until process exit.
- **Bug C** — `main.py` had no SIGHUP handler, so `systemctl reload` and controlling-terminal hangups bypassed the orderly-shutdown path uvicorn runs for SIGINT/SIGTERM.
- **Bug D** — startup made no attempt to release a stale BlueZ handle from a previous (possibly `SIGKILL`-ed) run, so the next `start_relay` could fight a ghost `Connected=true` state.

This PR closes **B, C, D** in this repo and bumps the relay pin to pick up **A**.

## Changes

### `app.py` — Bug B
`_shutdown` promoted to module-level `shutdown_services()`.  Order:

1. `device.disconnect()` — wrapped in `asyncio.wait_for(..., DEVICE_DISCONNECT_TIMEOUT_SECONDS=10)`
2. `event_bridge.stop()`
3. `relay.stop_relay()`

Each step in its own `try/except` so a failure in any one cannot block the rest.  `startup_services()` extracted the same way for symmetry + testability.

### `main.py` — Bug C
`_install_sighup_handler()` registers a handler that forwards SIGHUP to SIGTERM via `os.kill(pid, SIGTERM)`, so the existing uvicorn signal path runs the new `shutdown_services()` for hangups too.  No-op on Windows (`signal.SIGHUP` doesn't exist).

### `services/__init__.py` — Bug D
`_release_stale_bluetooth_handle(mac)` instantiates BlueZ's `BluetoothManager`, calls `disconnect_device(mac)` off-loop with a 5 s budget, closes the manager.  All errors swallowed + logged.  `init_services()` invokes it before `start_relay()` when `source == "bluetooth"` and either `mac_address` or legacy `address` is set.  `BluetoothManager` is lazy-imported so CI containers and macOS without `dbus-fast` are unaffected.

### `pyproject.toml` + `uv.lock` — Bug A pin
`sp_rtk_base_relay>=2.1.1` → `>=2.1.2`.  `uv lock --upgrade-package sp-rtk-base-relay` regenerated the resolution; verified registry source.

### Bluetooth scan duration UX (separate-but-related)
- `ui/pages/input.py`: new `DEFAULT_BT_SCAN_DURATION_SECONDS = 20` and a 20/30/45/60 s dropdown next to **Scan for Devices**.
- `models/config_models.py`: new `DEFAULT_BT_SCAN_TIMEOUT_SECONDS = 20` injected into `InputProfile.to_relay_config()` when the profile didn't pin its own `scan_timeout` (`self.config` is **not** mutated — test enforces this).

## Tests

**25 new tests** across 4 new files plus 4 `InputProfile` cases in `test_config_models.py`:

- `tests/unit/test_app_lifecycle.py` (12) — shutdown ordering, per-step resilience, the 10 s timeout actually bounds a hung disconnect, skip-when-no-driver, skip-when-already-disconnected, timeout-constant sanity check.
- `tests/unit/test_main_signals.py` (3) — SIGHUP handler installed on POSIX, forwards SIGTERM, `main()` calls the installer.
- `tests/unit/test_init_services_bt_recovery.py` (10) — helper happy path, swallowed disconnect / close errors, `asyncio.wait_for` bounding, silent skip when relay isn't importable, full source × auto_start × mac-key matrix.
- `tests/unit/test_input_page_bt_scan.py` (7) — dropdown constants, default ≥ 20, sorted ascending, all positive ints, presets present.

Full suite: **566 / 566 passing, 92.91 % coverage** (was 530 / 92.17 %).  ruff + pyright strict clean.

## Refs

- Relay PR: rodenj1/sp-rtk-base-relay#7
- Relay release: <https://github.com/rodenj1/sp-rtk-base-relay/releases/tag/v2.1.2>
- PyPI: <https://pypi.org/project/sp-rtk-base-relay/2.1.2/>