### PR TITLE
feat(device): add live receiver reads for RTCM ports and port protocols

### DIFF
--- a/src/sp_rtk_base/api/device.py
+++ b/src/sp_rtk_base/api/device.py
@@ -22,7 +22,9 @@ from sp_rtk_base.models.device_models import (
     FixedBaseConfig,
     GnssConfig,
     GpsPosition,
+    PortProtocolConfig,
     RtcmMessageConfig,
+    RtcmPortConfig,
     SerialPortInfo,
     SurveyInConfig,
     SurveyInProgress,
@@ -246,6 +248,33 @@ async def save_to_flash(
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 
     return DeviceActionResponse(status="ok", message="Configuration saved to flash")
+
+
+# ---------------------------------------------------------------------------
+# Live receiver reads: multi-port RTCM state & port protocol state
+# ---------------------------------------------------------------------------
+
+
+@router.get("/rtcm-ports", response_model=RtcmPortConfig)
+async def get_rtcm_ports(
+    svc: DeviceService = Depends(get_device_service),
+) -> RtcmPortConfig:
+    """Read the live per-port RTCM enable state, keyed by RtcmRowId."""
+    try:
+        return await svc.get_rtcm_port_config()
+    except RuntimeError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+
+@router.get("/port-protocols", response_model=PortProtocolConfig)
+async def get_port_protocols(
+    svc: DeviceService = Depends(get_device_service),
+) -> PortProtocolConfig:
+    """Read the live in/out protocol state for UART1, UART2 and USB."""
+    try:
+        return await svc.get_port_protocols()
+    except RuntimeError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
 
 
 # ---------------------------------------------------------------------------

--- a/src/sp_rtk_base/models/device_models.py
+++ b/src/sp_rtk_base/models/device_models.py
@@ -306,6 +306,53 @@ class RtcmPortConfig(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Port protocol configuration
+# ---------------------------------------------------------------------------
+
+
+class PortId(str, enum.Enum):
+    """Communication ports covered by live port-protocol reads."""
+
+    UART1 = "UART1"
+    UART2 = "UART2"
+    USB = "USB"
+
+
+class UbxProtocol(str, enum.Enum):
+    """I/O protocol a u-blox port can be configured to speak."""
+
+    UBX = "UBX"
+    NMEA = "NMEA"
+    RTCM3X = "RTCM3X"
+
+
+class PortProtocolConfig(BaseModel):
+    """Live in/out protocol state for UART1, UART2 and USB.
+
+    Covers the ``CFG_{PORT}{IN,OUT}PROT_{UBX,NMEA,RTCM3X}`` key family —
+    the full picture the assertive ports section, the UBX-in liveness
+    guard, and the profile form all need (issue #57).
+    """
+
+    in_protocols: dict[PortId, list[UbxProtocol]] = Field(
+        default_factory=lambda: dict[PortId, list[UbxProtocol]](),
+        description="port -> enabled input protocols",
+    )
+    out_protocols: dict[PortId, list[UbxProtocol]] = Field(
+        default_factory=lambda: dict[PortId, list[UbxProtocol]](),
+        description="port -> enabled output protocols",
+    )
+
+    def enabled_in(self, port: PortId) -> list[UbxProtocol]:
+        """Return input protocols enabled on a given port."""
+        return self.in_protocols.get(port, [])
+
+    def enabled_out(self, port: PortId) -> list[UbxProtocol]:
+        """Return output protocols enabled on a given port."""
+        return self.out_protocols.get(port, [])
+
+
+# ---------------------------------------------------------------------------
 # GNSS constellation configuration
 # ---------------------------------------------------------------------------
 

--- a/src/sp_rtk_base/services/device_service.py
+++ b/src/sp_rtk_base/services/device_service.py
@@ -23,6 +23,7 @@ from sp_rtk_base.models.device_models import (
     FixedBaseConfig,
     GnssConfig,
     GpsPosition,
+    PortProtocolConfig,
     RtcmMessageConfig,
     RtcmPortConfig,
     SurveyInConfig,
@@ -488,6 +489,18 @@ class DeviceService:
             self._state = DeviceConnectionState.CONNECTED
             self._last_error = str(exc)
             raise
+
+    async def get_port_protocols(self) -> PortProtocolConfig:
+        """Read live in/out protocol state for UART1, UART2 and USB.
+
+        Returns:
+            Per-port enabled input/output protocols.
+
+        Raises:
+            RuntimeError: If not connected.
+        """
+        driver = self._require_connected()
+        return await asyncio.to_thread(driver.get_port_protocols)
 
     async def get_gnss_config(self) -> GnssConfig:
         """Read the current GNSS constellation configuration.

--- a/src/sp_rtk_base/services/drivers/base.py
+++ b/src/sp_rtk_base/services/drivers/base.py
@@ -16,6 +16,7 @@ from sp_rtk_base.models.device_models import (
     FixedBaseConfig,
     GnssConfig,
     GpsPosition,
+    PortProtocolConfig,
     RtcmMessageConfig,
     RtcmPortConfig,
     SerialPortInfo,
@@ -172,6 +173,18 @@ class GpsReceiverDriver(abc.ABC):
         Raises:
             ConnectionError: If not connected.
             RuntimeError: If configuration fails.
+        """
+
+    @abc.abstractmethod
+    def get_port_protocols(self) -> PortProtocolConfig:
+        """Read live in/out protocol state for UART1, UART2 and USB.
+
+        Returns:
+            Per-port enabled input/output protocols.
+
+        Raises:
+            ConnectionError: If not connected.
+            RuntimeError: If the read fails.
         """
 
     @abc.abstractmethod

--- a/src/sp_rtk_base/services/drivers/fake.py
+++ b/src/sp_rtk_base/services/drivers/fake.py
@@ -58,12 +58,15 @@ from sp_rtk_base.models.device_models import (
     GnssSystemConfig,
     GpsFixType,
     GpsPosition,
+    PortId,
+    PortProtocolConfig,
     RtcmMessageConfig,
     RtcmPortConfig,
     RtcmRowId,
     SerialPortInfo,
     SurveyInConfig,
     SurveyInProgress,
+    UbxProtocol,
 )
 from sp_rtk_base.services.drivers.base import GpsReceiverDriver
 
@@ -150,6 +153,27 @@ class FakeGpsDriver(GpsReceiverDriver):
                     RtcmRowId.RTCM_1230,
                 )
             }
+        )
+
+        # Port protocols — mirrors the reference base's RTCM-only
+        # UART1/UART2 output profile (docs/zed-f9p-base-station-config-
+        # reference.md); USB is left at factory defaults (all three
+        # protocols both ways) since it's the local diagnostics port.
+        self._port_protocols: PortProtocolConfig = PortProtocolConfig(
+            in_protocols={
+                PortId.UART1: [
+                    UbxProtocol.UBX,
+                    UbxProtocol.NMEA,
+                    UbxProtocol.RTCM3X,
+                ],
+                PortId.UART2: [UbxProtocol.UBX, UbxProtocol.RTCM3X],
+                PortId.USB: [UbxProtocol.UBX, UbxProtocol.NMEA, UbxProtocol.RTCM3X],
+            },
+            out_protocols={
+                PortId.UART1: [UbxProtocol.RTCM3X],
+                PortId.UART2: [UbxProtocol.RTCM3X],
+                PortId.USB: [UbxProtocol.UBX, UbxProtocol.NMEA, UbxProtocol.RTCM3X],
+            },
         )
 
         # GNSS — all six constellations enabled by default.
@@ -331,6 +355,11 @@ class FakeGpsDriver(GpsReceiverDriver):
         """Store the per-port RTCM config in memory."""
         self._ensure_connected()
         self._rtcm_ports = config
+
+    def get_port_protocols(self) -> PortProtocolConfig:
+        """Return the fixed in-memory port protocol state."""
+        self._ensure_connected()
+        return self._port_protocols
 
     def save_to_flash(self) -> None:
         """No-op — fake driver has no flash memory.

--- a/src/sp_rtk_base/services/drivers/ublox.py
+++ b/src/sp_rtk_base/services/drivers/ublox.py
@@ -13,6 +13,7 @@ import fcntl
 import logging
 import threading
 import time
+from typing import Literal
 
 import serial  # type: ignore[import-untyped]
 from pyubx2 import (  # type: ignore[import-untyped]
@@ -36,12 +37,15 @@ from sp_rtk_base.models.device_models import (
     GnssSystemConfig,
     GpsFixType,
     GpsPosition,
+    PortId,
+    PortProtocolConfig,
     RtcmMessageConfig,
     RtcmOutputPort,
     RtcmPortConfig,
     RtcmRowId,
     SurveyInConfig,
     SurveyInProgress,
+    UbxProtocol,
 )
 from sp_rtk_base.services.drivers.base import GpsReceiverDriver
 
@@ -110,6 +114,27 @@ _BASE_OUTPUT_PROFILE: dict[str, int] = {
 # unconditionally on every base-mode transition rather than left as an
 # operator-configurable setting.
 _STATIONARY_DYN_MODEL: int = 2
+
+# CFG key prefix for each port covered by the live port-protocol read
+# (issue #57) — UART1/UART2 use a numbered prefix, USB does not.
+_PROTOCOL_PORT_PREFIXES: dict[PortId, str] = {
+    PortId.UART1: "CFG_UART1",
+    PortId.UART2: "CFG_UART2",
+    PortId.USB: "CFG_USB",
+}
+
+
+def _protocol_key(
+    port: PortId, direction: Literal["IN", "OUT"], protocol: UbxProtocol
+) -> str:
+    """Build the CFG_{PORT}{IN,OUT}PROT_{PROTOCOL} key name.
+
+    Args:
+        port: Communication port.
+        direction: ``"IN"`` or ``"OUT"``.
+        protocol: Protocol to query.
+    """
+    return f"{_PROTOCOL_PORT_PREFIXES[port]}{direction}PROT_{protocol.value}"
 
 
 class UbloxDriver(GpsReceiverDriver):
@@ -996,6 +1021,71 @@ class UbloxDriver(GpsReceiverDriver):
         with self._lock:
             self._write_and_verify_locked(cfg_data, layer=5, label="RTCM port config")
         logger.info("RTCM multi-port config applied (%d keys)", len(cfg_data))
+
+    # ------------------------------------------------------------------
+    # Port protocol configuration
+    # ------------------------------------------------------------------
+
+    def get_port_protocols(self) -> PortProtocolConfig:
+        """Read live in/out protocol state for UART1, UART2 and USB.
+
+        Polls all ``CFG_{PORT}{IN,OUT}PROT_{UBX,NMEA,RTCM3X}`` keys —
+        the driver previously only polled the six UART OUTPROT keys
+        (``_read_base_output_profile_locked``); this covers INPROT and
+        USB too (issue #57).
+        """
+        with self._lock:
+            return self._get_port_protocols_locked()
+
+    def _get_port_protocols_locked(self) -> PortProtocolConfig:
+        """Read port protocol config for all ports (must hold self._lock)."""
+        ser, reader = self._require_connection()
+
+        all_keys: list[str | int] = [
+            _protocol_key(port, direction, protocol)
+            for port in PortId
+            for direction in ("IN", "OUT")
+            for protocol in UbxProtocol
+        ]
+
+        msg = UBXMessage.config_poll(0, 0, all_keys)
+        ser.reset_input_buffer()
+        ser.write(msg.serialize())  # type: ignore[union-attr]
+
+        for _ in range(_MAX_READ_ATTEMPTS):
+            try:
+                raw, parsed = reader.read()  # type: ignore[misc]
+                if parsed is None:
+                    continue
+                identity = getattr(parsed, "identity", "")
+                if identity == "CFG-VALGET":
+                    return self._parse_port_protocols_valget(parsed)
+            except Exception:
+                continue
+
+        raise RuntimeError("No CFG-VALGET response for port protocol config")
+
+    @staticmethod
+    def _parse_port_protocols_valget(parsed: object) -> PortProtocolConfig:
+        """Parse a CFG-VALGET response into a port protocol config."""
+        in_protocols: dict[PortId, list[UbxProtocol]] = {}
+        out_protocols: dict[PortId, list[UbxProtocol]] = {}
+
+        for port in PortId:
+            in_protocols[port] = [
+                protocol
+                for protocol in UbxProtocol
+                if int(getattr(parsed, _protocol_key(port, "IN", protocol), 0)) == 1
+            ]
+            out_protocols[port] = [
+                protocol
+                for protocol in UbxProtocol
+                if int(getattr(parsed, _protocol_key(port, "OUT", protocol), 0)) == 1
+            ]
+
+        return PortProtocolConfig(
+            in_protocols=in_protocols, out_protocols=out_protocols
+        )
 
     # ------------------------------------------------------------------
     # GNSS constellation configuration

--- a/src/sp_rtk_base/services/drivers/ublox.py
+++ b/src/sp_rtk_base/services/drivers/ublox.py
@@ -123,6 +123,12 @@ _PROTOCOL_PORT_PREFIXES: dict[PortId, str] = {
     PortId.USB: "CFG_USB",
 }
 
+# Explicitly typed so a `for direction in _PROTOCOL_DIRECTIONS` loop
+# variable narrows to ``Literal["IN", "OUT"]`` under mypy strict, not
+# just pyright — an inline `("IN", "OUT")` tuple loses that narrowing
+# under mypy.
+_PROTOCOL_DIRECTIONS: tuple[Literal["IN", "OUT"], ...] = ("IN", "OUT")
+
 
 def _protocol_key(
     port: PortId, direction: Literal["IN", "OUT"], protocol: UbxProtocol
@@ -1044,7 +1050,7 @@ class UbloxDriver(GpsReceiverDriver):
         all_keys: list[str | int] = [
             _protocol_key(port, direction, protocol)
             for port in PortId
-            for direction in ("IN", "OUT")
+            for direction in _PROTOCOL_DIRECTIONS
             for protocol in UbxProtocol
         ]
 

--- a/tests/unit/test_driver_registry.py
+++ b/tests/unit/test_driver_registry.py
@@ -12,6 +12,7 @@ from sp_rtk_base.models.device_models import (
     FixedBaseConfig,
     GnssConfig,
     GpsPosition,
+    PortProtocolConfig,
     RtcmMessageConfig,
     RtcmPortConfig,
     SurveyInConfig,
@@ -69,6 +70,9 @@ class StubDriver(GpsReceiverDriver):
 
     def configure_rtcm_ports(self, config: RtcmPortConfig) -> None:
         pass
+
+    def get_port_protocols(self) -> PortProtocolConfig:
+        return PortProtocolConfig()
 
     def get_gnss_config(self) -> GnssConfig:
         return GnssConfig()

--- a/tests/unit/test_fake_driver.py
+++ b/tests/unit/test_fake_driver.py
@@ -7,7 +7,7 @@ behaviour from the e2e harness.
 
 What we assert
 --------------
-- All 17 abstract methods of :class:`GpsReceiverDriver` are
+- All 18 abstract methods of :class:`GpsReceiverDriver` are
   implemented (mypy already enforces this; we verify at runtime too).
 - ``connect`` / ``disconnect`` flip the ``is_connected`` flag.
 - Every method that touches device state raises ``ConnectionError``
@@ -207,6 +207,12 @@ class TestDisconnectedGuards:
         with pytest.raises(ConnectionError):
             driver.configure_rtcm_ports(RtcmPortConfig())
 
+    def test_get_port_protocols_requires_connection(
+        self, driver: FakeGpsDriver
+    ) -> None:
+        with pytest.raises(ConnectionError):
+            driver.get_port_protocols()
+
     def test_save_to_flash_requires_connection(self, driver: FakeGpsDriver) -> None:
         with pytest.raises(ConnectionError):
             driver.save_to_flash()
@@ -326,6 +332,17 @@ class TestConfigurationRoundTrips:
         """Default GNSS config exposes every constellation in the model."""
         cfg = connected_driver.get_gnss_config()
         assert {s.constellation for s in cfg.systems} == set(GnssConstellation)
+
+    def test_default_port_protocols_covers_uart1_uart2_usb(
+        self, connected_driver: FakeGpsDriver
+    ) -> None:
+        """Default port protocol state covers all three ports so the
+        GPS-config UI has something to display for each."""
+        from sp_rtk_base.models.device_models import PortId
+
+        cfg = connected_driver.get_port_protocols()
+        for port in PortId:
+            assert cfg.enabled_in(port) != [] or cfg.enabled_out(port) != []
 
     def test_save_to_flash_is_noop_when_connected(
         self, connected_driver: FakeGpsDriver

--- a/tests/unit/test_port_protocols.py
+++ b/tests/unit/test_port_protocols.py
@@ -1,0 +1,348 @@
+"""Tests for live port-protocol reads (issue #57).
+
+Covers models, driver parsing/polling, DeviceService wrappers, and
+API endpoints for ``GET /api/device/rtcm-ports`` and
+``GET /api/device/port-protocols``.
+"""
+
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from sp_rtk_base.models.device_models import (
+    DeviceConnectionState,
+    PortId,
+    PortProtocolConfig,
+    RtcmPortConfig,
+    RtcmRowId,
+    UbxProtocol,
+)
+from sp_rtk_base.services.device_service import DeviceService
+from sp_rtk_base.services.drivers.ublox import UbloxDriver, _protocol_key
+
+# ---------------------------------------------------------------------------
+# Model tests
+# ---------------------------------------------------------------------------
+
+
+class TestPortProtocolConfig:
+    """Tests for the PortProtocolConfig model."""
+
+    def test_default_empty(self) -> None:
+        config = PortProtocolConfig()
+        assert config.in_protocols == {}
+        assert config.out_protocols == {}
+        assert config.enabled_in(PortId.UART1) == []
+        assert config.enabled_out(PortId.UART1) == []
+
+    def test_enabled_in_and_out(self) -> None:
+        config = PortProtocolConfig(
+            in_protocols={
+                PortId.UART1: [UbxProtocol.UBX, UbxProtocol.NMEA, UbxProtocol.RTCM3X],
+                PortId.UART2: [UbxProtocol.UBX, UbxProtocol.RTCM3X],
+            },
+            out_protocols={
+                PortId.UART1: [UbxProtocol.RTCM3X],
+                PortId.UART2: [UbxProtocol.RTCM3X],
+            },
+        )
+        assert config.enabled_in(PortId.UART1) == [
+            UbxProtocol.UBX,
+            UbxProtocol.NMEA,
+            UbxProtocol.RTCM3X,
+        ]
+        assert config.enabled_in(PortId.UART2) == [UbxProtocol.UBX, UbxProtocol.RTCM3X]
+        assert config.enabled_out(PortId.UART1) == [UbxProtocol.RTCM3X]
+        # Port with no entry at all reports empty, not KeyError
+        assert config.enabled_in(PortId.USB) == []
+
+    def test_serialization_roundtrip(self) -> None:
+        config = PortProtocolConfig(
+            in_protocols={PortId.USB: [UbxProtocol.UBX]},
+            out_protocols={PortId.USB: [UbxProtocol.UBX, UbxProtocol.NMEA]},
+        )
+        data = config.model_dump()
+        restored = PortProtocolConfig(**data)
+        assert restored == config
+
+
+class TestPortIdAndUbxProtocol:
+    """Tests for the PortId and UbxProtocol enums."""
+
+    def test_port_id_members(self) -> None:
+        ports = list(PortId)
+        assert len(ports) == 3
+        assert PortId.UART1 in ports
+        assert PortId.UART2 in ports
+        assert PortId.USB in ports
+
+    def test_ubx_protocol_members(self) -> None:
+        protocols = list(UbxProtocol)
+        assert len(protocols) == 3
+        assert UbxProtocol.UBX in protocols
+        assert UbxProtocol.NMEA in protocols
+        assert UbxProtocol.RTCM3X in protocols
+
+
+# ---------------------------------------------------------------------------
+# Driver key mapping tests
+# ---------------------------------------------------------------------------
+
+
+class TestProtocolKeyMapping:
+    """Tests for the _protocol_key helper."""
+
+    def test_uart_keys(self) -> None:
+        assert (
+            _protocol_key(PortId.UART1, "IN", UbxProtocol.UBX) == "CFG_UART1INPROT_UBX"
+        )
+        assert (
+            _protocol_key(PortId.UART2, "OUT", UbxProtocol.RTCM3X)
+            == "CFG_UART2OUTPROT_RTCM3X"
+        )
+
+    def test_usb_keys_have_no_numeric_suffix(self) -> None:
+        assert _protocol_key(PortId.USB, "IN", UbxProtocol.NMEA) == "CFG_USBINPROT_NMEA"
+        assert _protocol_key(PortId.USB, "OUT", UbxProtocol.UBX) == "CFG_USBOUTPROT_UBX"
+
+
+# ---------------------------------------------------------------------------
+# Driver parse tests
+# ---------------------------------------------------------------------------
+
+
+class _FakeValget:
+    """Fake parsed CFG-VALGET with configurable attribute values."""
+
+    def __init__(self, values: dict[str, int] | None = None) -> None:
+        self._values = values or {}
+        self.identity = "CFG-VALGET"
+
+    def __getattr__(self, name: str) -> int:
+        return self._values.get(name, 0)
+
+
+class TestParsePortProtocolsValget:
+    """Tests for UbloxDriver._parse_port_protocols_valget."""
+
+    def test_parse_all_zero(self) -> None:
+        parsed = _FakeValget()
+        config = UbloxDriver._parse_port_protocols_valget(parsed)
+        assert isinstance(config, PortProtocolConfig)
+        for port in PortId:
+            assert config.enabled_in(port) == []
+            assert config.enabled_out(port) == []
+
+    def test_parse_reference_receiver_uart_profile(self) -> None:
+        """Acceptance criterion: UART1 in [UBX, NMEA, RTCM3] / out
+        [RTCM3], UART2 in [UBX, RTCM3] / out [RTCM3]."""
+        parsed = _FakeValget(
+            {
+                "CFG_UART1INPROT_UBX": 1,
+                "CFG_UART1INPROT_NMEA": 1,
+                "CFG_UART1INPROT_RTCM3X": 1,
+                "CFG_UART1OUTPROT_UBX": 0,
+                "CFG_UART1OUTPROT_NMEA": 0,
+                "CFG_UART1OUTPROT_RTCM3X": 1,
+                "CFG_UART2INPROT_UBX": 1,
+                "CFG_UART2INPROT_NMEA": 0,
+                "CFG_UART2INPROT_RTCM3X": 1,
+                "CFG_UART2OUTPROT_UBX": 0,
+                "CFG_UART2OUTPROT_NMEA": 0,
+                "CFG_UART2OUTPROT_RTCM3X": 1,
+            }
+        )
+        config = UbloxDriver._parse_port_protocols_valget(parsed)
+
+        assert config.enabled_in(PortId.UART1) == [
+            UbxProtocol.UBX,
+            UbxProtocol.NMEA,
+            UbxProtocol.RTCM3X,
+        ]
+        assert config.enabled_out(PortId.UART1) == [UbxProtocol.RTCM3X]
+        assert config.enabled_in(PortId.UART2) == [UbxProtocol.UBX, UbxProtocol.RTCM3X]
+        assert config.enabled_out(PortId.UART2) == [UbxProtocol.RTCM3X]
+
+    def test_parse_usb_covered(self) -> None:
+        parsed = _FakeValget(
+            {
+                "CFG_USBINPROT_UBX": 1,
+                "CFG_USBINPROT_NMEA": 1,
+                "CFG_USBINPROT_RTCM3X": 1,
+                "CFG_USBOUTPROT_UBX": 1,
+                "CFG_USBOUTPROT_NMEA": 0,
+                "CFG_USBOUTPROT_RTCM3X": 0,
+            }
+        )
+        config = UbloxDriver._parse_port_protocols_valget(parsed)
+        assert config.enabled_in(PortId.USB) == [
+            UbxProtocol.UBX,
+            UbxProtocol.NMEA,
+            UbxProtocol.RTCM3X,
+        ]
+        assert config.enabled_out(PortId.USB) == [UbxProtocol.UBX]
+
+    def test_all_ports_present_even_when_disabled(self) -> None:
+        parsed = _FakeValget()
+        config = UbloxDriver._parse_port_protocols_valget(parsed)
+        assert set(config.in_protocols.keys()) == set(PortId)
+        assert set(config.out_protocols.keys()) == set(PortId)
+
+
+# ---------------------------------------------------------------------------
+# Driver get_port_protocols read tests
+# ---------------------------------------------------------------------------
+
+
+class TestUbloxGetPortProtocols:
+    """Tests for UbloxDriver.get_port_protocols."""
+
+    @pytest.fixture()
+    def connected_driver(self) -> UbloxDriver:
+        driver = UbloxDriver()
+        mock_serial = MagicMock()
+        mock_serial.is_open = True
+        mock_reader = MagicMock()
+        driver._serial = mock_serial
+        driver._reader = mock_reader
+        return driver
+
+    def test_get_port_protocols_success(self, connected_driver: UbloxDriver) -> None:
+        response = _FakeValget(
+            {
+                "CFG_UART1OUTPROT_RTCM3X": 1,
+                "CFG_UART1INPROT_UBX": 1,
+            }
+        )
+        connected_driver._reader.read.return_value = (b"", response)
+        config = connected_driver.get_port_protocols()
+        assert isinstance(config, PortProtocolConfig)
+        assert config.enabled_out(PortId.UART1) == [UbxProtocol.RTCM3X]
+        assert UbxProtocol.UBX in config.enabled_in(PortId.UART1)
+
+    def test_get_port_protocols_no_response(
+        self, connected_driver: UbloxDriver
+    ) -> None:
+        connected_driver._reader.read.side_effect = Exception("timeout")
+        with pytest.raises(RuntimeError, match="No CFG-VALGET response"):
+            connected_driver.get_port_protocols()
+
+    def test_get_port_protocols_not_connected(self) -> None:
+        driver = UbloxDriver()
+        with pytest.raises(ConnectionError):
+            driver.get_port_protocols()
+
+
+# ---------------------------------------------------------------------------
+# DeviceService wrapper tests
+# ---------------------------------------------------------------------------
+
+
+class TestDeviceServicePortProtocols:
+    """Tests for DeviceService.get_port_protocols / get_rtcm_port_config."""
+
+    @pytest.fixture()
+    def service_with_driver(self) -> DeviceService:
+        svc = DeviceService()
+        mock_driver = MagicMock()
+        mock_driver.is_connected = True
+        svc._driver = mock_driver
+        svc._state = DeviceConnectionState.CONNECTED
+        return svc
+
+    @pytest.mark.asyncio
+    async def test_get_port_protocols(self, service_with_driver: DeviceService) -> None:
+        expected = PortProtocolConfig(
+            in_protocols={PortId.UART1: [UbxProtocol.UBX]},
+            out_protocols={PortId.UART1: [UbxProtocol.RTCM3X]},
+        )
+        service_with_driver._driver.get_port_protocols.return_value = expected
+        result = await service_with_driver.get_port_protocols()
+        assert result == expected
+        service_with_driver._driver.get_port_protocols.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_port_protocols_not_connected(self) -> None:
+        svc = DeviceService()
+        with pytest.raises(RuntimeError):
+            await svc.get_port_protocols()
+
+    @pytest.mark.asyncio
+    async def test_get_rtcm_port_config_passthrough(
+        self, service_with_driver: DeviceService
+    ) -> None:
+        expected = RtcmPortConfig(messages={RtcmRowId.RTCM_1005: {"USB": 1}})
+        service_with_driver._driver.get_rtcm_port_config.return_value = expected
+        result = await service_with_driver.get_rtcm_port_config()
+        assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# API endpoint tests
+# ---------------------------------------------------------------------------
+
+
+class TestPortProtocolsAndRtcmPortsApi:
+    """Tests for GET /api/device/rtcm-ports and GET /api/device/port-protocols."""
+
+    @pytest.fixture()
+    def mock_device_service(self) -> MagicMock:
+        return MagicMock(spec=DeviceService)
+
+    @pytest.fixture()
+    def client(self, mock_device_service: MagicMock) -> TestClient:
+        from sp_rtk_base.app import create_api_app
+        from sp_rtk_base.services import get_device_service
+
+        app = create_api_app()
+        app.dependency_overrides[get_device_service] = lambda: mock_device_service
+        return TestClient(app)
+
+    def test_get_rtcm_ports(
+        self, client: TestClient, mock_device_service: MagicMock
+    ) -> None:
+        expected = RtcmPortConfig(messages={RtcmRowId.RTCM_1005: {"USB": 1}})
+        mock_device_service.get_rtcm_port_config = AsyncMock(return_value=expected)
+
+        resp = client.get("/api/device/rtcm-ports")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["messages"]["1005"]["USB"] == 1
+
+    def test_get_rtcm_ports_not_connected(
+        self, client: TestClient, mock_device_service: MagicMock
+    ) -> None:
+        mock_device_service.get_rtcm_port_config = AsyncMock(
+            side_effect=RuntimeError("Device not connected")
+        )
+        resp = client.get("/api/device/rtcm-ports")
+        assert resp.status_code == 409
+
+    def test_get_port_protocols(
+        self, client: TestClient, mock_device_service: MagicMock
+    ) -> None:
+        expected = PortProtocolConfig(
+            in_protocols={PortId.UART1: [UbxProtocol.UBX, UbxProtocol.NMEA]},
+            out_protocols={PortId.UART1: [UbxProtocol.RTCM3X]},
+        )
+        mock_device_service.get_port_protocols = AsyncMock(return_value=expected)
+
+        resp = client.get("/api/device/port-protocols")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["in_protocols"]["UART1"] == ["UBX", "NMEA"]
+        assert data["out_protocols"]["UART1"] == ["RTCM3X"]
+
+    def test_get_port_protocols_not_connected(
+        self, client: TestClient, mock_device_service: MagicMock
+    ) -> None:
+        mock_device_service.get_port_protocols = AsyncMock(
+            side_effect=RuntimeError("Device not connected")
+        )
+        resp = client.get("/api/device/port-protocols")
+        assert resp.status_code == 409


### PR DESCRIPTION
## Summary
- `GET /api/device/rtcm-ports` — wires up the existing multi-port RTCM read (`DeviceService.get_rtcm_port_config`); returns the live per-port RTCM enable state keyed by `RtcmRowId`, 409 when not connected.
- `GET /api/device/port-protocols` — new driver work: polls all `CFG_{PORT}{IN,OUT}PROT_{UBX,NMEA,RTCM3X}` keys for UART1, UART2 and USB (the driver previously only polled the six UART OUTPROT keys — no INPROT read, no USB coverage). Adds `PortId`/`UbxProtocol` enums and `PortProtocolConfig` model, `get_port_protocols()` on the driver ABC + u-blox + fake implementations, and the DeviceService/API passthrough.

**Scope note:** the ticket's "12 keys" figure only works if USB is excluded from the `CFG_{PORT}{IN,OUT}PROT_{UBX,NMEA,RTCM3X}` template (3 ports × 2 directions × 3 protocols = 18), but the ticket also explicitly names "no USB coverage" as a gap to close. Implemented full coverage of all three ports (18 keys) as a superset that still satisfies the two concrete UART1/UART2 acceptance values given. Worth a quick confirmation from whoever wrote #57 that USB coverage was intended.

Closes #57

## Test plan
- [x] `uv run pytest` — 1082 passed, 91.56% coverage (gate is 90%)
- [x] `uv run pyright src/` — clean, strict mode
- [x] `uv run ruff check src/ tests/` / `ruff format --check` — clean
- [x] New `tests/unit/test_port_protocols.py` covers model, driver key-mapping, driver parse (including the exact reference-receiver UART1/UART2 profile from the acceptance criteria), driver read, DeviceService passthrough, and both API endpoints (success + 409)
- [x] `/code-review` run (Standards + Spec axes) — no hard violations or spec gaps; one minor typing tightening applied (`_protocol_key`'s `direction` param narrowed to `Literal["IN", "OUT"]`)