### PR TITLE
fix: force stationary dynamics model (DYN_MODEL=2) on base-mode transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ the changelog can be regenerated automatically via `uv run cz bump`.
 
 Baseline release; not yet published to PyPI.
 
+## v0.5.2 (2026-08-26)
+
+- feat(ublox): force stationary dynamics model (DYN_MODEL=2) on base-mode transitions
+- Fresh ZED-F9P receivers default CFG_NAVSPG_DYNMODEL to 0 (portable),
+which is the wrong nav class for a fixed-mount base station and can
+slow survey-in convergence / degrade the averaged position. Add
+_apply_stationary_dyn_model_locked(), called from both
+configure_survey_in() and configure_fixed_base() after their
+mode-specific write succeeds, to write and verify CFG_NAVSPG_DYNMODEL=2
+via the existing layer=5 verify-and-retry helper.
+- disable_base_mode() deliberately leaves the dynamics model untouched
+— rover mode is out of scope for this app, and clearing it would
+regress a receiver a prior session already set to stationary.
+- Closes #38
+
 ## v0.5.0 (2026-08-25)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sp-rtk-base"
-version = "0.5.1"
+version = "0.5.2"
 description = "Web UI and API for controlling and monitoring a u-blox GPS RTK base station relay"
 readme = "README.md"
 authors = [

--- a/src/sp_rtk_base/__init__.py
+++ b/src/sp_rtk_base/__init__.py
@@ -2,4 +2,4 @@
 
 from __future__ import annotations
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"

--- a/src/sp_rtk_base/services/drivers/ublox.py
+++ b/src/sp_rtk_base/services/drivers/ublox.py
@@ -101,6 +101,15 @@ _BASE_OUTPUT_PROFILE: dict[str, int] = {
     "CFG_UART2OUTPROT_RTCM3X": 1,
 }
 
+# u-blox dynamics-model class for a fixed-mount base station (issue #38).
+# 2 = stationary — tightens the position filter and suppresses
+# velocity/heading estimation, which is the correct nav class for a
+# receiver that never moves.  The receiver defaults to 0 (portable),
+# which is wrong for every base in this fleet, so it's applied
+# unconditionally on every base-mode transition rather than left as an
+# operator-configurable setting.
+_STATIONARY_DYN_MODEL: int = 2
+
 
 class UbloxDriver(GpsReceiverDriver):
     """u-blox GPS receiver driver using UBX protocol via PyUBX2.
@@ -518,6 +527,9 @@ class UbloxDriver(GpsReceiverDriver):
             # for the whole survey, not just once a fixed base is
             # later saved.
             self._apply_base_output_profile_locked()
+            # Force stationary dynamics for the whole survey (issue
+            # #38) — see ``_apply_stationary_dyn_model_locked``.
+            self._apply_stationary_dyn_model_locked()
         logger.info(
             "Survey-in configured: %ds min, %dmm accuracy",
             config.min_duration_seconds,
@@ -540,6 +552,12 @@ class UbloxDriver(GpsReceiverDriver):
         after the second attempt, a ``RuntimeError`` is raised so
         the caller can surface the failure to the operator instead
         of silently leaving the survey running.
+
+        Deliberately leaves ``CFG_NAVSPG_DYNMODEL`` untouched (issue
+        #38): rover mode is not a concern of this app, so there's no
+        "correct" dynamics class to restore here, and clearing it would
+        regress a receiver that a prior fixed-base/survey-in session
+        already set to stationary back to portable for no benefit.
         """
         with self._lock:
             self._send_cfg_valset_locked([("CFG_TMODE_MODE", 0)], layer=1)
@@ -658,6 +676,9 @@ class UbloxDriver(GpsReceiverDriver):
             # VALSET, same as configure_survey_in — see that method's
             # comment for why this isn't merged into the write above.
             self._apply_base_output_profile_locked()
+            # Force stationary dynamics (issue #38) — see
+            # ``_apply_stationary_dyn_model_locked``.
+            self._apply_stationary_dyn_model_locked()
         logger.info(
             "Fixed base configured: %.7f, %.7f, %.2fm (ECEF cm: %d, %d, %d)",
             config.latitude,
@@ -671,6 +692,34 @@ class UbloxDriver(GpsReceiverDriver):
     # ------------------------------------------------------------------
     # Base station output profile (issue #40)
     # ------------------------------------------------------------------
+
+    def _apply_stationary_dyn_model_locked(self) -> None:
+        """Write and verify ``CFG_NAVSPG_DYNMODEL=2`` (stationary).
+
+        Must hold ``self._lock``.  Called from both ``configure_survey_in``
+        and ``configure_fixed_base`` after their mode-specific VALSET (and
+        the base output profile) has already succeeded — issue #38.
+
+        Written to layer=5 (RAM+Flash) rather than the RAM-only layer the
+        issue's original write-up suggested, matching the layer
+        ``configure_survey_in``'s own SVIN params already use since issue
+        #42: a RAM-only write reverts to the last-flashed value on reboot
+        or port reopen, which would fail this issue's own "after a reboot,
+        the value is still 2" acceptance criterion for the survey-in path.
+
+        Reuses ``_write_and_verify_locked``, so a read-back mismatch
+        retries once before raising — same pattern as every other durable
+        CFG-VALSET write in this driver.
+        """
+        self._write_and_verify_locked(
+            [("CFG_NAVSPG_DYNMODEL", _STATIONARY_DYN_MODEL)],
+            layer=5,
+            label="Dynamics model",
+        )
+        logger.info(
+            "Dynamics model set to stationary (CFG_NAVSPG_DYNMODEL=%d)",
+            _STATIONARY_DYN_MODEL,
+        )
 
     def _apply_base_output_profile_locked(self) -> None:
         """Write and verify the RTCM-only UART1/UART2 output profile.

--- a/tests/unit/test_cancel_survey_in.py
+++ b/tests/unit/test_cancel_survey_in.py
@@ -71,6 +71,14 @@ def _make_profile_valget() -> SimpleNamespace:
     )
 
 
+def _make_dyn_model_valget(value: int = 2) -> SimpleNamespace:
+    """CFG-VALGET response for CFG_NAVSPG_DYNMODEL (issue #38).
+
+    Defaults to 2 (stationary).
+    """
+    return SimpleNamespace(identity="CFG-VALGET", CFG_NAVSPG_DYNMODEL=value)
+
+
 # ---------------------------------------------------------------------------
 # FakeGpsDriver.disable_base_mode
 # ---------------------------------------------------------------------------
@@ -223,6 +231,11 @@ class TestUbloxDisableBaseMode:
             ),
             (b"", _make_ack()),  # base output profile write (issue #40)
             (b"", _make_profile_valget()),  # read-back matches
+            (b"", _make_ack()),  # dyn model write (issue #38)
+            (
+                b"",
+                _make_dyn_model_valget(),
+            ),  # dyn model read-back matches
         ]
         mock_reader_cls.return_value = reader
 
@@ -237,9 +250,10 @@ class TestUbloxDisableBaseMode:
                 SurveyInConfig(min_duration_seconds=120, accuracy_limit_mm=50000)
             )
 
-        # Three config_sets: full-layer disable, RAM+Flash enable, and
-        # the layer=5 base output profile (issue #40).
-        assert mock_ubx_msg.config_set.call_count == 3
+        # Four config_sets: full-layer disable, RAM+Flash enable, the
+        # layer=5 base output profile (issue #40), and the layer=5
+        # dyn model write (issue #38).
+        assert mock_ubx_msg.config_set.call_count == 4
         disable = mock_ubx_msg.config_set.call_args_list[0]
         enable = mock_ubx_msg.config_set.call_args_list[1]
         assert disable[0][2] == [("CFG_TMODE_MODE", 0)]
@@ -401,6 +415,11 @@ class TestUbloxDisableBaseMode:
             (b"", nav_svin_fresh_after),  # after-snapshot
             (b"", _make_ack()),  # base output profile write (issue #40)
             (b"", _make_profile_valget()),  # read-back matches
+            (b"", _make_ack()),  # dyn model write (issue #38)
+            (
+                b"",
+                _make_dyn_model_valget(),
+            ),  # dyn model read-back matches
         ]
         mock_reader_cls.return_value = reader
 
@@ -422,11 +441,12 @@ class TestUbloxDisableBaseMode:
 
         # No rollback path triggered — the pre-reset cleared the
         # stale state, and the post-write verify saw a fresh
-        # (dur=0 -> dur=3) progression.  3 CFG-VALSETs fire:
-        # layer=7 disable, layer=5 enable, layer=5 output profile.
-        assert mock_ubx_msg.config_set.call_count == 3
+        # (dur=0 -> dur=3) progression.  4 CFG-VALSETs fire:
+        # layer=7 disable, layer=5 enable, layer=5 output profile,
+        # layer=5 dyn model (issue #38).
+        assert mock_ubx_msg.config_set.call_count == 4
         layers = [c[0][0] for c in mock_ubx_msg.config_set.call_args_list]
-        assert layers == [7, 5, 5]
+        assert layers == [7, 5, 5, 5]
 
     @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
     @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
@@ -472,6 +492,11 @@ class TestUbloxDisableBaseMode:
             (b"", nav_svin_progressed),  # after-snapshot
             (b"", _make_ack()),  # base output profile write
             (b"", _make_profile_valget()),  # read-back matches
+            (b"", _make_ack()),  # dyn model write (issue #38)
+            (
+                b"",
+                _make_dyn_model_valget(),
+            ),  # dyn model read-back matches
         ]
         mock_reader_cls.return_value = reader
 
@@ -486,10 +511,11 @@ class TestUbloxDisableBaseMode:
                 SurveyInConfig(min_duration_seconds=60, accuracy_limit_mm=50000)
             )  # must not raise
 
-        # disable(7) + enable(5) + retried enable(5) + profile(5) = 4 VALSETs.
-        assert mock_ubx_msg.config_set.call_count == 4
+        # disable(7) + enable(5) + retried enable(5) + profile(5) +
+        # dyn model(5) = 5 VALSETs.
+        assert mock_ubx_msg.config_set.call_count == 5
         layers = [c[0][0] for c in mock_ubx_msg.config_set.call_args_list]
-        assert layers == [7, 5, 5, 5]
+        assert layers == [7, 5, 5, 5, 5]
 
     @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
     @patch("sp_rtk_base.services.drivers.ublox.UBXReader")

--- a/tests/unit/test_ublox_driver.py
+++ b/tests/unit/test_ublox_driver.py
@@ -121,6 +121,14 @@ def _make_base_output_profile_valget(**overrides: int) -> SimpleNamespace:
     return SimpleNamespace(identity="CFG-VALGET", **values)
 
 
+def _make_dyn_model_valget(value: int = 2) -> SimpleNamespace:
+    """Create a mock CFG-VALGET response for CFG_NAVSPG_DYNMODEL (issue #38).
+
+    Defaults to 2 (stationary); pass ``value=0`` to simulate a mismatch.
+    """
+    return SimpleNamespace(identity="CFG-VALGET", CFG_NAVSPG_DYNMODEL=value)
+
+
 @pytest.fixture()
 def mock_serial() -> MagicMock:
     """Create a mock serial.Serial instance."""
@@ -336,6 +344,8 @@ class TestUbloxDriverConfiguration:
         #   6. NAV-SVIN poll                                -> dur=3 (incremented)
         #   7. CFG-VALSET base output profile (layer=5)     -> ACK
         #   8. CFG-VALGET read-back                         -> matches (issue #40)
+        #   9. CFG-VALSET dyn model (layer=5)                -> ACK
+        #  10. CFG-VALGET read-back                         -> matches (issue #38)
         reader.read.side_effect = [
             (b"", _make_mon_ver_response()),
             (b"", _make_nav_svin_response(active=0, valid=0, dur=0, obs=0)),  # baseline
@@ -354,6 +364,11 @@ class TestUbloxDriverConfiguration:
             (b"", _make_nav_svin_response(active=0, valid=0, dur=3, obs=1)),
             (b"", _make_ack_response()),  # base output profile write
             (b"", _make_base_output_profile_valget()),  # read-back matches
+            (b"", _make_ack_response()),  # dyn model write
+            (
+                b"",
+                _make_dyn_model_valget(),
+            ),  # dyn model read-back matches
         ]
         mock_reader_cls.return_value = reader
 
@@ -368,15 +383,18 @@ class TestUbloxDriverConfiguration:
         with patch("sp_rtk_base.services.drivers.ublox.time.sleep"):
             driver.configure_survey_in(config)
 
-        # Three CFG-VALSET calls: layer=7 disable, layer=5 enable
-        # (issue #42), and layer=5 base output profile (issue #40).
-        assert mock_ubx_msg.config_set.call_count == 3
+        # Four CFG-VALSET calls: layer=7 disable, layer=5 enable
+        # (issue #42), layer=5 base output profile (issue #40), and
+        # layer=5 dyn model (issue #38).
+        assert mock_ubx_msg.config_set.call_count == 4
         disable_layer = mock_ubx_msg.config_set.call_args_list[0][0][0]
         disable_cfg = mock_ubx_msg.config_set.call_args_list[0][0][2]
         enable_layer = mock_ubx_msg.config_set.call_args_list[1][0][0]
         enable_cfg = mock_ubx_msg.config_set.call_args_list[1][0][2]
         profile_layer = mock_ubx_msg.config_set.call_args_list[2][0][0]
         profile_cfg = mock_ubx_msg.config_set.call_args_list[2][0][2]
+        dyn_model_layer = mock_ubx_msg.config_set.call_args_list[3][0][0]
+        dyn_model_cfg = mock_ubx_msg.config_set.call_args_list[3][0][2]
 
         # Disable must hit RAM|BBR|Flash (7), per u-blox C099 reference
         # script — RAM-only leaves BBR pinned and the ``dur`` counter
@@ -411,6 +429,9 @@ class TestUbloxDriverConfiguration:
             ("CFG_UART2OUTPROT_UBX", 0),
             ("CFG_UART2OUTPROT_RTCM3X", 1),
         ]
+        # Dynamics model: separate layer=5 VALSET, stationary (issue #38).
+        assert dyn_model_layer == 5
+        assert dyn_model_cfg == [("CFG_NAVSPG_DYNMODEL", 2)]
         # UBX input protocols must never be touched — the app manages
         # the receiver over the same link.
         all_keys = {
@@ -457,6 +478,11 @@ class TestUbloxDriverConfiguration:
             ),
             (b"", _make_ack_response()),  # ACK for base output profile write
             (b"", _make_base_output_profile_valget()),  # read-back matches
+            (b"", _make_ack_response()),  # ACK for dyn model write
+            (
+                b"",
+                _make_dyn_model_valget(),
+            ),  # dyn model read-back matches
         ]
         mock_reader_cls.return_value = reader
 
@@ -476,19 +502,22 @@ class TestUbloxDriverConfiguration:
         with patch("sp_rtk_base.services.drivers.ublox.time.sleep"):
             driver.configure_fixed_base(config)
 
-        # Three CFG-VALSETs: layer=7 disable, layer=5 fixed-base, and
-        # layer=5 base output profile (issue #40).
+        # Four CFG-VALSETs: layer=7 disable, layer=5 fixed-base, layer=5
+        # base output profile (issue #40), and layer=5 dyn model
+        # (issue #38).
         # Pre-disable mirrors configure_survey_in — without it, a
         # receiver currently in TMODE=1 silently coalesces the
         # TMODE=2 write and stays in survey-in (the Path 2 bug
         # diagnosed on larson-base before v0.3.5).
-        assert mock_ubx_msg.config_set.call_count == 3
+        assert mock_ubx_msg.config_set.call_count == 4
         disable_layer = mock_ubx_msg.config_set.call_args_list[0][0][0]
         disable_cfg = mock_ubx_msg.config_set.call_args_list[0][0][2]
         fixed_layer = mock_ubx_msg.config_set.call_args_list[1][0][0]
         fixed_cfg = mock_ubx_msg.config_set.call_args_list[1][0][2]
         profile_layer = mock_ubx_msg.config_set.call_args_list[2][0][0]
         profile_cfg = mock_ubx_msg.config_set.call_args_list[2][0][2]
+        dyn_model_layer = mock_ubx_msg.config_set.call_args_list[3][0][0]
+        dyn_model_cfg = mock_ubx_msg.config_set.call_args_list[3][0][2]
 
         assert disable_layer == 7
         assert disable_cfg == [("CFG_TMODE_MODE", 0)]
@@ -530,6 +559,9 @@ class TestUbloxDriverConfiguration:
             ("CFG_UART2OUTPROT_UBX", 0),
             ("CFG_UART2OUTPROT_RTCM3X", 1),
         ]
+        # Dynamics model: separate layer=5 VALSET, stationary (issue #38).
+        assert dyn_model_layer == 5
+        assert dyn_model_cfg == [("CFG_NAVSPG_DYNMODEL", 2)]
         # UBX input protocols must never be touched — the app manages
         # the receiver over the same link.
         all_keys = {
@@ -677,6 +709,11 @@ class TestUbloxDriverConfiguration:
             (b"", _make_base_output_profile_valget(CFG_UART1OUTPROT_NMEA=1)),
             (b"", _make_ack_response()),  # retried profile write
             (b"", _make_base_output_profile_valget()),  # second read-back matches
+            (b"", _make_ack_response()),  # dyn model write
+            (
+                b"",
+                _make_dyn_model_valget(),
+            ),  # dyn model read-back matches
         ]
         mock_reader_cls.return_value = reader
 
@@ -693,8 +730,9 @@ class TestUbloxDriverConfiguration:
         with patch("sp_rtk_base.services.drivers.ublox.time.sleep"):
             driver.configure_fixed_base(config)  # must not raise
 
-        # disable(7) + fixed(5) + profile write + profile retry = 4 VALSETs.
-        assert mock_ubx_msg.config_set.call_count == 4
+        # disable(7) + fixed(5) + profile write + profile retry + dyn
+        # model = 5 VALSETs.
+        assert mock_ubx_msg.config_set.call_count == 5
 
     @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
     @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
@@ -751,6 +789,122 @@ class TestUbloxDriverConfiguration:
 
         # disable(7) + fixed(5) + profile write + profile retry = 4 VALSETs.
         assert mock_ubx_msg.config_set.call_count == 4
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_dyn_model_retries_once_on_mismatch(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        """Issue #38: a read-back mismatch on CFG_NAVSPG_DYNMODEL is
+        retried once, mirroring the base output profile's verify-and-retry
+        pattern, rather than failing immediately."""
+        ser = MagicMock()
+        ser.is_open = True
+        mock_serial_cls.return_value = ser
+
+        reader = MagicMock()
+        reader.read.side_effect = [
+            (b"", _make_mon_ver_response()),
+            (b"", _make_ack_response()),  # ACK for layer=7 disable
+            (b"", _make_ack_response()),  # ACK for layer=5 fixed-base write
+            (
+                b"",
+                SimpleNamespace(
+                    identity="CFG-VALGET",
+                    CFG_TMODE_ECEF_X=427750094,
+                    CFG_TMODE_ECEF_Y=64275758,
+                    CFG_TMODE_ECEF_Z=467210663,
+                ),
+            ),
+            (b"", _make_ack_response()),  # base output profile write
+            (b"", _make_base_output_profile_valget()),  # read-back matches
+            (b"", _make_ack_response()),  # first dyn model write
+            # First read-back — still portable (0), write hasn't taken.
+            (b"", _make_dyn_model_valget(0)),
+            (b"", _make_ack_response()),  # retried dyn model write
+            (
+                b"",
+                _make_dyn_model_valget(),
+            ),  # second read-back matches
+        ]
+        mock_reader_cls.return_value = reader
+
+        mock_msg = MagicMock()
+        mock_msg.serialize.return_value = b"\x00"
+        mock_ubx_msg.config_set.return_value = mock_msg
+
+        driver = UbloxDriver()
+        driver.connect("/dev/ttyUSB0")
+
+        config = FixedBaseConfig(
+            latitude=47.3977, longitude=8.5456, altitude_m=408.0, accuracy_mm=500
+        )
+        with patch("sp_rtk_base.services.drivers.ublox.time.sleep"):
+            driver.configure_fixed_base(config)  # must not raise
+
+        # disable(7) + fixed(5) + profile + dyn write + dyn retry = 5.
+        assert mock_ubx_msg.config_set.call_count == 5
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_dyn_model_raises_after_second_mismatch(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        """Issue #38: if CFG_NAVSPG_DYNMODEL still doesn't read back as 2
+        after the retry, configure_fixed_base must fail hard — even though
+        TMODE/position and the output profile already succeeded."""
+        ser = MagicMock()
+        ser.is_open = True
+        mock_serial_cls.return_value = ser
+
+        stale = _make_dyn_model_valget(0)
+        reader = MagicMock()
+        reader.read.side_effect = [
+            (b"", _make_mon_ver_response()),
+            (b"", _make_ack_response()),  # ACK for layer=7 disable
+            (b"", _make_ack_response()),  # ACK for layer=5 fixed-base write
+            (
+                b"",
+                SimpleNamespace(
+                    identity="CFG-VALGET",
+                    CFG_TMODE_ECEF_X=427750094,
+                    CFG_TMODE_ECEF_Y=64275758,
+                    CFG_TMODE_ECEF_Z=467210663,
+                ),
+            ),
+            (b"", _make_ack_response()),  # base output profile write
+            (b"", _make_base_output_profile_valget()),  # read-back matches
+            (b"", _make_ack_response()),  # first dyn model write
+            (b"", stale),  # first read-back — mismatch
+            (b"", _make_ack_response()),  # retried dyn model write
+            (b"", stale),  # second read-back — still mismatched
+        ]
+        mock_reader_cls.return_value = reader
+
+        mock_msg = MagicMock()
+        mock_msg.serialize.return_value = b"\x00"
+        mock_ubx_msg.config_set.return_value = mock_msg
+
+        driver = UbloxDriver()
+        driver.connect("/dev/ttyUSB0")
+
+        config = FixedBaseConfig(
+            latitude=47.3977, longitude=8.5456, altitude_m=408.0, accuracy_mm=500
+        )
+        with patch("sp_rtk_base.services.drivers.ublox.time.sleep"):
+            with pytest.raises(RuntimeError, match="[Dd]ynamics model"):
+                driver.configure_fixed_base(config)
+
+        # disable(7) + fixed(5) + profile + dyn write + dyn retry = 5.
+        assert mock_ubx_msg.config_set.call_count == 5
 
     @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
     @patch("sp_rtk_base.services.drivers.ublox.UBXReader")

--- a/uv.lock
+++ b/uv.lock
@@ -2710,7 +2710,7 @@ wheels = [
 
 [[package]]
 name = "sp-rtk-base"
-version = "0.5.1"
+version = "0.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- `configure_survey_in()` and `configure_fixed_base()` never touched `CFG_NAVSPG_DYNMODEL`, leaving freshly configured bases at the receiver's default (0, portable) instead of the correct stationary class for a fixed mount.
- Adds `_apply_stationary_dyn_model_locked()`, called from both transitions after their mode-specific write succeeds, writing+verifying `CFG_NAVSPG_DYNMODEL=2` via the existing layer=5 verify-and-retry helper (`_write_and_verify_locked`).
- `disable_base_mode()` deliberately leaves it untouched — rover mode is out of scope, and clearing it would regress a receiver a prior session already set to stationary.
- Bumps version 0.5.1 → 0.5.2 and adds a CHANGELOG entry.

Closes #38

## Test plan
- [x] Unit tests updated (`test_ublox_driver.py`, `test_cancel_survey_in.py`) covering the new write, the retry-once-on-mismatch path, and the raise-after-second-mismatch path.
- [x] Full unit suite: 1053 passed, 91.46% coverage.
- [x] `pyright` strict + `mypy` strict clean.
- [x] `ruff check` / `ruff format --check` clean.
- [x] Ran `/code-review` (Standards + Spec) — both passed; addressed the two judgement-call findings (test fixture duplication, missing success-path log line).