### PR TITLE
feat(profiles): add ReceiverConfig/Profile schema and the F9P base built-in

### DIFF
--- a/src/sp_rtk_base/models/profile_models.py
+++ b/src/sp_rtk_base/models/profile_models.py
@@ -1,0 +1,211 @@
+"""GPS receiver profile schema — ``ReceiverConfig`` and ``Profile``.
+
+Two nested types:
+
+- ``ReceiverConfig`` — everything writable to a receiver (no ``name``).
+  This is what Apply takes.
+- ``Profile`` — ``ReceiverConfig`` plus identity metadata (``name``,
+  ``version``, ``hardware``, ``forked_from``). This is what gets
+  saved, listed, exported and imported.
+
+Only *context-free* validation lives here — rules that need no live
+device state. The UBX-in liveness guard and the ``tmode_mode: fixed``
+coordinate guard are service-level and belong to the apply ticket.
+"""
+
+from __future__ import annotations
+
+import enum
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from sp_rtk_base.models.device_models import (
+    BaseMode as TmodeMode,
+)
+from sp_rtk_base.models.device_models import (
+    GnssConstellation,
+    PortId,
+    RtcmRowId,
+    UbxProtocol,
+)
+
+# ---------------------------------------------------------------------------
+# Hardware target tokens
+# ---------------------------------------------------------------------------
+
+#: Verbatim MON-VER MOD= model ids this app can target directly. The only
+#: entry needed today is the one built-in's hardware tag; the hardware-
+#: detection ticket owns the full identity catalog.
+KNOWN_HARDWARE_MODELS: frozenset[str] = frozenset({"ZED-F9P"})
+
+#: Generation-level fallback tokens (a profile compatible with a whole
+#: hardware family rather than one specific model). Empty for now — no
+#: profile targets a family yet, and the token names themselves are the
+#: hardware-detection ticket's design to make, not this schema's to guess.
+KNOWN_HARDWARE_FAMILIES: frozenset[str] = frozenset()
+
+#: Token meaning "compatible with every receiver".
+HARDWARE_ANY: str = "any"
+
+#: Schema major versions this running app understands.
+KNOWN_PROFILE_VERSIONS: frozenset[int] = frozenset({1})
+
+#: Ports that can carry the app's own management link and therefore
+#: qualify as a rover data-link source. USB is excluded per spec.
+_DATA_LINK_CANDIDATE_PORTS: frozenset[PortId] = frozenset({PortId.UART1, PortId.UART2})
+
+_SANE_BAUD_MIN = 9600
+_SANE_BAUD_MAX = 921600
+
+
+# ---------------------------------------------------------------------------
+# Receiver role fields
+#
+# ``tmode_mode`` reuses ``device_models.BaseMode`` (imported here as
+# ``TmodeMode``) — same three values (``CFG_TMODE_MODE``), whether read live
+# or declared by a profile. Port protocols reuse ``device_models.UbxProtocol``
+# for the same reason.
+# ---------------------------------------------------------------------------
+
+
+class DynModel(str, enum.Enum):
+    """``CFG_NAVSPG_DYNMODEL`` — the receiver's dynamics platform model."""
+
+    STATIONARY = "stationary"
+    PORTABLE = "portable"
+    PEDESTRIAN = "pedestrian"
+    AUTOMOTIVE = "automotive"
+    SEA = "sea"
+    AIRBORNE_1G = "airborne_1g"
+    AIRBORNE_2G = "airborne_2g"
+    AIRBORNE_4G = "airborne_4g"
+
+
+# ---------------------------------------------------------------------------
+# Nested value objects
+# ---------------------------------------------------------------------------
+
+
+class BaudConfig(BaseModel):
+    """Per-UART baud rate. USB is excluded — USB CDC has no baud rate."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    uart1: int | None = Field(default=None, ge=_SANE_BAUD_MIN, le=_SANE_BAUD_MAX)
+    uart2: int | None = Field(default=None, ge=_SANE_BAUD_MIN, le=_SANE_BAUD_MAX)
+
+
+class PortProtocolSet(BaseModel):
+    """Full in/out protocol set for one port (assertive, not a delta)."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    in_: list[UbxProtocol] = Field(
+        default_factory=lambda: list[UbxProtocol](), alias="in"
+    )
+    out: list[UbxProtocol] = Field(default_factory=lambda: list[UbxProtocol]())
+
+
+class RtcmStreamConfig(BaseModel):
+    """The boolean RTCM message x port matrix.
+
+    Absent cell = off. Rows are restricted to the standard 12-member
+    ``RtcmRowId`` set; columns to ``PortId`` (UART1/UART2/USB) — the
+    matrix deliberately does not claim I2C or SPI.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    matrix: dict[RtcmRowId, dict[PortId, bool]] = Field(
+        default_factory=lambda: dict[RtcmRowId, dict[PortId, bool]]()
+    )
+
+
+# ---------------------------------------------------------------------------
+# ReceiverConfig — what Apply takes
+# ---------------------------------------------------------------------------
+
+
+class ReceiverConfig(BaseModel):
+    """Everything writable to a receiver. No ``name`` — see ``Profile``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    baud: BaudConfig | None = Field(default=None)
+    meas_period_ms: int = Field(default=1000, ge=100, le=60000)
+    constellations: list[GnssConstellation] | None = Field(default=None)
+    ports: dict[PortId, PortProtocolSet] | None = Field(default=None)
+    data_link_port: list[PortId] = Field(min_length=1)
+    dyn_model: DynModel | None = Field(default=None)
+    tmode_mode: TmodeMode | None = Field(default=None)
+    elevation_mask_deg: int | None = Field(default=None, ge=0, le=90)
+    bds_b2_enabled: bool | None = Field(default=None)
+    spi_enabled: bool | None = Field(default=None)
+    rtcm_stream: RtcmStreamConfig = Field(default_factory=RtcmStreamConfig)
+
+    @model_validator(mode="after")
+    def _validate_data_link_ports_are_uart(self) -> ReceiverConfig:
+        invalid_ports = [
+            p for p in self.data_link_port if p not in _DATA_LINK_CANDIDATE_PORTS
+        ]
+        if invalid_ports:
+            raise ValueError(
+                f"data_link_port: {[p.value for p in invalid_ports]} cannot be a "
+                "data-link port — only UART1/UART2 are valid"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _validate_1005_on_a_data_link_port(self) -> ReceiverConfig:
+        rows_on_1005 = self.rtcm_stream.matrix.get(RtcmRowId.RTCM_1005, {})
+        if not any(rows_on_1005.get(port, False) for port in self.data_link_port):
+            raise ValueError(
+                "1005 (Station ARP) must be enabled on at least one data_link_port"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _validate_every_data_link_port_has_a_row_on(self) -> ReceiverConfig:
+        matrix = self.rtcm_stream.matrix
+        for port in self.data_link_port:
+            has_any_row_on = any(
+                ports_for_row.get(port, False) for ports_for_row in matrix.values()
+            )
+            if not has_any_row_on:
+                raise ValueError(
+                    f"data_link_port {port.value}: has zero RTCM rows enabled"
+                )
+        return self
+
+
+# ---------------------------------------------------------------------------
+# Profile — ReceiverConfig + identity metadata
+# ---------------------------------------------------------------------------
+
+
+class Profile(ReceiverConfig):
+    """A saved, named, hardware-tagged receiver configuration."""
+
+    name: str = Field(min_length=1)
+    version: int
+    hardware: str
+    forked_from: str | None = Field(default=None)
+
+    @model_validator(mode="after")
+    def _validate_identity(self) -> Profile:
+        if self.version not in KNOWN_PROFILE_VERSIONS:
+            raise ValueError(
+                f"version {self.version} is not a schema version this app knows "
+                f"(known: {sorted(KNOWN_PROFILE_VERSIONS)})"
+            )
+
+        known_hardware = (
+            KNOWN_HARDWARE_MODELS | KNOWN_HARDWARE_FAMILIES | {HARDWARE_ANY}
+        )
+        if self.hardware not in known_hardware:
+            raise ValueError(
+                f"hardware {self.hardware!r} is not a known model, family, or "
+                f"{HARDWARE_ANY!r} token"
+            )
+
+        return self

--- a/src/sp_rtk_base/profiles/__init__.py
+++ b/src/sp_rtk_base/profiles/__init__.py
@@ -1,0 +1,30 @@
+"""Built-in GPS receiver profiles.
+
+Each built-in ships as one YAML file under ``profiles/builtin/`` in
+the package, validated by the ``Profile`` Pydantic model at import
+time — adding a built-in is a file drop, zero new Python. Built-ins
+are read-only; nothing here ever mutates a loaded ``Profile``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from sp_rtk_base.models.profile_models import Profile
+
+BUILTIN_PROFILES_DIR: Path = Path(__file__).parent / "builtin"
+
+
+def _load_builtin_profiles(directory: Path) -> dict[str, Profile]:
+    profiles: dict[str, Profile] = {}
+    for path in sorted(directory.glob("*.yaml")):
+        data = yaml.safe_load(path.read_text())
+        profile = Profile.model_validate(data)
+        profiles[profile.name] = profile
+    return profiles
+
+
+#: Internal name -> Profile, for every built-in shipped with this app.
+BUILTIN_PROFILES: dict[str, Profile] = _load_builtin_profiles(BUILTIN_PROFILES_DIR)

--- a/src/sp_rtk_base/profiles/builtin/ublox-f9p-base-standard.yaml
+++ b/src/sp_rtk_base/profiles/builtin/ublox-f9p-base-standard.yaml
@@ -1,0 +1,59 @@
+# u-blox F9P — Base Station (Standard)
+#
+# The reference base station's measured configuration (HPG 1.12),
+# minus the survey-in position. See
+# docs/zed-f9p-base-station-config-reference.md for the hardware
+# audit this file reproduces cell-for-cell.
+name: ublox-f9p-base-standard
+version: 1
+hardware: ZED-F9P
+
+baud:
+  uart1: 57600
+  uart2: 115200
+
+meas_period_ms: 1000
+
+constellations:
+  - gps
+  - glonass
+  - galileo
+  - beidou
+  - qzss
+  - sbas
+
+# USB is omitted entirely — the reference records no USB protocol
+# changes, so leaving it out guarantees this can't drift from the
+# reference on USB (omitted = untouched).
+ports:
+  UART1:
+    in: [UBX, NMEA, RTCM3X]
+    out: [RTCM3X]
+  UART2:
+    in: [UBX, RTCM3X]
+    out: [RTCM3X]
+
+data_link_port: [UART1, UART2]
+
+dyn_model: stationary
+# tmode_mode is deliberately omitted — this is a configuration
+# profile; positioning stays the operator's separate survey-in step.
+
+elevation_mask_deg: 15
+bds_b2_enabled: false
+spi_enabled: true
+
+rtcm_stream:
+  matrix:
+    "1005": {UART1: true, UART2: true, USB: false}
+    "4072.0": {UART1: true, UART2: true, USB: false}
+    "4072.1": {UART1: true, UART2: true, USB: false}
+    "1074": {UART1: true, UART2: true, USB: false}
+    "1077": {UART1: false, UART2: false, USB: false}
+    "1084": {UART1: true, UART2: true, USB: false}
+    "1087": {UART1: false, UART2: false, USB: false}
+    "1094": {UART1: true, UART2: true, USB: false}
+    "1097": {UART1: false, UART2: false, USB: false}
+    "1124": {UART1: true, UART2: true, USB: false}
+    "1127": {UART1: false, UART2: false, USB: false}
+    "1230": {UART1: true, UART2: true, USB: false}

--- a/tests/unit/test_builtin_profiles.py
+++ b/tests/unit/test_builtin_profiles.py
@@ -1,0 +1,98 @@
+"""Tests for the shipped built-in GPS receiver profiles."""
+
+from __future__ import annotations
+
+from sp_rtk_base.models.device_models import GnssConstellation, PortId, RtcmRowId
+from sp_rtk_base.models.profile_models import DynModel
+from sp_rtk_base.profiles import BUILTIN_PROFILES
+
+_ON_ROWS = {
+    RtcmRowId.RTCM_1005,
+    RtcmRowId.RTCM_4072_0,
+    RtcmRowId.RTCM_4072_1,
+    RtcmRowId.RTCM_1074,
+    RtcmRowId.RTCM_1084,
+    RtcmRowId.RTCM_1094,
+    RtcmRowId.RTCM_1124,
+    RtcmRowId.RTCM_1230,
+}
+_OFF_ROWS = {
+    RtcmRowId.RTCM_1077,
+    RtcmRowId.RTCM_1087,
+    RtcmRowId.RTCM_1097,
+    RtcmRowId.RTCM_1127,
+}
+
+
+class TestBuiltinCatalog:
+    def test_imports_cleanly_with_exactly_one_builtin(self) -> None:
+        assert list(BUILTIN_PROFILES) == ["ublox-f9p-base-standard"]
+
+
+class TestUbloxF9pBaseStandard:
+    def setup_method(self) -> None:
+        self.profile = BUILTIN_PROFILES["ublox-f9p-base-standard"]
+
+    def test_identity(self) -> None:
+        assert self.profile.name == "ublox-f9p-base-standard"
+        assert self.profile.version == 1
+        assert self.profile.hardware == "ZED-F9P"
+
+    def test_baud_split(self) -> None:
+        assert self.profile.baud is not None
+        assert self.profile.baud.uart1 == 57600
+        assert self.profile.baud.uart2 == 115200
+
+    def test_port_protocols(self) -> None:
+        assert self.profile.ports is not None
+        uart1 = self.profile.ports[PortId.UART1]
+        assert {p.value for p in uart1.in_} == {"UBX", "NMEA", "RTCM3X"}
+        assert {p.value for p in uart1.out} == {"RTCM3X"}
+
+        uart2 = self.profile.ports[PortId.UART2]
+        assert {p.value for p in uart2.in_} == {"UBX", "RTCM3X"}
+        assert {p.value for p in uart2.out} == {"RTCM3X"}
+
+    def test_usb_omitted_from_ports(self) -> None:
+        assert self.profile.ports is not None
+        assert PortId.USB not in self.profile.ports
+
+    def test_all_constellations_enabled(self) -> None:
+        assert self.profile.constellations is not None
+        assert set(self.profile.constellations) == set(GnssConstellation)
+
+    def test_meas_period_ms_is_1000(self) -> None:
+        assert self.profile.meas_period_ms == 1000
+
+    def test_role_fields(self) -> None:
+        assert self.profile.dyn_model == DynModel.STATIONARY
+        assert self.profile.tmode_mode is None
+
+    def test_optimisations(self) -> None:
+        assert self.profile.elevation_mask_deg == 15
+        assert self.profile.bds_b2_enabled is False
+        assert self.profile.spi_enabled is True
+
+    def test_data_link_port(self) -> None:
+        assert self.profile.data_link_port == [PortId.UART1, PortId.UART2]
+
+    def test_matrix_on_rows_on_both_uarts_off_usb(self) -> None:
+        matrix = self.profile.rtcm_stream.matrix
+        for row in _ON_ROWS:
+            assert matrix[row][PortId.UART1] is True, row
+            assert matrix[row][PortId.UART2] is True, row
+            assert matrix[row][PortId.USB] is False, row
+
+    def test_matrix_msm7_off(self) -> None:
+        matrix = self.profile.rtcm_stream.matrix
+        for row in _OFF_ROWS:
+            assert matrix[row][PortId.UART1] is False, row
+            assert matrix[row][PortId.UART2] is False, row
+            assert matrix[row][PortId.USB] is False, row
+
+    def test_entire_usb_column_off(self) -> None:
+        matrix = self.profile.rtcm_stream.matrix
+        assert all(not ports.get(PortId.USB, False) for ports in matrix.values())
+
+    def test_matrix_covers_all_twelve_rows(self) -> None:
+        assert set(self.profile.rtcm_stream.matrix) == set(RtcmRowId)

--- a/tests/unit/test_profile_models.py
+++ b/tests/unit/test_profile_models.py
@@ -1,0 +1,255 @@
+"""Tests for the GPS receiver profile schema (ReceiverConfig + Profile).
+
+Covers only context-free validation — rules that need no live device
+state. The UBX-in liveness guard and the tmode_mode=fixed coordinate
+guard are service-level and are tested with the apply ticket.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from sp_rtk_base.models.device_models import GnssConstellation, PortId, RtcmRowId
+from sp_rtk_base.models.profile_models import (
+    DynModel,
+    Profile,
+    ReceiverConfig,
+    TmodeMode,
+)
+
+
+def _matrix_ok() -> dict[RtcmRowId, dict[PortId, bool]]:
+    """A minimal matrix satisfying the data-link validation rules."""
+    return {
+        RtcmRowId.RTCM_1005: {PortId.UART1: True},
+    }
+
+
+def _base_kwargs() -> dict[str, object]:
+    """Minimal kwargs for a valid ReceiverConfig."""
+    return {
+        "data_link_port": [PortId.UART1],
+        "rtcm_stream": {"matrix": _matrix_ok()},
+    }
+
+
+class TestReceiverConfig:
+    """ReceiverConfig is what Apply takes — no name field."""
+
+    def test_minimal_valid_config(self) -> None:
+        config = ReceiverConfig.model_validate(_base_kwargs())
+        assert config.data_link_port == [PortId.UART1]
+        assert config.meas_period_ms == 1000
+
+    def test_has_no_name_field(self) -> None:
+        assert "name" not in ReceiverConfig.model_fields
+
+    def test_dyn_model_and_tmode_mode_default_to_omitted(self) -> None:
+        config = ReceiverConfig.model_validate(_base_kwargs())
+        assert config.dyn_model is None
+        assert config.tmode_mode is None
+
+    def test_dyn_model_and_tmode_mode_settable(self) -> None:
+        kwargs = _base_kwargs()
+        kwargs["dyn_model"] = "stationary"
+        kwargs["tmode_mode"] = "fixed"
+        config = ReceiverConfig.model_validate(kwargs)
+        assert config.dyn_model == DynModel.STATIONARY
+        assert config.tmode_mode == TmodeMode.FIXED
+
+    def test_missing_data_link_port_rejected(self) -> None:
+        kwargs = _base_kwargs()
+        del kwargs["data_link_port"]
+        with pytest.raises(ValidationError, match="data_link_port"):
+            ReceiverConfig.model_validate(kwargs)
+
+    def test_empty_data_link_port_rejected(self) -> None:
+        kwargs = _base_kwargs()
+        kwargs["data_link_port"] = []
+        with pytest.raises(ValidationError, match="data_link_port"):
+            ReceiverConfig.model_validate(kwargs)
+
+    def test_data_link_port_usb_rejected(self) -> None:
+        kwargs = _base_kwargs()
+        kwargs["data_link_port"] = [PortId.USB]
+        with pytest.raises(ValidationError):
+            ReceiverConfig.model_validate(kwargs)
+
+    def test_1005_not_on_any_data_link_port_rejected(self) -> None:
+        kwargs = _base_kwargs()
+        kwargs["rtcm_stream"] = {"matrix": {RtcmRowId.RTCM_1074: {PortId.UART1: True}}}
+        with pytest.raises(ValidationError, match="1005"):
+            ReceiverConfig.model_validate(kwargs)
+
+    def test_1005_on_a_non_data_link_port_is_not_enough(self) -> None:
+        kwargs = _base_kwargs()
+        kwargs["data_link_port"] = [PortId.UART1, PortId.UART2]
+        kwargs["rtcm_stream"] = {
+            "matrix": {
+                RtcmRowId.RTCM_1005: {PortId.UART2: False, PortId.UART1: False},
+                RtcmRowId.RTCM_1074: {PortId.UART1: True, PortId.UART2: True},
+            }
+        }
+        with pytest.raises(ValidationError, match="1005"):
+            ReceiverConfig.model_validate(kwargs)
+
+    def test_data_link_port_with_zero_rows_on_rejected(self) -> None:
+        kwargs = _base_kwargs()
+        kwargs["data_link_port"] = [PortId.UART1, PortId.UART2]
+        # UART2 is a data-link port but has nothing routed to it.
+        kwargs["rtcm_stream"] = {"matrix": {RtcmRowId.RTCM_1005: {PortId.UART1: True}}}
+        with pytest.raises(ValidationError, match="UART2"):
+            ReceiverConfig.model_validate(kwargs)
+
+    @pytest.mark.parametrize("meas_period_ms", [99, 60001])
+    def test_meas_period_ms_out_of_range_rejected(self, meas_period_ms: int) -> None:
+        kwargs = _base_kwargs()
+        kwargs["meas_period_ms"] = meas_period_ms
+        with pytest.raises(ValidationError):
+            ReceiverConfig.model_validate(kwargs)
+
+    @pytest.mark.parametrize("meas_period_ms", [100, 1000, 60000])
+    def test_meas_period_ms_in_range_accepted(self, meas_period_ms: int) -> None:
+        kwargs = _base_kwargs()
+        kwargs["meas_period_ms"] = meas_period_ms
+        config = ReceiverConfig.model_validate(kwargs)
+        assert config.meas_period_ms == meas_period_ms
+
+    @pytest.mark.parametrize("baud", [9599, 921601])
+    def test_baud_out_of_range_rejected(self, baud: int) -> None:
+        kwargs = _base_kwargs()
+        kwargs["baud"] = {"uart1": baud}
+        with pytest.raises(ValidationError):
+            ReceiverConfig.model_validate(kwargs)
+
+    def test_baud_in_range_accepted(self) -> None:
+        kwargs = _base_kwargs()
+        kwargs["baud"] = {"uart1": 57600, "uart2": 115200}
+        config = ReceiverConfig.model_validate(kwargs)
+        assert config.baud is not None
+        assert config.baud.uart1 == 57600
+        assert config.baud.uart2 == 115200
+
+    def test_baud_has_no_usb_field(self) -> None:
+        assert "usb" not in {f.lower() for f in ReceiverConfig.model_fields}
+
+    @pytest.mark.parametrize("elevation_mask_deg", [-1, 91])
+    def test_elevation_mask_deg_out_of_range_rejected(
+        self, elevation_mask_deg: int
+    ) -> None:
+        kwargs = _base_kwargs()
+        kwargs["elevation_mask_deg"] = elevation_mask_deg
+        with pytest.raises(ValidationError):
+            ReceiverConfig.model_validate(kwargs)
+
+    @pytest.mark.parametrize("elevation_mask_deg", [0, 15, 90])
+    def test_elevation_mask_deg_in_range_accepted(
+        self, elevation_mask_deg: int
+    ) -> None:
+        kwargs = _base_kwargs()
+        kwargs["elevation_mask_deg"] = elevation_mask_deg
+        config = ReceiverConfig.model_validate(kwargs)
+        assert config.elevation_mask_deg == elevation_mask_deg
+
+    def test_unknown_matrix_row_rejected(self) -> None:
+        kwargs = _base_kwargs()
+        kwargs["rtcm_stream"] = {"matrix": {"9999": {PortId.UART1: True}}}
+        with pytest.raises(ValidationError):
+            ReceiverConfig.model_validate(kwargs)
+
+    def test_unknown_matrix_column_rejected(self) -> None:
+        kwargs = _base_kwargs()
+        kwargs["rtcm_stream"] = {"matrix": {RtcmRowId.RTCM_1005: {"I2C": True}}}
+        with pytest.raises(ValidationError):
+            ReceiverConfig.model_validate(kwargs)
+
+    def test_constellations_settable(self) -> None:
+        kwargs = _base_kwargs()
+        kwargs["constellations"] = [GnssConstellation.GPS, GnssConstellation.GLONASS]
+        config = ReceiverConfig.model_validate(kwargs)
+        assert config.constellations == [
+            GnssConstellation.GPS,
+            GnssConstellation.GLONASS,
+        ]
+
+    def test_extra_field_rejected(self) -> None:
+        kwargs = _base_kwargs()
+        kwargs["bogus_field"] = "nope"
+        with pytest.raises(ValidationError):
+            ReceiverConfig.model_validate(kwargs)
+
+
+class TestProfile:
+    """Profile = ReceiverConfig + name, version, hardware, forked_from."""
+
+    def _profile_kwargs(self) -> dict[str, object]:
+        kwargs = _base_kwargs()
+        kwargs["name"] = "custom-test-profile"
+        kwargs["version"] = 1
+        kwargs["hardware"] = "ZED-F9P"
+        return kwargs
+
+    def test_minimal_valid_profile(self) -> None:
+        profile = Profile.model_validate(self._profile_kwargs())
+        assert profile.name == "custom-test-profile"
+        assert profile.version == 1
+        assert profile.hardware == "ZED-F9P"
+        assert profile.forked_from is None
+
+    def test_missing_name_rejected(self) -> None:
+        kwargs = self._profile_kwargs()
+        del kwargs["name"]
+        with pytest.raises(ValidationError, match="name"):
+            Profile.model_validate(kwargs)
+
+    def test_missing_version_rejected(self) -> None:
+        kwargs = self._profile_kwargs()
+        del kwargs["version"]
+        with pytest.raises(ValidationError, match="version"):
+            Profile.model_validate(kwargs)
+
+    def test_unknown_version_rejected(self) -> None:
+        kwargs = self._profile_kwargs()
+        kwargs["version"] = 999
+        with pytest.raises(ValidationError, match="version"):
+            Profile.model_validate(kwargs)
+
+    @pytest.mark.parametrize("hardware", ["ZED-F9P", "any"])
+    def test_known_hardware_tokens_accepted(self, hardware: str) -> None:
+        kwargs = self._profile_kwargs()
+        kwargs["hardware"] = hardware
+        profile = Profile.model_validate(kwargs)
+        assert profile.hardware == hardware
+
+    def test_unknown_hardware_token_rejected(self) -> None:
+        kwargs = self._profile_kwargs()
+        kwargs["hardware"] = "ACME-9000"
+        with pytest.raises(ValidationError, match="hardware"):
+            Profile.model_validate(kwargs)
+
+    def test_unregistered_family_token_rejected(self) -> None:
+        # No family tokens are registered yet — that catalog belongs to
+        # the (not-yet-built) hardware-detection ticket, not this schema.
+        kwargs = self._profile_kwargs()
+        kwargs["hardware"] = "gen9"
+        with pytest.raises(ValidationError, match="hardware"):
+            Profile.model_validate(kwargs)
+
+    def test_forked_from_settable(self) -> None:
+        kwargs = self._profile_kwargs()
+        kwargs["forked_from"] = "ublox-f9p-base-standard"
+        profile = Profile.model_validate(kwargs)
+        assert profile.forked_from == "ublox-f9p-base-standard"
+
+    def test_inherits_receiver_config_validation(self) -> None:
+        kwargs = self._profile_kwargs()
+        kwargs["meas_period_ms"] = 1
+        with pytest.raises(ValidationError):
+            Profile.model_validate(kwargs)
+
+    def test_serialization_roundtrip(self) -> None:
+        profile = Profile.model_validate(self._profile_kwargs())
+        data = profile.model_dump(mode="json")
+        restored = Profile.model_validate(data)
+        assert restored == profile


### PR DESCRIPTION
## Summary

- Adds the profile data model: `ReceiverConfig` (everything writable to a receiver, no `name` — what Apply takes) and `Profile` (`ReceiverConfig` + `name`/`version`/`hardware`/`forked_from`), with context-free validation only (live-device rules like the UBX-in guard and the `tmode_mode: fixed` coordinate guard are service-level and belong to the apply ticket).
- Ships the one built-in, `ublox-f9p-base-standard.yaml`, validated by the Pydantic model at import time, reproducing the reference receiver's measured configuration cell-for-cell (minus survey-in position).
- Reuses existing `device_models` enums (`BaseMode`, `UbxProtocol`) instead of duplicating them; keeps the hardware-token catalog minimal (just `ZED-F9P` + `any`) so it doesn't pre-empt the not-yet-built hardware-detection ticket (#46)'s family-token design.

Closes #58.

## Test plan

- [x] `uv run pytest tests/unit/test_profile_models.py tests/unit/test_builtin_profiles.py` — 53 new tests, 100% coverage on the new modules
- [x] `uv run pytest` — full unit suite, 1135 passed, 91.79% coverage (gate 90%)
- [x] `uv run pyright src/` — strict, clean
- [x] `uv run ruff check` / `ruff format --check` — clean
- [x] Two-axis code review (standards + spec) run against the diff; findings (duplicate enums, an overloaded validator, speculative hardware tokens) fixed before commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)