### PR TITLE
refactor(rtcm): replace int-keyed RTCM row identity with RtcmRowId enum

### DIFF
--- a/src/sp_rtk_base/api/device.py
+++ b/src/sp_rtk_base/api/device.py
@@ -231,7 +231,7 @@ async def configure_rtcm_messages(
 
     return DeviceActionResponse(
         status="ok",
-        message=f"RTCM messages configured: {config.message_ids}",
+        message=f"RTCM messages configured: {config.message_id_values}",
     )
 
 

--- a/src/sp_rtk_base/models/device_models.py
+++ b/src/sp_rtk_base/models/device_models.py
@@ -168,10 +168,34 @@ class CurrentBaseConfig(BaseModel):
     )
 
 
+class RtcmRowId(str, enum.Enum):
+    """Row identity for an RTCM message output slot.
+
+    The 12 rows this app can address, keyed by their RTCM/u-blox
+    identity string rather than a bare message-type int. This exists
+    because 4072 (u-blox reference-station PVT) has two independently
+    controllable sub-messages, 4072.0 and 4072.1, which an ``int``
+    cannot represent as distinct rows.
+    """
+
+    RTCM_1005 = "1005"
+    RTCM_4072_0 = "4072.0"
+    RTCM_4072_1 = "4072.1"
+    RTCM_1074 = "1074"
+    RTCM_1077 = "1077"
+    RTCM_1084 = "1084"
+    RTCM_1087 = "1087"
+    RTCM_1094 = "1094"
+    RTCM_1097 = "1097"
+    RTCM_1124 = "1124"
+    RTCM_1127 = "1127"
+    RTCM_1230 = "1230"
+
+
 class RtcmMessageConfig(BaseModel):
     """RTCM message output selection (simple, single-port).
 
-    Standard RTCM 3.x message IDs for base station operation:
+    Standard RTCM 3.x rows for base station operation:
     - 1005: Station ARP (position)
     - 1077: GPS MSM7
     - 1087: GLONASS MSM7
@@ -180,9 +204,16 @@ class RtcmMessageConfig(BaseModel):
     - 1230: GLONASS code-phase biases
     """
 
