### PR TITLE
fix(ublox): persist RTCM message/port selection and survey-in enable to flash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sp-rtk-base"
-version = "0.5.0"
+version = "0.5.1"
 description = "Web UI and API for controlling and monitoring a u-blox GPS RTK base station relay"
 readme = "README.md"
 authors = [

--- a/src/sp_rtk_base/__init__.py
+++ b/src/sp_rtk_base/__init__.py
@@ -2,4 +2,4 @@
 
 from __future__ import annotations
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"

--- a/src/sp_rtk_base/services/drivers/ublox.py
+++ b/src/sp_rtk_base/services/drivers/ublox.py
@@ -416,11 +416,15 @@ class UbloxDriver(GpsReceiverDriver):
             # rather than coalesced with the previous state.
             time.sleep(self._TMODE_RESTART_DELAY_S)
 
-            # Step 3: write the new survey-in parameters and enable
-            # to RAM only.  Per u-blox C099 "F9P Base Survey in
-            # start.txt", survey-in is intentionally NOT persisted to
-            # flash — only the completed fixed-base coordinates from
-            # ``save_to_flash`` are persisted.
+            # Step 3: write the new survey-in parameters and enable.
+            # Issue #42: this used to write RAM only (layer=1) on the
+            # theory that survey-in is transient state; in practice
+            # that meant the *enable* never survived a reboot or even
+            # the app re-opening the port, silently reverting the base
+            # to disabled. Write RAM+Flash (layer=5) instead, matching
+            # ``configure_fixed_base`` — the transition intent must be
+            # durable even though CFG_TMODE_MODE=1 is conceptually
+            # transient while the survey itself is running.
             # CFG_TMODE_SVIN_ACC_LIMIT is in 0.1 mm units on the
             # wire (u-blox spec: "1 m = 10000, 3.2598 m = 32598").
             # The Python API uses mm, so multiply by 10 here.  Same
@@ -439,7 +443,12 @@ class UbloxDriver(GpsReceiverDriver):
                 # Survey-in mode (last so params land first)
                 ("CFG_TMODE_MODE", 1),
             ]
-            self._send_cfg_valset_locked(cfg_data, layer=1)  # RAM only
+            # Verify-after-write: an ACK'd layer=5 write that silently
+            # didn't persist is exactly issue #42's original failure
+            # mode, and it wouldn't be caught by the dur-progression
+            # check below (that confirms the survey *engine* started,
+            # not that these CFG keys landed in flash).
+            self._write_and_verify_locked(cfg_data, layer=5, label="Survey-in config")
 
             # Step 5: confirm a *fresh* survey is running.  Two
             # signals together:
@@ -504,11 +513,10 @@ class UbloxDriver(GpsReceiverDriver):
                 )
 
             # Apply the RTCM-only output profile as a separate layer=5