-    message_ids: list[int] = Field(
-        default_factory=lambda: [1005, 1077, 1087, 1097, 1127, 1230],
-        description="RTCM message IDs to enable on the receiver",
+    message_ids: list[RtcmRowId] = Field(
+        default_factory=lambda: [
+            RtcmRowId.RTCM_1005,
+            RtcmRowId.RTCM_1077,
+            RtcmRowId.RTCM_1087,
+            RtcmRowId.RTCM_1097,
+            RtcmRowId.RTCM_1127,
+            RtcmRowId.RTCM_1230,
+        ],
+        description="RTCM row IDs to enable on the receiver",
     )
     rate_hz: int = Field(
         default=1,
@@ -190,6 +221,18 @@ class RtcmMessageConfig(BaseModel):
         le=10,
         description="Output rate in Hz (messages per second)",
     )
+
+    @property
+    def message_id_values(self) -> list[str]:
+        """Plain string values, for logging/display.
+
+        A bare f-string/list of ``RtcmRowId`` members renders via
+        ``repr()`` (e.g. ``<RtcmRowId.RTCM_1005: '1005'>``) rather than
+        the enum's string value, since Python only special-cases the
+        mixed-in ``__str__`` for a single member, not one nested in a
+        list.
+        """
+        return [m.value for m in self.message_ids]
 
 
 class RtcmOutputPort(str, enum.Enum):
@@ -202,18 +245,25 @@ class RtcmOutputPort(str, enum.Enum):
     SPI = "SPI"
 
 
-# RTCM message groups for UI display
-RTCM_MESSAGE_GROUPS: list[tuple[str, list[tuple[int, str]]]] = [
-    ("Reference", [(1005, "Station ARP"), (4072, "Ref station PVT")]),
-    ("GPS", [(1074, "MSM4"), (1077, "MSM7")]),
-    ("GLONASS", [(1084, "MSM4"), (1087, "MSM7")]),
-    ("Galileo", [(1094, "MSM4"), (1097, "MSM7")]),
-    ("BeiDou", [(1124, "MSM4"), (1127, "MSM7")]),
-    ("GLONASS Bias", [(1230, "Code-phase biases")]),
+# RTCM row groups for UI display
+RTCM_MESSAGE_GROUPS: list[tuple[str, list[tuple[RtcmRowId, str]]]] = [
+    (
+        "Reference",
+        [
+            (RtcmRowId.RTCM_1005, "Station ARP"),
+            (RtcmRowId.RTCM_4072_0, "Ref station PVT (4072.0)"),
+            (RtcmRowId.RTCM_4072_1, "Ref station PVT (4072.1)"),
+        ],
+    ),
+    ("GPS", [(RtcmRowId.RTCM_1074, "MSM4"), (RtcmRowId.RTCM_1077, "MSM7")]),
+    ("GLONASS", [(RtcmRowId.RTCM_1084, "MSM4"), (RtcmRowId.RTCM_1087, "MSM7")]),
+    ("Galileo", [(RtcmRowId.RTCM_1094, "MSM4"), (RtcmRowId.RTCM_1097, "MSM7")]),
+    ("BeiDou", [(RtcmRowId.RTCM_1124, "MSM4"), (RtcmRowId.RTCM_1127, "MSM7")]),
+    ("GLONASS Bias", [(RtcmRowId.RTCM_1230, "Code-phase biases")]),
 ]
 
-# All known RTCM message IDs (flat list)
-ALL_RTCM_MESSAGE_IDS: list[int] = [
+# All known RTCM row IDs (flat list)
+ALL_RTCM_MESSAGE_IDS: list[RtcmRowId] = [
     msg_id for _, msgs in RTCM_MESSAGE_GROUPS for msg_id, _ in msgs
 ]
 
@@ -221,37 +271,37 @@ ALL_RTCM_MESSAGE_IDS: list[int] = [
 class RtcmPortConfig(BaseModel):
     """Multi-port RTCM output configuration.
 
-    Stores per-message, per-port output rates.  A rate of 0 means
-    the message is disabled on that port; rate > 0 means enabled
+    Stores per-row, per-port output rates.  A rate of 0 means
+    the row is disabled on that port; rate > 0 means enabled
     at that many messages per navigation epoch.
 
     Example::
 
         config.messages = {
-            1005: {"USB": 1, "UART1": 0, "UART2": 1, "I2C": 0, "SPI": 0},
-            1077: {"USB": 1, "UART1": 1, "UART2": 0, "I2C": 0, "SPI": 0},
+            RtcmRowId.RTCM_1005: {"USB": 1, "UART1": 0, "UART2": 1, "I2C": 0, "SPI": 0},
+            RtcmRowId.RTCM_1077: {"USB": 1, "UART1": 1, "UART2": 0, "I2C": 0, "SPI": 0},
         }
     """
 
-    messages: dict[int, dict[str, int]] = Field(
-        default_factory=lambda: dict[int, dict[str, int]](),
-        description="msg_id → {port: rate} mapping",
+    messages: dict[RtcmRowId, dict[str, int]] = Field(
+        default_factory=lambda: dict[RtcmRowId, dict[str, int]](),
+        description="row id → {port: rate} mapping",
     )
 
-    def enabled_on_port(self, port: RtcmOutputPort) -> list[int]:
-        """Return message IDs enabled (rate > 0) on a given port."""
+    def enabled_on_port(self, port: RtcmOutputPort) -> list[RtcmRowId]:
+        """Return row IDs enabled (rate > 0) on a given port."""
         return [
             msg_id
             for msg_id, ports in self.messages.items()
             if ports.get(port.value, 0) > 0
         ]
 
-    def is_enabled(self, msg_id: int, port: RtcmOutputPort) -> bool:
-        """Check if a specific message is enabled on a specific port."""
+    def is_enabled(self, msg_id: RtcmRowId, port: RtcmOutputPort) -> bool:
+        """Check if a specific row is enabled on a specific port."""
         return self.messages.get(msg_id, {}).get(port.value, 0) > 0
 
-    def rate(self, msg_id: int, port: RtcmOutputPort) -> int:
-        """Get the rate for a specific message on a specific port."""
+    def rate(self, msg_id: RtcmRowId, port: RtcmOutputPort) -> int:
+        """Get the rate for a specific row on a specific port."""
         return self.messages.get(msg_id, {}).get(port.value, 0)
 
 

--- a/src/sp_rtk_base/services/device_service.py
+++ b/src/sp_rtk_base/services/device_service.py
@@ -437,7 +437,7 @@ class DeviceService:
             self._state = DeviceConnectionState.CONNECTED
             logger.info(
                 "RTCM messages configured: %s @ %dHz",
-                config.message_ids,
+                config.message_id_values,
                 config.rate_hz,
             )
         except Exception as exc:

--- a/src/sp_rtk_base/services/drivers/fake.py
+++ b/src/sp_rtk_base/services/drivers/fake.py
@@ -60,6 +60,7 @@ from sp_rtk_base.models.device_models import (
     GpsPosition,
     RtcmMessageConfig,
     RtcmPortConfig,
+    RtcmRowId,
     SerialPortInfo,
     SurveyInConfig,
     SurveyInProgress,
@@ -139,12 +140,15 @@ class FakeGpsDriver(GpsReceiverDriver):
         self._rtcm_msgs: RtcmMessageConfig = RtcmMessageConfig()
         self._rtcm_ports: RtcmPortConfig = RtcmPortConfig(
             messages={
-                1005: {"USB": 1, "UART1": 1, "UART2": 0, "I2C": 0, "SPI": 0},
-                1077: {"USB": 1, "UART1": 1, "UART2": 0, "I2C": 0, "SPI": 0},
-                1087: {"USB": 1, "UART1": 1, "UART2": 0, "I2C": 0, "SPI": 0},
-                1097: {"USB": 1, "UART1": 1, "UART2": 0, "I2C": 0, "SPI": 0},
-                1127: {"USB": 1, "UART1": 1, "UART2": 0, "I2C": 0, "SPI": 0},
-                1230: {"USB": 1, "UART1": 1, "UART2": 0, "I2C": 0, "SPI": 0},
+                msg_id: {"USB": 1, "UART1": 1, "UART2": 0, "I2C": 0, "SPI": 0}
+                for msg_id in (
+                    RtcmRowId.RTCM_1005,
+                    RtcmRowId.RTCM_1077,
+                    RtcmRowId.RTCM_1087,
+                    RtcmRowId.RTCM_1097,
+                    RtcmRowId.RTCM_1127,
+                    RtcmRowId.RTCM_1230,
+                )
             }
         )
 

--- a/src/sp_rtk_base/services/drivers/ublox.py
+++ b/src/sp_rtk_base/services/drivers/ublox.py
@@ -39,6 +39,7 @@ from sp_rtk_base.models.device_models import (
     RtcmMessageConfig,
     RtcmOutputPort,
     RtcmPortConfig,
+    RtcmRowId,
     SurveyInConfig,
     SurveyInProgress,
 )
@@ -57,32 +58,32 @@ _MAX_READ_ATTEMPTS = 50
 # u-blox output port suffixes for CFG key names
 _RTCM_PORTS: list[str] = [p.value for p in RtcmOutputPort]
 
-# RTCM message IDs and their CFG key base names.
-# Most follow pattern CFG_MSGOUT_RTCM_3X_TYPE{id}_{port}
-# except 4072 which is CFG_MSGOUT_RTCM_3X_TYPE4072_0_{port}
-_RTCM_KEY_BASES: dict[int, str] = {
-    1005: "CFG_MSGOUT_RTCM_3X_TYPE1005",
-    1074: "CFG_MSGOUT_RTCM_3X_TYPE1074",
-    1077: "CFG_MSGOUT_RTCM_3X_TYPE1077",
-    1084: "CFG_MSGOUT_RTCM_3X_TYPE1084",
-    1087: "CFG_MSGOUT_RTCM_3X_TYPE1087",
-    1094: "CFG_MSGOUT_RTCM_3X_TYPE1094",
-    1097: "CFG_MSGOUT_RTCM_3X_TYPE1097",
-    1124: "CFG_MSGOUT_RTCM_3X_TYPE1124",
-    1127: "CFG_MSGOUT_RTCM_3X_TYPE1127",
-    1230: "CFG_MSGOUT_RTCM_3X_TYPE1230",
-    4072: "CFG_MSGOUT_RTCM_3X_TYPE4072_0",
+# RTCM row IDs and their CFG key base names.
+# Every row follows pattern CFG_MSGOUT_RTCM_3X_TYPE{id}_{port} — 4072.0
+# and 4072.1 are distinct rows with distinct CFG keys.
+_RTCM_KEY_BASES: dict[RtcmRowId, str] = {
+    RtcmRowId.RTCM_1005: "CFG_MSGOUT_RTCM_3X_TYPE1005",
+    RtcmRowId.RTCM_4072_0: "CFG_MSGOUT_RTCM_3X_TYPE4072_0",
+    RtcmRowId.RTCM_4072_1: "CFG_MSGOUT_RTCM_3X_TYPE4072_1",
+    RtcmRowId.RTCM_1074: "CFG_MSGOUT_RTCM_3X_TYPE1074",
+    RtcmRowId.RTCM_1077: "CFG_MSGOUT_RTCM_3X_TYPE1077",
+    RtcmRowId.RTCM_1084: "CFG_MSGOUT_RTCM_3X_TYPE1084",
+    RtcmRowId.RTCM_1087: "CFG_MSGOUT_RTCM_3X_TYPE1087",
+    RtcmRowId.RTCM_1094: "CFG_MSGOUT_RTCM_3X_TYPE1094",
+    RtcmRowId.RTCM_1097: "CFG_MSGOUT_RTCM_3X_TYPE1097",
+    RtcmRowId.RTCM_1124: "CFG_MSGOUT_RTCM_3X_TYPE1124",
+    RtcmRowId.RTCM_1127: "CFG_MSGOUT_RTCM_3X_TYPE1127",
+    RtcmRowId.RTCM_1230: "CFG_MSGOUT_RTCM_3X_TYPE1230",
 }
 
 
-def _rtcm_key(msg_id: int, port: str) -> str:
-    """Build the full CFG key name for an RTCM message + port."""
-    base = _RTCM_KEY_BASES.get(msg_id, f"CFG_MSGOUT_RTCM_3X_TYPE{msg_id}")
-    return f"{base}_{port}"
+def _rtcm_key(msg_id: RtcmRowId, port: str) -> str:
+    """Build the full CFG key name for an RTCM row + port."""
+    return f"{_RTCM_KEY_BASES[msg_id]}_{port}"
 
 
 # Legacy USB-only mapping (backward compat)
-_RTCM_USB_KEYS: dict[int, str] = {
+_RTCM_USB_KEYS: dict[RtcmRowId, str] = {
     msg_id: _rtcm_key(msg_id, "USB") for msg_id in _RTCM_KEY_BASES
 }
 
@@ -850,12 +851,7 @@ class UbloxDriver(GpsReceiverDriver):
 
         # Then enable requested messages at the specified rate
         for msg_id in config.message_ids:
-            # New local name (different type from the str loop var above)
-            mapped_key = _RTCM_USB_KEYS.get(msg_id)
-            if mapped_key is not None:
-                cfg_data.append((mapped_key, config.rate_hz))
-            else:
-                logger.warning("Unknown RTCM message ID %d — skipped", msg_id)
+            cfg_data.append((_RTCM_USB_KEYS[msg_id], config.rate_hz))
 
         with self._lock:
             # Issue #42: this used to write RAM only (layer=1), so the
@@ -869,7 +865,7 @@ class UbloxDriver(GpsReceiverDriver):
             )
         logger.info(
             "RTCM messages configured: %s @ %dHz",
-            config.message_ids,
+            config.message_id_values,
             config.rate_hz,
         )
 
@@ -907,7 +903,7 @@ class UbloxDriver(GpsReceiverDriver):
     @staticmethod
     def _parse_rtcm_valget(parsed: object) -> RtcmMessageConfig:
         """Parse a CFG-VALGET response containing RTCM message rates."""
-        enabled_ids: list[int] = []
+        enabled_ids: list[RtcmRowId] = []
         rates: list[int] = []
 
         for msg_id, key_name in _RTCM_USB_KEYS.items():
@@ -932,7 +928,7 @@ class UbloxDriver(GpsReceiverDriver):
         """Read RTCM output config for ALL ports from the receiver.
 
         Polls ``CFG_MSGOUT_RTCM_3X_TYPE*_{USB,UART1,UART2,I2C,SPI}``
-        and returns a matrix of msg_id → {port: rate}.
+        and returns a matrix of row id → {port: rate}.
         """
         with self._lock:
             return self._get_rtcm_port_config_locked()
@@ -941,7 +937,7 @@ class UbloxDriver(GpsReceiverDriver):
         """Read multi-port RTCM config (must hold self._lock)."""
         ser, reader = self._require_connection()
 
-        # Build key list: 11 messages × 5 ports = 55 keys
+        # Build key list: 12 rows × 5 ports = 60 keys
         all_keys: list[str | int] = []
         for msg_id in _ALL_RTCM_IDS:
             for port in _RTCM_PORTS:
@@ -967,7 +963,7 @@ class UbloxDriver(GpsReceiverDriver):
     @staticmethod
     def _parse_rtcm_port_valget(parsed: object) -> RtcmPortConfig:
         """Parse a CFG-VALGET response into a multi-port RTCM config."""
-        messages: dict[int, dict[str, int]] = {}
+        messages: dict[RtcmRowId, dict[str, int]] = {}
 
         for msg_id in _ALL_RTCM_IDS:
             port_rates: dict[str, int] = {}
@@ -989,9 +985,6 @@ class UbloxDriver(GpsReceiverDriver):
         cfg_data: list[tuple[str, int]] = []
 
         for msg_id, port_rates in config.messages.items():
-            if msg_id not in _RTCM_KEY_BASES:
-                logger.warning("Unknown RTCM message ID %d — skipped", msg_id)
-                continue
             for port, rate in port_rates.items():
                 key = _rtcm_key(msg_id, port)
                 cfg_data.append((key, rate))

--- a/src/sp_rtk_base/ui/pages/gps_config.py
+++ b/src/sp_rtk_base/ui/pages/gps_config.py
@@ -24,6 +24,7 @@ from sp_rtk_base.models.device_models import (
     DeviceConnectionState,
     RtcmOutputPort,
     RtcmPortConfig,
+    RtcmRowId,
 )
 from sp_rtk_base.services import get_config_service, get_device_service
 from sp_rtk_base.services.drivers import create_driver, list_drivers
@@ -125,7 +126,7 @@ def gps_config_page() -> None:
                 ).classes("text-grey-4 q-mt-xs text-caption")
 
                 # Build checkbox grid: rtcm_port_checks[msg_id][port] = checkbox
-                rtcm_port_checks: dict[int, dict[str, ui.checkbox]] = {}
+                rtcm_port_checks: dict[RtcmRowId, dict[str, ui.checkbox]] = {}
 
                 with ui.column().classes("q-mt-sm gap-0 w-full"):
                     # Header row
@@ -480,7 +481,7 @@ def gps_config_page() -> None:
         async def _apply_rtcm() -> None:
             """Apply multi-port RTCM message configuration."""
             rate = int(rtcm_rate.value or 1)
-            messages: dict[int, dict[str, int]] = {}
+            messages: dict[RtcmRowId, dict[str, int]] = {}
 
             any_enabled = False
             for msg_id, port_cbs in rtcm_port_checks.items():

--- a/tests/unit/test_api_device.py
+++ b/tests/unit/test_api_device.py
@@ -421,7 +421,7 @@ class TestConfigureRtcm:
         resp = client.post(
             "/api/device/configure/rtcm",
             json={
-                "message_ids": [1005, 1077, 1087],
+                "message_ids": ["1005", "1077", "1087"],
                 "rate_hz": 1,
             },
         )

--- a/tests/unit/test_device_models.py
+++ b/tests/unit/test_device_models.py
@@ -12,6 +12,7 @@ from sp_rtk_base.models.device_models import (
     DeviceStatus,
     FixedBaseConfig,
     RtcmMessageConfig,
+    RtcmRowId,
     SurveyInConfig,
     SurveyInProgress,
 )
@@ -128,11 +129,20 @@ class TestRtcmMessageConfig:
 
     def test_defaults(self) -> None:
         cfg = RtcmMessageConfig()
-        assert cfg.message_ids == [1005, 1077, 1087, 1097, 1127, 1230]
+        assert cfg.message_ids == [
+            RtcmRowId.RTCM_1005,
+            RtcmRowId.RTCM_1077,
+            RtcmRowId.RTCM_1087,
+            RtcmRowId.RTCM_1097,
+            RtcmRowId.RTCM_1127,
+            RtcmRowId.RTCM_1230,
+        ]
         assert cfg.rate_hz == 1
 
     def test_custom_messages(self) -> None:
-        cfg = RtcmMessageConfig(message_ids=[1005, 1077], rate_hz=5)
+        cfg = RtcmMessageConfig(
+            message_ids=[RtcmRowId.RTCM_1005, RtcmRowId.RTCM_1077], rate_hz=5
+        )
         assert len(cfg.message_ids) == 2
         assert cfg.rate_hz == 5
 
@@ -141,6 +151,28 @@ class TestRtcmMessageConfig:
             RtcmMessageConfig(rate_hz=0)
         with pytest.raises(ValidationError):
             RtcmMessageConfig(rate_hz=11)
+
+    def test_rejects_unknown_row_id(self) -> None:
+        """message_ids only accepts the 12 known RtcmRowId values."""
+        with pytest.raises(ValidationError):
+            RtcmMessageConfig(message_ids=["9999"])  # type: ignore[list-item]
+
+
+class TestRtcmRowId:
+    """Tests for the RtcmRowId enum."""
+
+    def test_twelve_members(self) -> None:
+        assert len(RtcmRowId) == 12
+
+    def test_4072_split_into_two_rows(self) -> None:
+        assert RtcmRowId.RTCM_4072_0.value == "4072.0"
+        assert RtcmRowId.RTCM_4072_1.value == "4072.1"
+        assert RtcmRowId.RTCM_4072_0 != RtcmRowId.RTCM_4072_1
+
+    def test_is_str_subclass(self) -> None:
+        """Values must serialise as plain strings over the API."""
+        assert isinstance(RtcmRowId.RTCM_1005, str)
+        assert RtcmRowId.RTCM_1005 == "1005"
 
 
 class TestSurveyInProgress:

--- a/tests/unit/test_device_service.py
+++ b/tests/unit/test_device_service.py
@@ -15,6 +15,7 @@ from sp_rtk_base.models.device_models import (
     DeviceInfo,
     FixedBaseConfig,
     RtcmMessageConfig,
+    RtcmRowId,
     SurveyInConfig,
     SurveyInProgress,
 )
@@ -267,7 +268,9 @@ class TestConfiguration:
 
     @pytest.mark.asyncio()
     async def test_configure_rtcm_messages(self, connected_svc: DeviceService) -> None:
-        config = RtcmMessageConfig(message_ids=[1005, 1077], rate_hz=2)
+        config = RtcmMessageConfig(
+            message_ids=[RtcmRowId.RTCM_1005, RtcmRowId.RTCM_1077], rate_hz=2
+        )
         await connected_svc.configure_rtcm_messages(config)
 
         assert connected_svc.state == DeviceConnectionState.CONNECTED

--- a/tests/unit/test_fake_driver.py
+++ b/tests/unit/test_fake_driver.py
@@ -46,6 +46,7 @@ from sp_rtk_base.models.device_models import (
     GpsFixType,
     RtcmMessageConfig,
     RtcmPortConfig,
+    RtcmRowId,
     SurveyInConfig,
 )
 from sp_rtk_base.services.drivers.base import GpsReceiverDriver
@@ -262,19 +263,32 @@ class TestConfigurationRoundTrips:
         assert current.accuracy_mm == 47308
 
     def test_rtcm_messages_round_trip(self, connected_driver: FakeGpsDriver) -> None:
-        cfg = RtcmMessageConfig(message_ids=[1005, 1077], rate_hz=2)
+        cfg = RtcmMessageConfig(
+            message_ids=[RtcmRowId.RTCM_1005, RtcmRowId.RTCM_1077], rate_hz=2
+        )
         connected_driver.configure_rtcm_messages(cfg)
-        assert connected_driver.get_rtcm_config().message_ids == [1005, 1077]
+        assert connected_driver.get_rtcm_config().message_ids == [
+            RtcmRowId.RTCM_1005,
+            RtcmRowId.RTCM_1077,
+        ]
         assert connected_driver.get_rtcm_config().rate_hz == 2
 
     def test_rtcm_ports_round_trip(self, connected_driver: FakeGpsDriver) -> None:
         cfg = RtcmPortConfig(
-            messages={1005: {"USB": 0, "UART1": 1, "UART2": 0, "I2C": 0, "SPI": 0}}
+            messages={
+                RtcmRowId.RTCM_1005: {
+                    "USB": 0,
+                    "UART1": 1,
+                    "UART2": 0,
+                    "I2C": 0,
+                    "SPI": 0,
+                }
+            }
         )
         connected_driver.configure_rtcm_ports(cfg)
         out = connected_driver.get_rtcm_port_config()
-        assert out.messages[1005]["UART1"] == 1
-        assert out.messages[1005]["USB"] == 0
+        assert out.messages[RtcmRowId.RTCM_1005]["UART1"] == 1
+        assert out.messages[RtcmRowId.RTCM_1005]["USB"] == 0
 
     def test_gnss_round_trip(self, connected_driver: FakeGpsDriver) -> None:
         cfg = GnssConfig(
@@ -297,7 +311,14 @@ class TestConfigurationRoundTrips:
         """Sanity check: default port config exposes the six common
         RTCM messages so the GPS-config UI has something to display."""
         cfg = connected_driver.get_rtcm_port_config()
-        assert {1005, 1077, 1087, 1097, 1127, 1230} <= cfg.messages.keys()
+        assert {
+            RtcmRowId.RTCM_1005,
+            RtcmRowId.RTCM_1077,
+            RtcmRowId.RTCM_1087,
+            RtcmRowId.RTCM_1097,
+            RtcmRowId.RTCM_1127,
+            RtcmRowId.RTCM_1230,
+        } <= cfg.messages.keys()
 
     def test_default_gnss_has_all_six_constellations(
         self, connected_driver: FakeGpsDriver

--- a/tests/unit/test_rtcm_port_config.py
+++ b/tests/unit/test_rtcm_port_config.py
@@ -7,12 +7,14 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import pytest
+from pydantic import ValidationError
 
 from sp_rtk_base.models.device_models import (
     ALL_RTCM_MESSAGE_IDS,
     RTCM_MESSAGE_GROUPS,
     RtcmOutputPort,
     RtcmPortConfig,
+    RtcmRowId,
 )
 
 # ---------------------------------------------------------------------------
@@ -30,40 +32,64 @@ class TestRtcmPortConfig:
     def test_enabled_on_port(self) -> None:
         config = RtcmPortConfig(
             messages={
-                1005: {"USB": 1, "UART1": 0, "UART2": 1, "I2C": 0, "SPI": 0},
-                1077: {"USB": 1, "UART1": 1, "UART2": 0, "I2C": 0, "SPI": 0},
-                1087: {"USB": 0, "UART1": 0, "UART2": 0, "I2C": 0, "SPI": 0},
+                RtcmRowId.RTCM_1005: {
+                    "USB": 1,
+                    "UART1": 0,
+                    "UART2": 1,
+                    "I2C": 0,
+                    "SPI": 0,
+                },
+                RtcmRowId.RTCM_1077: {
+                    "USB": 1,
+                    "UART1": 1,
+                    "UART2": 0,
+                    "I2C": 0,
+                    "SPI": 0,
+                },
+                RtcmRowId.RTCM_1087: {
+                    "USB": 0,
+                    "UART1": 0,
+                    "UART2": 0,
+                    "I2C": 0,
+                    "SPI": 0,
+                },
             }
         )
         usb_enabled = config.enabled_on_port(RtcmOutputPort.USB)
-        assert 1005 in usb_enabled
-        assert 1077 in usb_enabled
-        assert 1087 not in usb_enabled
+        assert RtcmRowId.RTCM_1005 in usb_enabled
+        assert RtcmRowId.RTCM_1077 in usb_enabled
+        assert RtcmRowId.RTCM_1087 not in usb_enabled
 
         uart1_enabled = config.enabled_on_port(RtcmOutputPort.UART1)
-        assert 1077 in uart1_enabled
-        assert 1005 not in uart1_enabled
+        assert RtcmRowId.RTCM_1077 in uart1_enabled
+        assert RtcmRowId.RTCM_1005 not in uart1_enabled
 
     def test_is_enabled(self) -> None:
         config = RtcmPortConfig(
             messages={
-                1005: {"USB": 1, "UART1": 0},
+                RtcmRowId.RTCM_1005: {"USB": 1, "UART1": 0},
             }
         )
-        assert config.is_enabled(1005, RtcmOutputPort.USB) is True
-        assert config.is_enabled(1005, RtcmOutputPort.UART1) is False
-        # Non-existent message
-        assert config.is_enabled(9999, RtcmOutputPort.USB) is False
+        assert config.is_enabled(RtcmRowId.RTCM_1005, RtcmOutputPort.USB) is True
+        assert config.is_enabled(RtcmRowId.RTCM_1005, RtcmOutputPort.UART1) is False
+        # Non-existent row on this config
+        assert config.is_enabled(RtcmRowId.RTCM_1230, RtcmOutputPort.USB) is False
 
     def test_rate(self) -> None:
         config = RtcmPortConfig(
             messages={
-                1005: {"USB": 3, "UART1": 0},
+                RtcmRowId.RTCM_1005: {"USB": 3, "UART1": 0},
             }
         )
-        assert config.rate(1005, RtcmOutputPort.USB) == 3
-        assert config.rate(1005, RtcmOutputPort.UART1) == 0
-        assert config.rate(9999, RtcmOutputPort.USB) == 0
+        assert config.rate(RtcmRowId.RTCM_1005, RtcmOutputPort.USB) == 3
+        assert config.rate(RtcmRowId.RTCM_1005, RtcmOutputPort.UART1) == 0
+        assert config.rate(RtcmRowId.RTCM_1230, RtcmOutputPort.USB) == 0
+
+    def test_construct_rejects_unknown_row_id(self) -> None:
+        """messages is keyed by RtcmRowId — an unknown identifier must
+        fail at the model boundary rather than being silently accepted."""
+        with pytest.raises(ValidationError):
+            RtcmPortConfig(messages={"9999": {"USB": 1}})  # type: ignore[arg-type]
 
 
 class TestRtcmOutputPort:
@@ -84,11 +110,14 @@ class TestRtcmMessageGroups:
 
     def test_all_ids_covered(self) -> None:
         """Ensure ALL_RTCM_MESSAGE_IDS matches the groups."""
-        ids_from_groups: list[int] = []
+        ids_from_groups: list[RtcmRowId] = []
         for _, messages in RTCM_MESSAGE_GROUPS:
             for msg_id, _ in messages:
                 ids_from_groups.append(msg_id)
         assert sorted(ids_from_groups) == sorted(ALL_RTCM_MESSAGE_IDS)
+
+    def test_twelve_rows_total(self) -> None:
+        assert len(ALL_RTCM_MESSAGE_IDS) == 12
 
     def test_groups_present(self) -> None:
         group_names = [name for name, _ in RTCM_MESSAGE_GROUPS]
@@ -98,6 +127,15 @@ class TestRtcmMessageGroups:
         assert "Galileo" in group_names
         assert "BeiDou" in group_names
         assert "GLONASS Bias" in group_names
+
+    def test_reference_group_has_both_4072_rows(self) -> None:
+        """4072.0 and 4072.1 must be separately addressable rows."""
+        reference = next(
+            msgs for name, msgs in RTCM_MESSAGE_GROUPS if name == "Reference"
+        )
+        ids = [msg_id for msg_id, _ in reference]
+        assert RtcmRowId.RTCM_4072_0 in ids
+        assert RtcmRowId.RTCM_4072_1 in ids
 
     def test_msm4_and_msm7_pairs(self) -> None:
         """MSM4 and MSM7 messages should be paired per constellation."""
@@ -119,15 +157,32 @@ class TestRtcmKeyMapping:
     def test_rtcm_key_standard(self) -> None:
         from sp_rtk_base.services.drivers.ublox import _rtcm_key
 
-        assert _rtcm_key(1005, "USB") == "CFG_MSGOUT_RTCM_3X_TYPE1005_USB"
-        assert _rtcm_key(1077, "UART1") == "CFG_MSGOUT_RTCM_3X_TYPE1077_UART1"
-        assert _rtcm_key(1087, "I2C") == "CFG_MSGOUT_RTCM_3X_TYPE1087_I2C"
+        assert (
+            _rtcm_key(RtcmRowId.RTCM_1005, "USB") == "CFG_MSGOUT_RTCM_3X_TYPE1005_USB"
+        )
+        assert (
+            _rtcm_key(RtcmRowId.RTCM_1077, "UART1")
+            == "CFG_MSGOUT_RTCM_3X_TYPE1077_UART1"
+        )
+        assert (
+            _rtcm_key(RtcmRowId.RTCM_1087, "I2C") == "CFG_MSGOUT_RTCM_3X_TYPE1087_I2C"
+        )
 
-    def test_rtcm_key_4072(self) -> None:
+    def test_rtcm_key_4072_0_and_4072_1_are_distinct(self) -> None:
         from sp_rtk_base.services.drivers.ublox import _rtcm_key
 
-        assert _rtcm_key(4072, "USB") == "CFG_MSGOUT_RTCM_3X_TYPE4072_0_USB"
-        assert _rtcm_key(4072, "UART2") == "CFG_MSGOUT_RTCM_3X_TYPE4072_0_UART2"
+        assert (
+            _rtcm_key(RtcmRowId.RTCM_4072_0, "USB")
+            == "CFG_MSGOUT_RTCM_3X_TYPE4072_0_USB"
+        )
+        assert (
+            _rtcm_key(RtcmRowId.RTCM_4072_1, "USB")
+            == "CFG_MSGOUT_RTCM_3X_TYPE4072_1_USB"
+        )
+        assert (
+            _rtcm_key(RtcmRowId.RTCM_4072_1, "UART2")
+            == "CFG_MSGOUT_RTCM_3X_TYPE4072_1_UART2"
+        )
 
     def test_legacy_usb_keys_match(self) -> None:
         from sp_rtk_base.services.drivers.ublox import _RTCM_KEY_BASES, _RTCM_USB_KEYS
@@ -175,17 +230,34 @@ class TestParseRtcmPortValget:
 
         parsed = _FakeValget(
             {
-                _rtcm_key(1005, "USB"): 1,
-                _rtcm_key(1005, "UART1"): 2,
-                _rtcm_key(1077, "USB"): 1,
+                _rtcm_key(RtcmRowId.RTCM_1005, "USB"): 1,
+                _rtcm_key(RtcmRowId.RTCM_1005, "UART1"): 2,
+                _rtcm_key(RtcmRowId.RTCM_1077, "USB"): 1,
             }
         )
 
         config = UbloxDriver._parse_rtcm_port_valget(parsed)
-        assert config.is_enabled(1005, RtcmOutputPort.USB)
-        assert config.rate(1005, RtcmOutputPort.UART1) == 2
-        assert config.is_enabled(1077, RtcmOutputPort.USB)
-        assert not config.is_enabled(1087, RtcmOutputPort.USB)
+        assert config.is_enabled(RtcmRowId.RTCM_1005, RtcmOutputPort.USB)
+        assert config.rate(RtcmRowId.RTCM_1005, RtcmOutputPort.UART1) == 2
+        assert config.is_enabled(RtcmRowId.RTCM_1077, RtcmOutputPort.USB)
+        assert not config.is_enabled(RtcmRowId.RTCM_1087, RtcmOutputPort.USB)
+
+    def test_parse_round_trips_all_twelve_rows_including_4072_split(self) -> None:
+        """Acceptance: a read-model round trip preserves all 12 rows,
+        with 4072.0 and 4072.1 controllable independently."""
+        from sp_rtk_base.services.drivers.ublox import UbloxDriver, _rtcm_key
+
+        parsed = _FakeValget(
+            {
+                _rtcm_key(RtcmRowId.RTCM_4072_0, "USB"): 1,
+                _rtcm_key(RtcmRowId.RTCM_4072_1, "USB"): 0,
+            }
+        )
+
+        config = UbloxDriver._parse_rtcm_port_valget(parsed)
+        assert set(config.messages.keys()) == set(ALL_RTCM_MESSAGE_IDS)
+        assert config.is_enabled(RtcmRowId.RTCM_4072_0, RtcmOutputPort.USB)
+        assert not config.is_enabled(RtcmRowId.RTCM_4072_1, RtcmOutputPort.USB)
 
 
 # ---------------------------------------------------------------------------
@@ -206,7 +278,13 @@ class TestConfigureRtcmPorts:
 
         config = RtcmPortConfig(
             messages={
-                1005: {"USB": 1, "UART1": 0, "UART2": 0, "I2C": 0, "SPI": 0},
+                RtcmRowId.RTCM_1005: {
+                    "USB": 1,
+                    "UART1": 0,
+                    "UART2": 0,
+                    "I2C": 0,
+                    "SPI": 0,
+                },
             }
         )
 
@@ -255,24 +333,6 @@ class TestConfigureRtcmPorts:
             # Should NOT call valset since there are no keys
             mock_valset.assert_not_called()
 
-    def test_configure_unknown_msg_skipped(self) -> None:
-        from sp_rtk_base.services.drivers.ublox import UbloxDriver
-
-        driver = UbloxDriver()
-        driver._serial = MagicMock()
-        driver._serial.is_open = True
-        driver._reader = MagicMock()
-
-        config = RtcmPortConfig(
-            messages={
-                9999: {"USB": 1},  # Unknown message
-            }
-        )
-
-        with patch.object(driver, "_send_cfg_valset_locked") as mock_valset:
-            driver.configure_rtcm_ports(config)
-            mock_valset.assert_not_called()
-
     def test_configure_retries_once_on_mismatch(self) -> None:
         """Issue #42: a read-back mismatch after the first write is
         retried once, mirroring the ECEF/base-output-profile pattern,
@@ -284,7 +344,7 @@ class TestConfigureRtcmPorts:
         driver._serial.is_open = True
         driver._reader = MagicMock()
 
-        config = RtcmPortConfig(messages={1005: {"USB": 1}})
+        config = RtcmPortConfig(messages={RtcmRowId.RTCM_1005: {"USB": 1}})
 
         with (
             patch.object(driver, "_send_cfg_valset_locked") as mock_valset,
@@ -310,7 +370,7 @@ class TestConfigureRtcmPorts:
         driver._serial.is_open = True
         driver._reader = MagicMock()
 
-        config = RtcmPortConfig(messages={1005: {"USB": 1}})
+        config = RtcmPortConfig(messages={RtcmRowId.RTCM_1005: {"USB": 1}})
 
         with (
             patch.object(driver, "_send_cfg_valset_locked") as mock_valset,
@@ -338,7 +398,7 @@ class TestDeviceServiceRtcmPorts:
 
         mock_driver = MagicMock()
         mock_driver.is_connected = True
-        expected = RtcmPortConfig(messages={1005: {"USB": 1}})
+        expected = RtcmPortConfig(messages={RtcmRowId.RTCM_1005: {"USB": 1}})
         mock_driver.get_rtcm_port_config.return_value = expected
 
         svc = DeviceService()
@@ -367,7 +427,7 @@ class TestDeviceServiceRtcmPorts:
         svc._driver = mock_driver
         svc._state = DeviceConnectionState.CONNECTED
 
-        config = RtcmPortConfig(messages={1005: {"USB": 1}})
+        config = RtcmPortConfig(messages={RtcmRowId.RTCM_1005: {"USB": 1}})
         await svc.configure_rtcm_ports(config)
         mock_driver.configure_rtcm_ports.assert_called_once_with(config)
         assert svc._state == DeviceConnectionState.CONNECTED

--- a/tests/unit/test_ublox_driver.py
+++ b/tests/unit/test_ublox_driver.py
@@ -22,6 +22,7 @@ from sp_rtk_base.models.device_models import (
     DeviceCapability,
     FixedBaseConfig,
     RtcmMessageConfig,
+    RtcmRowId,
     SurveyInConfig,
 )
 from sp_rtk_base.services.drivers.ublox import UbloxDriver
@@ -943,48 +944,16 @@ class TestUbloxDriverConfiguration:
         driver = UbloxDriver()
         driver.connect("/dev/ttyUSB0")
 
-        config = RtcmMessageConfig(message_ids=[1005, 1077, 1087], rate_hz=1)
+        config = RtcmMessageConfig(
+            message_ids=[RtcmRowId.RTCM_1005, RtcmRowId.RTCM_1077, RtcmRowId.RTCM_1087],
+            rate_hz=1,
+        )
         driver.configure_rtcm_messages(config)
 
         mock_ubx_msg.config_set.assert_called_once()
         # Issue #42: RAM+Flash, not RAM-only — a layer=1 write reverted
         # to the last-flashed message selection on reboot / reconnect.
         assert mock_ubx_msg.config_set.call_args[0][0] == 5
-
-    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
-    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
-    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
-    def test_configure_rtcm_unknown_message_id(
-        self,
-        mock_serial_cls: MagicMock,
-        mock_reader_cls: MagicMock,
-        mock_ubx_msg: MagicMock,
-    ) -> None:
-        ser = MagicMock()
-        ser.is_open = True
-        mock_serial_cls.return_value = ser
-
-        reader = MagicMock()
-        reader.read.side_effect = [
-            (b"", _make_mon_ver_response()),
-            (b"", _make_ack_response()),
-            (
-                b"",
-                _make_rtcm_valget({"CFG_MSGOUT_RTCM_3X_TYPE1005_USB": 1}),
-            ),  # read-back verify — matches
-        ]
-        mock_reader_cls.return_value = reader
-
-        mock_msg = MagicMock()
-        mock_msg.serialize.return_value = b"\x00"
-        mock_ubx_msg.config_set.return_value = mock_msg
-
-        driver = UbloxDriver()
-        driver.connect("/dev/ttyUSB0")
-
-        # 9999 is not a known RTCM message
-        config = RtcmMessageConfig(message_ids=[1005, 9999], rate_hz=1)
-        driver.configure_rtcm_messages(config)  # Should not raise, just warn
 
     @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
     @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
@@ -1021,7 +990,7 @@ class TestUbloxDriverConfiguration:
         driver = UbloxDriver()
         driver.connect("/dev/ttyUSB0")
 
-        config = RtcmMessageConfig(message_ids=[1005], rate_hz=1)
+        config = RtcmMessageConfig(message_ids=[RtcmRowId.RTCM_1005], rate_hz=1)
         driver.configure_rtcm_messages(config)  # must not raise
 
         assert mock_ubx_msg.config_set.call_count == 2
@@ -1060,7 +1029,7 @@ class TestUbloxDriverConfiguration:
         driver = UbloxDriver()
         driver.connect("/dev/ttyUSB0")
 
-        config = RtcmMessageConfig(message_ids=[1005], rate_hz=1)
+        config = RtcmMessageConfig(message_ids=[RtcmRowId.RTCM_1005], rate_hz=1)
         with pytest.raises(RuntimeError, match="did not take effect"):
             driver.configure_rtcm_messages(config)
 
@@ -1803,7 +1772,14 @@ class TestGetRtcmConfig:
             CFG_MSGOUT_RTCM_3X_TYPE4072_0_USB=0,
         )
         result = UbloxDriver._parse_rtcm_valget(parsed)  # pyright: ignore[reportPrivateUsage]
-        assert set(result.message_ids) == {1005, 1077, 1087, 1097, 1127, 1230}
+        assert set(result.message_ids) == {
+            RtcmRowId.RTCM_1005,
+            RtcmRowId.RTCM_1077,
+            RtcmRowId.RTCM_1087,
+            RtcmRowId.RTCM_1097,
+            RtcmRowId.RTCM_1127,
+            RtcmRowId.RTCM_1230,
+        }
         assert result.rate_hz == 1
 
     def test_parse_rtcm_valget_all_disabled(self) -> None:  # pyright: ignore[reportPrivateUsage]
@@ -1823,8 +1799,8 @@ class TestGetRtcmConfig:
             CFG_MSGOUT_RTCM_3X_TYPE1097_USB=1,
         )
         result = UbloxDriver._parse_rtcm_valget(parsed)  # pyright: ignore[reportPrivateUsage]
-        assert 1005 in result.message_ids
-        assert 1077 in result.message_ids
+        assert RtcmRowId.RTCM_1005 in result.message_ids
+        assert RtcmRowId.RTCM_1077 in result.message_ids
         assert result.rate_hz == 1  # most common
 
     @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
@@ -1862,8 +1838,8 @@ class TestGetRtcmConfig:
         driver.connect("/dev/ttyUSB0")
         result = driver.get_rtcm_config()
 
-        assert 1005 in result.message_ids
-        assert 1077 in result.message_ids
+        assert RtcmRowId.RTCM_1005 in result.message_ids
+        assert RtcmRowId.RTCM_1077 in result.message_ids
         assert result.rate_hz == 1
 
 


### PR DESCRIPTION
## Summary
- Introduces a 12-member `RtcmRowId` string enum as the single RTCM row identity across the u-blox driver key table, the read/write models (`RtcmMessageConfig`/`RtcmPortConfig`), the REST API, and the Advanced GPS page.
- Splits message 4072 into distinct `4072.0`/`4072.1` rows (`CFG_MSGOUT_RTCM_3X_TYPE4072_0`/`_1`), making 4072.1 controllable for the first time — the previous `int`-keyed identity couldn't represent the two sub-messages separately.
- Landed atomically, since re-keying the read model breaks every reader at once (~7 source files, 6 test files touched in one pass).
- Removed the driver's "unknown RTCM id → skip and warn" defensive branches, since Pydantic now rejects an invalid row id at the model/API boundary before it ever reaches the driver — this is a small, deliberate behavior tightening (previously silent 200, now 422) flagged for reviewer awareness.

Closes #37, #56.

## Test plan
- [x] `uv run pytest` — full unit suite (1059 tests) passes, coverage 91%+ (gate 90%)
- [x] `uv run ruff check` / `uv run ruff format --check` — clean
- [x] `uv run pyright src/` — 0 errors
- [x] Dedicated round-trip test verifies all 12 rows (including 4072.0/4072.1 independently) survive a read-model round trip
- [x] `/code-review` run (standards + spec axes) — no hard standards violations, all acceptance criteria met; two duplicated-code cleanups applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)