-            # (RAM+Flash) VALSET — independent of the layer=1 survey
-            # write above.  Unlike TMODE/SVIN params, port protocol
-            # config is not survey state, so it's flashed immediately
-            # even during survey-in (silencing NMEA for the whole
-            # survey, not just once a fixed base is later saved).
+            # (RAM+Flash) VALSET — independent of the survey write
+            # above (also layer=5 as of issue #42).  Silences NMEA
+            # for the whole survey, not just once a fixed base is
+            # later saved.
             self._apply_base_output_profile_locked()
         logger.info(
             "Survey-in configured: %ds min, %dmm accuracy",
@@ -724,6 +732,66 @@ class UbloxDriver(GpsReceiverDriver):
 
         raise RuntimeError("No CFG-VALGET response for base output profile")
 
+    def _read_cfg_keys_locked(self, keys: list[str]) -> dict[str, int]:
+        """Poll arbitrary CFG keys and return them as a dict (must hold ``self._lock``).
+
+        Used to verify a CFG-VALSET write actually took effect — same
+        read-back pattern as ``_read_ecef_locked`` /
+        ``_read_base_output_profile_locked``, generalised to an
+        arbitrary key list (issue #42).
+        """
+        ser, reader = self._require_connection()
+
+        poll_keys: list[str | int] = list(keys)
+        msg = UBXMessage.config_poll(0, 0, poll_keys)
+        ser.reset_input_buffer()
+        ser.write(msg.serialize())  # type: ignore[union-attr]
+
+        for _ in range(_MAX_READ_ATTEMPTS):
+            try:
+                raw, parsed = reader.read()  # type: ignore[misc]
+                if parsed is None:
+                    continue
+                identity = getattr(parsed, "identity", "")
+                if identity == "CFG-VALGET":
+                    return {key: int(getattr(parsed, key, -1)) for key in keys}
+            except Exception:
+                continue
+
+        raise RuntimeError("No CFG-VALGET response for config keys")
+
+    def _write_and_verify_locked(
+        self, cfg_data: list[tuple[str, int]], layer: int, label: str
+    ) -> None:
+        """Send a CFG-VALSET and verify the read-back, retrying once on mismatch.
+
+        Must hold ``self._lock``. Shared verify-and-retry helper for the
+        layer=5 writers touched by issue #42 — a bare ACK can lie about
+        whether the value actually landed, so every durable write needs
+        the same read-back check ``configure_fixed_base`` established for
+        ECEF (issue #39).
+
+        Raises:
+            RuntimeError: if the read-back still doesn't match after one
+                retry.
+        """
+        expected = dict(cfg_data)
+        self._send_cfg_valset_locked(cfg_data, layer=layer)
+        actual = self._read_cfg_keys_locked(list(expected))
+        if actual == expected:
+            return
+
+        logger.warning("%s mismatch after first write — retrying", label)
+        self._send_cfg_valset_locked(cfg_data, layer=layer)
+        actual = self._read_cfg_keys_locked(list(expected))
+        if actual != expected:
+            raise RuntimeError(
+                f"{label} did not take effect: receiver reports {actual}, "
+                f"expected {expected} after two write attempts. Try "
+                "disconnecting and reconnecting, or power-cycle the "
+                "receiver."
+            )
+
     def configure_rtcm_messages(self, config: RtcmMessageConfig) -> None:
         cfg_data: list[tuple[str, int]] = []
 
@@ -741,7 +809,15 @@ class UbloxDriver(GpsReceiverDriver):
                 logger.warning("Unknown RTCM message ID %d — skipped", msg_id)
 
         with self._lock:
-            self._send_cfg_valset_locked(cfg_data, layer=1)  # RAM only
+            # Issue #42: this used to write RAM only (layer=1), so the
+            # message selection reverted to whatever was last flashed
+            # as soon as the receiver rebooted or the port was
+            # reopened. Write RAM+Flash (layer=5) and verify the
+            # read-back, mirroring the ECEF verify-and-retry pattern
+            # added for issue #39.
+            self._write_and_verify_locked(
+                cfg_data, layer=5, label="RTCM message config"
+            )
         logger.info(
             "RTCM messages configured: %s @ %dHz",
             config.message_ids,
@@ -857,7 +933,9 @@ class UbloxDriver(GpsReceiverDriver):
     def configure_rtcm_ports(self, config: RtcmPortConfig) -> None:
         """Apply multi-port RTCM output configuration to the receiver.
 
-        Sends a CFG-VALSET with rates for each message on each port.
+        Sends a CFG-VALSET with rates for each message on each port,
+        writes to RAM+Flash (layer=5), and verifies the read-back —
+        see ``configure_rtcm_messages`` for why (issue #42).
         """
         cfg_data: list[tuple[str, int]] = []
 
@@ -874,7 +952,7 @@ class UbloxDriver(GpsReceiverDriver):
             return
 
         with self._lock:
-            self._send_cfg_valset_locked(cfg_data, layer=1)  # RAM only
+            self._write_and_verify_locked(cfg_data, layer=5, label="RTCM port config")
         logger.info("RTCM multi-port config applied (%d keys)", len(cfg_data))
 
     # ------------------------------------------------------------------

--- a/tests/unit/test_cancel_survey_in.py
+++ b/tests/unit/test_cancel_survey_in.py
@@ -170,10 +170,11 @@ class TestUbloxDisableBaseMode:
         # configure_survey_in now performs:
         #   0. NAV-SVIN baseline poll                       -> dur=0 (no pre-reset)
         #   1. CFG-VALSET TMODE=0 (layer=7: RAM+BBR+Flash)  -> ACK
-        #   2. CFG-VALSET TMODE=1 + SVIN params (layer=1)   -> ACK
-        #   3. NAV-SVIN poll                                -> dur=0
-        #   4. (wait ~2s)
-        #   5. NAV-SVIN poll                                -> dur=2 (incremented)
+        #   2. CFG-VALSET TMODE=1 + SVIN params (layer=5)   -> ACK
+        #   3. CFG-VALGET read-back                         -> matches (issue #42)
+        #   4. NAV-SVIN poll                                -> dur=0
+        #   5. (wait ~2s)
+        #   6. NAV-SVIN poll                                -> dur=2 (incremented)
         reader.read.side_effect = [
             (b"", _make_mon_ver()),
             (
@@ -189,6 +190,15 @@ class TestUbloxDisableBaseMode:
             ),
             (b"", _make_ack()),  # full-layer disable
             (b"", _make_ack()),  # enable
+            (
+                b"",
+                SimpleNamespace(
+                    identity="CFG-VALGET",
+                    CFG_TMODE_SVIN_MIN_DUR=120,
+                    CFG_TMODE_SVIN_ACC_LIMIT=500000,
+                    CFG_TMODE_MODE=1,
+                ),
+            ),  # enable read-back — matches
             (
                 b"",
                 SimpleNamespace(
@@ -227,7 +237,7 @@ class TestUbloxDisableBaseMode:
                 SurveyInConfig(min_duration_seconds=120, accuracy_limit_mm=50000)
             )
 
-        # Three config_sets: full-layer disable, RAM-only enable, and
+        # Three config_sets: full-layer disable, RAM+Flash enable, and
         # the layer=5 base output profile (issue #40).
         assert mock_ubx_msg.config_set.call_count == 3
         disable = mock_ubx_msg.config_set.call_args_list[0]
@@ -237,9 +247,10 @@ class TestUbloxDisableBaseMode:
         # BBR coverage is the critical bit — RAM+Flash alone leaves
         # ``dur`` ticking from a stale prior session.
         assert disable[0][0] == 7
-        # The enable call writes to RAM only (survey-in is intentionally
-        # not persisted) and contains the new survey params.
-        assert enable[0][0] == 1
+        # The enable call writes to RAM+Flash (issue #42) so the
+        # survey-in selection survives a reboot / port reopen, and
+        # contains the new survey params.
+        assert enable[0][0] == 5
         keys = {k: v for k, v in enable[0][2]}
         assert keys.get("CFG_TMODE_MODE") == 1
         assert keys.get("CFG_TMODE_SVIN_MIN_DUR") == 120
@@ -278,12 +289,22 @@ class TestUbloxDisableBaseMode:
         )
         reader = MagicMock()
         # baseline (dur=0, no pre-reset) → disable ACK → enable ACK
-        # → NAV-SVIN(dur=0) → NAV-SVIN(dur=0) → rollback disable ACK
+        # → read-back → NAV-SVIN(dur=0) → NAV-SVIN(dur=0) → rollback
+        # disable ACK
         reader.read.side_effect = [
             (b"", _make_mon_ver()),
             (b"", nav_svin_idle),  # baseline (no pre-reset)
             (b"", _make_ack()),  # full-layer disable
             (b"", _make_ack()),  # enable
+            (
+                b"",
+                SimpleNamespace(
+                    identity="CFG-VALGET",
+                    CFG_TMODE_SVIN_MIN_DUR=60,
+                    CFG_TMODE_SVIN_ACC_LIMIT=500000,
+                    CFG_TMODE_MODE=1,
+                ),
+            ),  # enable read-back — matches (issue #42)
             (b"", nav_svin_idle),  # before-snapshot
             (b"", nav_svin_idle),  # after-snapshot, dur unchanged
             (b"", _make_ack()),  # rollback layer=7 disable
@@ -302,11 +323,11 @@ class TestUbloxDisableBaseMode:
                     SurveyInConfig(min_duration_seconds=60, accuracy_limit_mm=50000)
                 )
 
-        # Three CFG-VALSETs: initial layer=7 disable, layer=1 enable,
+        # Three CFG-VALSETs: initial layer=7 disable, layer=5 enable,
         # then layer=7 rollback after dur failed to advance.
         assert mock_ubx_msg.config_set.call_count == 3
         layers = [c[0][0] for c in mock_ubx_msg.config_set.call_args_list]
-        assert layers == [7, 1, 7]
+        assert layers == [7, 5, 7]
         # First and last (rollback) payloads must be the disable key.
         assert mock_ubx_msg.config_set.call_args_list[0][0][2] == [
             ("CFG_TMODE_MODE", 0)
@@ -366,7 +387,16 @@ class TestUbloxDisableBaseMode:
             (b"", _make_mon_ver()),
             (b"", nav_svin_stale),  # baseline -> triggers pre-reset
             (b"", _make_ack()),  # layer=7 disable (after reset)
-            (b"", _make_ack()),  # enable (RAM)
+            (b"", _make_ack()),  # enable (RAM+Flash)
+            (
+                b"",
+                SimpleNamespace(
+                    identity="CFG-VALGET",
+                    CFG_TMODE_SVIN_MIN_DUR=60,
+                    CFG_TMODE_SVIN_ACC_LIMIT=500000,
+                    CFG_TMODE_MODE=1,
+                ),
+            ),  # enable read-back — matches (issue #42)
             (b"", nav_svin_fresh_before),  # before-snapshot
             (b"", nav_svin_fresh_after),  # after-snapshot
             (b"", _make_ack()),  # base output profile write (issue #40)
@@ -393,10 +423,127 @@ class TestUbloxDisableBaseMode:
         # No rollback path triggered — the pre-reset cleared the
         # stale state, and the post-write verify saw a fresh
         # (dur=0 -> dur=3) progression.  3 CFG-VALSETs fire:
-        # layer=7 disable, layer=1 enable, layer=5 output profile.
+        # layer=7 disable, layer=5 enable, layer=5 output profile.
         assert mock_ubx_msg.config_set.call_count == 3
         layers = [c[0][0] for c in mock_ubx_msg.config_set.call_args_list]
-        assert layers == [7, 1, 5]
+        assert layers == [7, 5, 5]
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_configure_survey_in_retries_once_on_verify_mismatch(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        """Issue #42: an ACK'd enable write that doesn't read back
+        correctly is retried once before the dur-progression check even
+        runs — a bare ACK can lie about whether the layer=5 write
+        actually persisted."""
+        ser = MagicMock()
+        ser.is_open = True
+        mock_serial_cls.return_value = ser
+
+        nav_svin_idle = SimpleNamespace(
+            identity="NAV-SVIN", valid=0, active=0, dur=0, meanAcc=0, obs=0
+        )
+        nav_svin_progressed = SimpleNamespace(
+            identity="NAV-SVIN", valid=0, active=0, dur=2, meanAcc=99999, obs=1
+        )
+        reader = MagicMock()
+        reader.read.side_effect = [
+            (b"", _make_mon_ver()),
+            (b"", nav_svin_idle),  # baseline (no pre-reset)
+            (b"", _make_ack()),  # full-layer disable
+            (b"", _make_ack()),  # enable (first attempt)
+            (b"", SimpleNamespace(identity="CFG-VALGET")),  # read-back — mismatch
+            (b"", _make_ack()),  # enable (retried)
+            (
+                b"",
+                SimpleNamespace(
+                    identity="CFG-VALGET",
+                    CFG_TMODE_SVIN_MIN_DUR=60,
+                    CFG_TMODE_SVIN_ACC_LIMIT=500000,
+                    CFG_TMODE_MODE=1,
+                ),
+            ),  # read-back — matches on retry
+            (b"", nav_svin_idle),  # before-snapshot
+            (b"", nav_svin_progressed),  # after-snapshot
+            (b"", _make_ack()),  # base output profile write
+            (b"", _make_profile_valget()),  # read-back matches
+        ]
+        mock_reader_cls.return_value = reader
+
+        mock_msg = MagicMock()
+        mock_msg.serialize.return_value = b"\x00"
+        mock_ubx_msg.config_set.return_value = mock_msg
+
+        drv = UbloxDriver()
+        drv.connect("/dev/ttyUSB0")
+        with patch("sp_rtk_base.services.drivers.ublox.time.sleep"):
+            drv.configure_survey_in(
+                SurveyInConfig(min_duration_seconds=60, accuracy_limit_mm=50000)
+            )  # must not raise
+
+        # disable(7) + enable(5) + retried enable(5) + profile(5) = 4 VALSETs.
+        assert mock_ubx_msg.config_set.call_count == 4
+        layers = [c[0][0] for c in mock_ubx_msg.config_set.call_args_list]
+        assert layers == [7, 5, 5, 5]
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_configure_survey_in_raises_after_second_verify_mismatch(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        """Issue #42: if the enable write still doesn't read back
+        correctly after one retry, configure_survey_in must fail hard
+        rather than silently reporting success with a survey config
+        that never took effect — the exact bug that let the RTCM/survey
+        selection revert to whatever was last flashed after a reboot
+        while the UI claimed success."""
+        ser = MagicMock()
+        ser.is_open = True
+        mock_serial_cls.return_value = ser
+
+        nav_svin_idle = SimpleNamespace(
+            identity="NAV-SVIN", valid=0, active=0, dur=0, meanAcc=0, obs=0
+        )
+        mismatch = SimpleNamespace(identity="CFG-VALGET")
+        reader = MagicMock()
+        reader.read.side_effect = [
+            (b"", _make_mon_ver()),
+            (b"", nav_svin_idle),  # baseline (no pre-reset)
+            (b"", _make_ack()),  # full-layer disable
+            (b"", _make_ack()),  # enable (first attempt)
+            (b"", mismatch),  # read-back — mismatch
+            (b"", _make_ack()),  # enable (retried)
+            (b"", mismatch),  # read-back — still mismatched
+        ]
+        mock_reader_cls.return_value = reader
+
+        mock_msg = MagicMock()
+        mock_msg.serialize.return_value = b"\x00"
+        mock_ubx_msg.config_set.return_value = mock_msg
+
+        drv = UbloxDriver()
+        drv.connect("/dev/ttyUSB0")
+        with patch("sp_rtk_base.services.drivers.ublox.time.sleep"):
+            with pytest.raises(RuntimeError, match="did not take effect"):
+                drv.configure_survey_in(
+                    SurveyInConfig(min_duration_seconds=60, accuracy_limit_mm=50000)
+                )
+
+        # disable(7) + enable(5) + retried enable(5) = 3 VALSETs; the
+        # verify fails before the dur-progression check ever runs, so
+        # no rollback and no base output profile write fire.
+        assert mock_ubx_msg.config_set.call_count == 3
+        layers = [c[0][0] for c in mock_ubx_msg.config_set.call_args_list]
+        assert layers == [7, 5, 5]
 
     def test_disable_base_mode_when_disconnected(self) -> None:
         drv = UbloxDriver()

--- a/tests/unit/test_rtcm_port_config.py
+++ b/tests/unit/test_rtcm_port_config.py
@@ -213,7 +213,14 @@ class TestConfigureRtcmPorts:
         # Patch the *locked* variant — that's what writers call now that
         # all CFG-VALSET callers acquire ``self._lock`` directly to make
         # multi-step writes atomic against concurrent polls.
-        with patch.object(driver, "_send_cfg_valset_locked") as mock_valset:
+        def _fake_read_back(keys: list[str]) -> dict[str, int]:
+            return dict.fromkeys(keys, 0) | {k: 1 for k in keys if k.endswith("_USB")}
+
+        with (
+            patch.object(driver, "_send_cfg_valset_locked") as mock_valset,
+            patch.object(driver, "_read_cfg_keys_locked") as mock_read,
+        ):
+            mock_read.side_effect = _fake_read_back
             driver.configure_rtcm_ports(config)
 
             mock_valset.assert_called_once()
@@ -225,6 +232,13 @@ class TestConfigureRtcmPorts:
             usb_entry = [(k, v) for k, v in cfg_data if k.endswith("_USB")]
             assert len(usb_entry) == 1
             assert usb_entry[0][1] == 1
+            # Issue #42: RAM+Flash, not RAM-only — a layer=1 write
+            # reverted to the last-flashed rates on reboot / reconnect.
+            assert mock_valset.call_args.kwargs["layer"] == 5
+            # Verify-after-write: the read-back must be polled with
+            # exactly the keys just written.
+            mock_read.assert_called_once()
+            assert set(mock_read.call_args[0][0]) == {k for k, _ in cfg_data}
 
     def test_configure_empty_config(self) -> None:
         from sp_rtk_base.services.drivers.ublox import UbloxDriver
@@ -258,6 +272,56 @@ class TestConfigureRtcmPorts:
         with patch.object(driver, "_send_cfg_valset_locked") as mock_valset:
             driver.configure_rtcm_ports(config)
             mock_valset.assert_not_called()
+
+    def test_configure_retries_once_on_mismatch(self) -> None:
+        """Issue #42: a read-back mismatch after the first write is
+        retried once, mirroring the ECEF/base-output-profile pattern,
+        rather than failing immediately."""
+        from sp_rtk_base.services.drivers.ublox import UbloxDriver
+
+        driver = UbloxDriver()
+        driver._serial = MagicMock()
+        driver._serial.is_open = True
+        driver._reader = MagicMock()
+
+        config = RtcmPortConfig(messages={1005: {"USB": 1}})
+
+        with (
+            patch.object(driver, "_send_cfg_valset_locked") as mock_valset,
+            patch.object(driver, "_read_cfg_keys_locked") as mock_read,
+        ):
+            mock_read.side_effect = [
+                {"CFG_MSGOUT_RTCM_3X_TYPE1005_USB": 0},  # mismatch
+                {"CFG_MSGOUT_RTCM_3X_TYPE1005_USB": 1},  # matches on retry
+            ]
+            driver.configure_rtcm_ports(config)  # must not raise
+
+        assert mock_valset.call_count == 2
+        assert mock_read.call_count == 2
+
+    def test_configure_raises_after_second_mismatch(self) -> None:
+        """Issue #42: if the read-back still doesn't match after the
+        retry, the call must fail hard rather than silently reporting
+        success with a config that never took effect."""
+        from sp_rtk_base.services.drivers.ublox import UbloxDriver
+
+        driver = UbloxDriver()
+        driver._serial = MagicMock()
+        driver._serial.is_open = True
+        driver._reader = MagicMock()
+
+        config = RtcmPortConfig(messages={1005: {"USB": 1}})
+
+        with (
+            patch.object(driver, "_send_cfg_valset_locked") as mock_valset,
+            patch.object(driver, "_read_cfg_keys_locked") as mock_read,
+        ):
+            mock_read.return_value = {"CFG_MSGOUT_RTCM_3X_TYPE1005_USB": 0}
+            with pytest.raises(RuntimeError, match="did not take effect"):
+                driver.configure_rtcm_ports(config)
+
+        assert mock_valset.call_count == 2
+        assert mock_read.call_count == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_ublox_driver.py
+++ b/tests/unit/test_ublox_driver.py
@@ -85,6 +85,24 @@ def _make_nav_svin_response(
     )
 
 
+def _make_rtcm_valget(overrides: dict[str, int] | None = None) -> object:
+    """Fake CFG-VALGET response for RTCM message keys.
+
+    Any key not present in ``overrides`` reads back as 0 (disabled) —
+    the ``_read_cfg_keys_locked`` verify step polls a specific key
+    list, so this only needs to answer for the keys it's asked about.
+    """
+    values = dict(overrides or {})
+
+    class _FakeRtcmValGet:
+        identity = "CFG-VALGET"
+
+        def __getattr__(self, name: str) -> int:
+            return values.get(name, 0)
+
+    return _FakeRtcmValGet()
+
+
 def _make_base_output_profile_valget(**overrides: int) -> SimpleNamespace:
     """Create a mock CFG-VALGET response for the six OUTPROT keys.
 
@@ -311,17 +329,27 @@ class TestUbloxDriverConfiguration:
         # configure_survey_in now performs:
         #   0. NAV-SVIN baseline poll                       -> dur=0 (no pre-reset)
         #   1. CFG-VALSET TMODE=0 (layer=7: RAM+BBR+Flash)  -> ACK
-        #   2. CFG-VALSET TMODE=1 + SVIN params (layer=1)   -> ACK
-        #   3. NAV-SVIN poll                                -> dur=0
-        #   4. (~2 s gap)
-        #   5. NAV-SVIN poll                                -> dur=3 (incremented)
-        #   6. CFG-VALSET base output profile (layer=5)     -> ACK
-        #   7. CFG-VALGET read-back                         -> matches (issue #40)
+        #   2. CFG-VALSET TMODE=1 + SVIN params (layer=5)   -> ACK
+        #   3. CFG-VALGET read-back                         -> matches (issue #42)
+        #   4. NAV-SVIN poll                                -> dur=0
+        #   5. (~2 s gap)
+        #   6. NAV-SVIN poll                                -> dur=3 (incremented)
+        #   7. CFG-VALSET base output profile (layer=5)     -> ACK
+        #   8. CFG-VALGET read-back                         -> matches (issue #40)
         reader.read.side_effect = [
             (b"", _make_mon_ver_response()),
             (b"", _make_nav_svin_response(active=0, valid=0, dur=0, obs=0)),  # baseline
             (b"", _make_ack_response()),  # full-layer disable
             (b"", _make_ack_response()),  # enable
+            (
+                b"",
+                SimpleNamespace(
+                    identity="CFG-VALGET",
+                    CFG_TMODE_SVIN_MIN_DUR=300,
+                    CFG_TMODE_SVIN_ACC_LIMIT=400000,
+                    CFG_TMODE_MODE=1,
+                ),
+            ),  # enable read-back — matches
             (b"", _make_nav_svin_response(active=0, valid=0, dur=0, obs=0)),
             (b"", _make_nav_svin_response(active=0, valid=0, dur=3, obs=1)),
             (b"", _make_ack_response()),  # base output profile write
@@ -340,8 +368,8 @@ class TestUbloxDriverConfiguration:
         with patch("sp_rtk_base.services.drivers.ublox.time.sleep"):
             driver.configure_survey_in(config)
 
-        # Three CFG-VALSET calls: layer=7 disable, layer=1 enable, and
-        # layer=5 base output profile (issue #40).
+        # Three CFG-VALSET calls: layer=7 disable, layer=5 enable
+        # (issue #42), and layer=5 base output profile (issue #40).
         assert mock_ubx_msg.config_set.call_count == 3
         disable_layer = mock_ubx_msg.config_set.call_args_list[0][0][0]
         disable_cfg = mock_ubx_msg.config_set.call_args_list[0][0][2]
@@ -355,8 +383,9 @@ class TestUbloxDriverConfiguration:
         # accumulating from prior sessions.
         assert disable_layer == 7
         assert disable_cfg == [("CFG_TMODE_MODE", 0)]
-        # Enable is RAM-only — survey-in is intentionally not persisted.
-        assert enable_layer == 1
+        # Enable is RAM+Flash (issue #42) — a RAM-only write reverted
+        # to the last-flashed selection on reboot / port reopen.
+        assert enable_layer == 5
         keys = [k for k, _ in enable_cfg]
         assert "CFG_TMODE_MODE" in keys
         assert "CFG_TMODE_SVIN_MIN_DUR" in keys
@@ -740,6 +769,16 @@ class TestUbloxDriverConfiguration:
         reader.read.side_effect = [
             (b"", _make_mon_ver_response()),
             (b"", _make_ack_response()),
+            (
+                b"",
+                _make_rtcm_valget(
+                    {
+                        "CFG_MSGOUT_RTCM_3X_TYPE1005_USB": 1,
+                        "CFG_MSGOUT_RTCM_3X_TYPE1077_USB": 1,
+                        "CFG_MSGOUT_RTCM_3X_TYPE1087_USB": 1,
+                    }
+                ),
+            ),  # read-back verify (issue #42) — matches
         ]
         mock_reader_cls.return_value = reader
 
@@ -754,6 +793,9 @@ class TestUbloxDriverConfiguration:
         driver.configure_rtcm_messages(config)
 
         mock_ubx_msg.config_set.assert_called_once()
+        # Issue #42: RAM+Flash, not RAM-only — a layer=1 write reverted
+        # to the last-flashed message selection on reboot / reconnect.
+        assert mock_ubx_msg.config_set.call_args[0][0] == 5
 
     @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
     @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
@@ -772,6 +814,10 @@ class TestUbloxDriverConfiguration:
         reader.read.side_effect = [
             (b"", _make_mon_ver_response()),
             (b"", _make_ack_response()),
+            (
+                b"",
+                _make_rtcm_valget({"CFG_MSGOUT_RTCM_3X_TYPE1005_USB": 1}),
+            ),  # read-back verify — matches
         ]
         mock_reader_cls.return_value = reader
 
@@ -785,6 +831,86 @@ class TestUbloxDriverConfiguration:
         # 9999 is not a known RTCM message
         config = RtcmMessageConfig(message_ids=[1005, 9999], rate_hz=1)
         driver.configure_rtcm_messages(config)  # Should not raise, just warn
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_configure_rtcm_messages_retries_once_on_mismatch(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        """Issue #42: a read-back mismatch after the first write is
+        retried once rather than failing immediately."""
+        ser = MagicMock()
+        ser.is_open = True
+        mock_serial_cls.return_value = ser
+
+        reader = MagicMock()
+        reader.read.side_effect = [
+            (b"", _make_mon_ver_response()),
+            (b"", _make_ack_response()),  # first write
+            (b"", _make_rtcm_valget()),  # first read-back — still all zero
+            (b"", _make_ack_response()),  # retried write
+            (
+                b"",
+                _make_rtcm_valget({"CFG_MSGOUT_RTCM_3X_TYPE1005_USB": 1}),
+            ),  # second read-back — matches
+        ]
+        mock_reader_cls.return_value = reader
+
+        mock_msg = MagicMock()
+        mock_msg.serialize.return_value = b"\x00"
+        mock_ubx_msg.config_set.return_value = mock_msg
+
+        driver = UbloxDriver()
+        driver.connect("/dev/ttyUSB0")
+
+        config = RtcmMessageConfig(message_ids=[1005], rate_hz=1)
+        driver.configure_rtcm_messages(config)  # must not raise
+
+        assert mock_ubx_msg.config_set.call_count == 2
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_configure_rtcm_messages_raises_after_second_mismatch(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        """Issue #42: if the message selection still doesn't match after
+        the retry, the call must fail hard instead of silently reporting
+        success — this is the exact bug that let RTCM output go silent
+        after a reboot while the UI claimed success."""
+        ser = MagicMock()
+        ser.is_open = True
+        mock_serial_cls.return_value = ser
+
+        reader = MagicMock()
+        reader.read.side_effect = [
+            (b"", _make_mon_ver_response()),
+            (b"", _make_ack_response()),  # first write
+            (b"", _make_rtcm_valget()),  # first read-back — still all zero
+            (b"", _make_ack_response()),  # retried write
+            (b"", _make_rtcm_valget()),  # second read-back — still all zero
+        ]
+        mock_reader_cls.return_value = reader
+
+        mock_msg = MagicMock()
+        mock_msg.serialize.return_value = b"\x00"
+        mock_ubx_msg.config_set.return_value = mock_msg
+
+        driver = UbloxDriver()
+        driver.connect("/dev/ttyUSB0")
+
+        config = RtcmMessageConfig(message_ids=[1005], rate_hz=1)
+        with pytest.raises(RuntimeError, match="did not take effect"):
+            driver.configure_rtcm_messages(config)
+
+        assert mock_ubx_msg.config_set.call_count == 2
 
     @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
     @patch("sp_rtk_base.services.drivers.ublox.UBXReader")

--- a/uv.lock
+++ b/uv.lock
@@ -2710,7 +2710,7 @@ wheels = [
 
 [[package]]
 name = "sp-rtk-base"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- Closes #42. `configure_rtcm_messages()`, `configure_rtcm_ports()`, and the survey-in enable write in `configure_survey_in()` wrote CFG-VALSET at `layer=1` (RAM only), so the config silently reverted to whatever was last flashed on receiver reboot or port reopen — even though the UI reported success.
- All three now write at `layer=5` (RAM+Flash), matching `configure_fixed_base()`, and verify each write's read-back via a new shared `_write_and_verify_locked()` helper (retry once, then raise on mismatch) — mirroring the ECEF verify-and-retry pattern added for #39.
- Bumps version 0.5.0 → 0.5.1.

## Test plan
- [x] `uv run pytest` — 1051 passed, 91.45% coverage (≥90% gate)
- [x] `uv run pyright src/` — 0 errors
- [x] `uv run ruff check` / `ruff format --check` — clean
- [x] New unit tests cover layer=5 assertions and verify-and-retry (success, one-retry, hard-fail) for RTCM messages, RTCM ports, and survey-in enable