### PR TITLE
feat(profiles): add ProfileStore and the /api/profiles CRUD surface

### DIFF
--- a/src/sp_rtk_base/api/profiles.py
+++ b/src/sp_rtk_base/api/profiles.py
@@ -1,0 +1,160 @@
+"""Profile management API endpoints.
+
+CRUD + export/import over :class:`sp_rtk_base.services.profile_store.ProfileStore`
+— the only filesystem toucher for GPS receiver profiles.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
+from pydantic import ValidationError
+
+from sp_rtk_base.models.api_models import (
+    ProfileDetailResponse,
+    ProfileListItem,
+    ProfileListResponse,
+    ProfileRenameRequest,
+    RelayActionResponse,
+)
+from sp_rtk_base.models.profile_models import Profile
+from sp_rtk_base.services import get_profile_store
+from sp_rtk_base.services.profile_store import (
+    ProfileBusinessRuleError,
+    ProfileConflictError,
+    ProfileImmutableError,
+    ProfileNotFoundError,
+    ProfileStore,
+    ProfileStoreError,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/profiles", tags=["profiles"])
+
+#: Maps each ProfileStore error to the HTTP status it carries — kept as a
+#: single table rather than a repeated except-clause ladder in every
+#: mutating endpoint below.
+_STATUS_BY_ERROR: dict[type[ProfileStoreError], int] = {
+    ProfileNotFoundError: 404,
+    ProfileImmutableError: 403,
+    ProfileConflictError: 409,
+    ProfileBusinessRuleError: 400,
+}
+
+
+def _error_response(exc: ProfileStoreError) -> JSONResponse:
+    return JSONResponse(
+        status_code=_STATUS_BY_ERROR[type(exc)],
+        content={"status": "error", "message": str(exc)},
+    )
+
+
+def _detail(store: ProfileStore, profile: Profile) -> ProfileDetailResponse:
+    return ProfileDetailResponse(
+        profile=profile, is_builtin=store.is_builtin(profile.name)
+    )
+
+
+@router.get("", response_model=ProfileListResponse)
+async def list_profiles(
+    store: ProfileStore = Depends(get_profile_store),
+) -> ProfileListResponse:
+    """List every profile, built-ins before customs, alphabetical within each."""
+    items = [
+        ProfileListItem(profile=p, is_builtin=store.is_builtin(p.name))
+        for p in store.list_profiles()
+    ]
+    return ProfileListResponse(profiles=items, count=len(items))
+
+
+@router.get("/{name}", response_model=ProfileDetailResponse)
+async def get_profile(
+    name: str,
+    store: ProfileStore = Depends(get_profile_store),
+) -> ProfileDetailResponse | JSONResponse:
+    """Get a single profile by name."""
+    profile = store.get_profile(name)
+    if profile is None:
+        return _error_response(ProfileNotFoundError(f"Profile '{name}' not found"))
+    return _detail(store, profile)
+
+
+@router.get("/{name}/export", response_model=Profile)
+async def export_profile(
+    name: str,
+    store: ProfileStore = Depends(get_profile_store),
+) -> Profile | JSONResponse:
+    """Export a profile in the shape ``POST /api/profiles/import`` accepts."""
+    try:
+        return store.export_profile(name)
+    except ProfileNotFoundError as exc:
+        return _error_response(exc)
+
+
+@router.post("", response_model=ProfileDetailResponse, status_code=201)
+async def create_profile(
+    request: Profile,
+    store: ProfileStore = Depends(get_profile_store),
+) -> ProfileDetailResponse | JSONResponse:
+    """Create a new custom profile."""
+    try:
+        created = store.create_profile(request)
+    except ProfileStoreError as exc:
+        return _error_response(exc)
+    logger.info("Created profile: %s", created.name)
+    return _detail(store, created)
+
+
+@router.post("/import", response_model=ProfileDetailResponse, status_code=201)
+async def import_profile(
+    request: dict[str, object],
+    store: ProfileStore = Depends(get_profile_store),
+) -> ProfileDetailResponse | JSONResponse:
+    """Import a previously exported profile document.
+
+    Validated as a :class:`Profile` — an unknown ``version`` (or any
+    other schema violation) is a 422; a name collision is a 409.
+    """
+    try:
+        imported = store.import_profile(request)
+    except ValidationError as exc:
+        return JSONResponse(
+            status_code=422, content={"status": "error", "message": str(exc)}
+        )
+    except ProfileStoreError as exc:
+        return _error_response(exc)
+    logger.info("Imported profile: %s", imported.name)
+    return _detail(store, imported)
+
+
+@router.patch("/{name}", response_model=ProfileDetailResponse)
+async def rename_profile(
+    name: str,
+    request: ProfileRenameRequest,
+    store: ProfileStore = Depends(get_profile_store),
+) -> ProfileDetailResponse | JSONResponse:
+    """Rename an existing custom profile."""
+    try:
+        renamed = store.rename_profile(name, request.new_name)
+    except ProfileStoreError as exc:
+        return _error_response(exc)
+    logger.info("Renamed profile: %s -> %s", name, request.new_name)
+    return _detail(store, renamed)
+
+
+@router.delete("/{name}", response_model=RelayActionResponse)
+async def delete_profile(
+    name: str,
+    store: ProfileStore = Depends(get_profile_store),
+) -> RelayActionResponse | JSONResponse:
+    """Delete a custom profile."""
+    try:
+        store.delete_profile(name)
+    except ProfileStoreError as exc:
+        return _error_response(exc)
+
+    logger.info("Deleted profile: %s", name)
+    return RelayActionResponse(status="ok", message=f"Profile '{name}' deleted")

--- a/src/sp_rtk_base/app.py
+++ b/src/sp_rtk_base/app.py
@@ -29,6 +29,7 @@ from sp_rtk_base.api.events import router as events_router
 from sp_rtk_base.api.health import router as health_router
 from sp_rtk_base.api.metrics import router as metrics_router
 from sp_rtk_base.api.network import router as network_router
+from sp_rtk_base.api.profiles import router as profiles_router
 from sp_rtk_base.api.relay import router as relay_router
 from sp_rtk_base.api.settings import router as settings_router
 
@@ -73,6 +74,7 @@ def create_api_app() -> FastAPI:
     api.include_router(config_router)
     api.include_router(device_router)
     api.include_router(network_router)
+    api.include_router(profiles_router)
     return api
 
 

--- a/src/sp_rtk_base/models/api_models.py
+++ b/src/sp_rtk_base/models/api_models.py
@@ -12,6 +12,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field
 
 from sp_rtk_base.models.net_provision_models import ActiveLink
+from sp_rtk_base.models.profile_models import Profile
 
 # ---------------------------------------------------------------------------
 # Relay status response models
@@ -306,3 +307,35 @@ class NetworkActionResponse(BaseModel):
 
     status: str
     message: str
+
+
+# ---------------------------------------------------------------------------
+# Profile management (issue #59)
+# ---------------------------------------------------------------------------
+
+
+class ProfileListItem(BaseModel):
+    """One entry in the profile picker list, tagged with its origin."""
+
+    profile: Profile
+    is_builtin: bool
+
+
+class ProfileListResponse(BaseModel):
+    """Every profile, built-ins before customs, alphabetical within each."""
+
+    profiles: list[ProfileListItem]
+    count: int
+
+
+class ProfileDetailResponse(BaseModel):
+    """A single profile, tagged with its origin."""
+
+    profile: Profile
+    is_builtin: bool
+
+
+class ProfileRenameRequest(BaseModel):
+    """Body for ``PATCH /api/profiles/{name}`` — rename a custom profile."""
+
+    new_name: str = Field(min_length=1)

--- a/src/sp_rtk_base/services/__init__.py
+++ b/src/sp_rtk_base/services/__init__.py
@@ -8,6 +8,7 @@ application's service layer:
 - ``EventBridge`` — thread-to-async event forwarding
 - ``MetricsService`` — Prometheus metrics from RelayStatus
 - ``DeviceService`` — GPS receiver connection & configuration (optional)
+- ``ProfileStore`` — GPS receiver profile persistence (built-in + custom)
 """
 
 from __future__ import annotations
@@ -27,6 +28,7 @@ from sp_rtk_base.services.device_service import DeviceService
 from sp_rtk_base.services.event_bridge import EventBridge
 from sp_rtk_base.services.metrics_service import MetricsService
 from sp_rtk_base.services.network_service import NetworkService
+from sp_rtk_base.services.profile_store import ProfileStore
 from sp_rtk_base.services.relay_service import RelayService
 
 logger = logging.getLogger(__name__)
@@ -107,6 +109,7 @@ event_bridge: EventBridge = EventBridge()
 metrics_service: MetricsService = MetricsService()
 device_service: DeviceService = DeviceService()
 network_service: NetworkService = NetworkService()
+profile_store: ProfileStore = ProfileStore()
 
 
 # ---------------------------------------------------------------------------
@@ -166,6 +169,15 @@ def get_network_service() -> NetworkService:
         The application's NetworkService instance.
     """
     return network_service
+
+
+def get_profile_store() -> ProfileStore:
+    """Get the singleton ProfileStore instance.
+
+    Returns:
+        The application's ProfileStore instance.
+    """
+    return profile_store
 
 
 # ---------------------------------------------------------------------------

--- a/src/sp_rtk_base/services/profile_store.py
+++ b/src/sp_rtk_base/services/profile_store.py
@@ -1,0 +1,285 @@
+"""Profile persistence — the only filesystem toucher for GPS profiles.
+
+Merges built-in profiles (read-only, shipped in the package) with
+custom profiles (one YAML file each, under a resolved profiles
+directory) behind a single read/write API. Path resolution follows
+the same precedence as :mod:`sp_rtk_base.services.config_service`:
+explicit path -> environment override -> default.
+
+A corrupt or schema-invalid custom file is skipped with a warning on
+load — never fatal — so one bad file can't take the picker down.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import ValidationError
+
+from sp_rtk_base.models.profile_models import Profile
+from sp_rtk_base.profiles import BUILTIN_PROFILES
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PROFILES_DIR = Path.home() / ".config" / "sp-rtk-base" / "profiles"
+ENV_PROFILES_DIR = "SP_RTK_BASE_PROFILES_DIR"
+
+#: Custom profile names must be filesystem- and URL-safe — this is the
+#: same slug rule the repo already applies to other named YAML records
+#: (see ``BaseStationPosition.name`` in config_service). Enforcing it
+#: here (rather than in the schema) keeps the schema hardware-agnostic
+#: about storage and lets the store reject path-unsafe names (e.g. a
+#: name containing ``/`` or ``..``) before they ever reach the filesystem.
+_SAFE_NAME_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+class ProfileStoreError(Exception):
+    """Base class for ProfileStore errors."""
+
+
+class ProfileNotFoundError(ProfileStoreError):
+    """Raised when a named profile (built-in or custom) does not exist."""
+
+
+class ProfileConflictError(ProfileStoreError):
+    """Raised when a name collides with an existing built-in or custom."""
+
+
+class ProfileImmutableError(ProfileStoreError):
+    """Raised when an operation would modify, rename, or delete a built-in."""
+
+
+class ProfileBusinessRuleError(ProfileStoreError):
+    """Raised for a business-rule rejection that isn't a schema violation."""
+
+
+def _get_profiles_dir() -> Path:
+    """Resolve the custom-profiles directory.
+
+    Checks the ``SP_RTK_BASE_PROFILES_DIR`` environment variable first,
+    then falls back to ``~/.config/sp-rtk-base/profiles``.
+    """
+    env_path = os.environ.get(ENV_PROFILES_DIR)
+    if env_path:
+        return Path(env_path)
+    return DEFAULT_PROFILES_DIR
+
+
+class ProfileStore:
+    """Merges built-in and custom GPS receiver profiles.
+
+    Built-ins ship read-only in the package (:data:`BUILTIN_PROFILES`)
+    and are never modified, overwritten, or deleted. Customs are one
+    YAML file per profile under :attr:`profiles_dir`.
+
+    Args:
+        profiles_dir: Optional explicit path to the custom-profiles
+            directory. If not provided, uses ``SP_RTK_BASE_PROFILES_DIR``
+            env var or the default ``~/.config/sp-rtk-base/profiles``.
+    """
+
+    def __init__(self, profiles_dir: Path | None = None) -> None:
+        self._profiles_dir = profiles_dir or _get_profiles_dir()
+
+    @property
+    def profiles_dir(self) -> Path:
+        """The resolved custom-profiles directory."""
+        return self._profiles_dir
+
+    # ------------------------------------------------------------------
+    # Read
+    # ------------------------------------------------------------------
+
+    def list_profiles(self) -> list[Profile]:
+        """List every profile, built-ins before customs, alphabetical within each.
+
+        Returns:
+            Built-in profiles sorted by name, followed by custom
+            profiles sorted by name.
+        """
+        customs = self._load_customs()
+        builtins_sorted = sorted(BUILTIN_PROFILES.values(), key=lambda p: p.name)
+        customs_sorted = sorted(customs.values(), key=lambda p: p.name)
+        return builtins_sorted + customs_sorted
+
+    def get_profile(self, name: str) -> Profile | None:
+        """Look up a profile by name across built-ins and customs.
+
+        Args:
+            name: Profile name.
+
+        Returns:
+            The matching profile, or None if no built-in or custom
+            profile has that name.
+        """
+        builtin = BUILTIN_PROFILES.get(name)
+        if builtin is not None:
+            return builtin
+        return self._load_customs().get(name)
+
+    def is_builtin(self, name: str) -> bool:
+        """Return True if *name* identifies a shipped built-in profile."""
+        return name in BUILTIN_PROFILES
+
+    # ------------------------------------------------------------------
+    # Write
+    # ------------------------------------------------------------------
+
+    def create_profile(self, profile: Profile) -> Profile:
+        """Persist a new custom profile.
+
+        Args:
+            profile: The profile to create.
+
+        Returns:
+            The created profile.
+
+        Raises:
+            ProfileBusinessRuleError: The name isn't filesystem-safe.
+            ProfileConflictError: The name collides with a built-in or
+                an existing custom profile.
+        """
+        self._validate_name_is_safe(profile.name)
+        if profile.name in BUILTIN_PROFILES:
+            raise ProfileConflictError(
+                f"'{profile.name}' collides with a built-in profile"
+            )
+        if profile.name in self._load_customs():
+            raise ProfileConflictError(
+                f"A custom profile named '{profile.name}' already exists"
+            )
+        self._write_custom(profile)
+        logger.info("Created custom profile: %s", profile.name)
+        return profile
+
+    def rename_profile(self, name: str, new_name: str) -> Profile:
+        """Rename an existing custom profile.
+
+        Args:
+            name: Current name of the custom profile.
+            new_name: New name to give it.
+
+        Returns:
+            The renamed profile.
+
+        Raises:
+            ProfileImmutableError: *name* identifies a built-in.
+            ProfileNotFoundError: No custom profile named *name* exists.
+            ProfileBusinessRuleError: *new_name* isn't filesystem-safe.
+            ProfileConflictError: *new_name* collides with a built-in or
+                another existing custom profile.
+        """
+        if name in BUILTIN_PROFILES:
+            raise ProfileImmutableError(f"'{name}' is a built-in and cannot be renamed")
+        customs = self._load_customs()
+        existing = customs.get(name)
+        if existing is None:
+            raise ProfileNotFoundError(f"No profile named '{name}'")
+
+        if new_name == name:
+            return existing
+
+        self._validate_name_is_safe(new_name)
+        if new_name in BUILTIN_PROFILES:
+            raise ProfileConflictError(f"'{new_name}' collides with a built-in profile")
+        if new_name in customs:
+            raise ProfileConflictError(
+                f"A custom profile named '{new_name}' already exists"
+            )
+
+        renamed = existing.model_copy(update={"name": new_name})
+        self._write_custom(renamed)
+        self._custom_path(name).unlink()
+        logger.info("Renamed custom profile: %s -> %s", name, new_name)
+        return renamed
+
+    def delete_profile(self, name: str) -> None:
+        """Delete a custom profile.
+
+        Args:
+            name: Name of the custom profile to delete.
+
+        Raises:
+            ProfileImmutableError: *name* identifies a built-in.
+            ProfileNotFoundError: No custom profile named *name* exists.
+        """
+        if name in BUILTIN_PROFILES:
+            raise ProfileImmutableError(f"'{name}' is a built-in and cannot be deleted")
+        if name not in self._load_customs():
+            raise ProfileNotFoundError(f"No profile named '{name}'")
+        self._custom_path(name).unlink()
+        logger.info("Deleted custom profile: %s", name)
+
+    def export_profile(self, name: str) -> Profile:
+        """Fetch a profile for export.
+
+        Args:
+            name: Profile name (built-in or custom).
+
+        Returns:
+            The profile, in the same shape :meth:`import_profile` accepts.
+
+        Raises:
+            ProfileNotFoundError: No profile named *name* exists.
+        """
+        profile = self.get_profile(name)
+        if profile is None:
+            raise ProfileNotFoundError(f"No profile named '{name}'")
+        return profile
+
+    def import_profile(self, data: dict[str, Any]) -> Profile:
+        """Validate and persist an exported profile document.
+
+        Args:
+            data: A profile document, as produced by :meth:`export_profile`.
+
+        Returns:
+            The imported (created) profile.
+
+        Raises:
+            pydantic.ValidationError: *data* fails schema validation,
+                including an unknown ``version``.
+            ProfileBusinessRuleError: The name isn't filesystem-safe.
+            ProfileConflictError: The name collides with a built-in or
+                an existing custom profile.
+        """
+        profile = Profile.model_validate(data)
+        return self.create_profile(profile)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _validate_name_is_safe(self, name: str) -> None:
+        if not _SAFE_NAME_RE.match(name):
+            raise ProfileBusinessRuleError(
+                f"profile name {name!r} must match ^[A-Za-z0-9_-]+$"
+            )
+
+    def _custom_path(self, name: str) -> Path:
+        return self._profiles_dir / f"{name}.yaml"
+
+    def _load_customs(self) -> dict[str, Profile]:
+        profiles: dict[str, Profile] = {}
+        if not self._profiles_dir.exists():
+            return profiles
+        for path in sorted(self._profiles_dir.glob("*.yaml")):
+            try:
+                data = yaml.safe_load(path.read_text(encoding="utf-8"))
+                profile = Profile.model_validate(data)
+            except (yaml.YAMLError, ValidationError) as exc:
+                logger.warning("Skipping malformed custom profile %s: %s", path, exc)
+                continue
+            profiles[profile.name] = profile
+        return profiles
+
+    def _write_custom(self, profile: Profile) -> None:
+        self._profiles_dir.mkdir(parents=True, exist_ok=True)
+        data = profile.model_dump(mode="json", exclude_none=True)
+        yaml_text = yaml.dump(data, default_flow_style=False, sort_keys=False)
+        self._custom_path(profile.name).write_text(yaml_text, encoding="utf-8")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,11 +13,13 @@ from sp_rtk_base.services import (
     get_config_service,
     get_event_bridge,
     get_metrics_service,
+    get_profile_store,
     get_relay_service,
 )
 from sp_rtk_base.services.config_service import ConfigService
 from sp_rtk_base.services.event_bridge import EventBridge
 from sp_rtk_base.services.metrics_service import MetricsService
+from sp_rtk_base.services.profile_store import ProfileStore
 from sp_rtk_base.services.relay_service import RelayService
 
 
@@ -71,11 +73,24 @@ def mock_metrics_service() -> MetricsService:
 
 
 @pytest.fixture()
+def profiles_dir(tmp_path: Path) -> Path:
+    """Provide a temp custom-profiles directory for tests."""
+    return tmp_path / "sp-rtk-base" / "profiles"
+
+
+@pytest.fixture()
+def mock_profile_store(profiles_dir: Path) -> ProfileStore:
+    """Create a ProfileStore with a temp custom-profiles directory."""
+    return ProfileStore(profiles_dir=profiles_dir)
+
+
+@pytest.fixture()
 def api_client_with_services(
     mock_config_service: ConfigService,
     mock_relay_service: MagicMock,
     mock_event_bridge: MagicMock,
     mock_metrics_service: MetricsService,
+    mock_profile_store: ProfileStore,
 ) -> TestClient:
     """Create a TestClient with overridden service dependencies.
 
@@ -88,5 +103,6 @@ def api_client_with_services(
     app.dependency_overrides[get_relay_service] = lambda: mock_relay_service
     app.dependency_overrides[get_event_bridge] = lambda: mock_event_bridge
     app.dependency_overrides[get_metrics_service] = lambda: mock_metrics_service
+    app.dependency_overrides[get_profile_store] = lambda: mock_profile_store
 
     return TestClient(app)

--- a/tests/unit/test_api_profiles.py
+++ b/tests/unit/test_api_profiles.py
@@ -1,0 +1,233 @@
+"""Tests for sp_rtk_base.api.profiles — profile CRUD API endpoints."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+from sp_rtk_base.services.profile_store import ProfileStore
+
+BUILTIN_NAME = "ublox-f9p-base-standard"
+
+
+def _profile_payload(name: str = "my-custom", **overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "name": name,
+        "version": 1,
+        "hardware": "ZED-F9P",
+        "data_link_port": ["UART1"],
+        "rtcm_stream": {"matrix": {"1005": {"UART1": True}}},
+    }
+    payload.update(overrides)
+    return payload
+
+
+class TestListProfiles:
+    def test_lists_builtin_only_when_no_customs(
+        self, api_client_with_services: TestClient
+    ) -> None:
+        resp = api_client_with_services.get("/api/profiles")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["count"] == 1
+        assert data["profiles"][0]["profile"]["name"] == BUILTIN_NAME
+        assert data["profiles"][0]["is_builtin"] is True
+
+    def test_builtins_before_customs_alphabetical(
+        self, api_client_with_services: TestClient, mock_profile_store: ProfileStore
+    ) -> None:
+        api_client_with_services.post("/api/profiles", json=_profile_payload("zeta"))
+        api_client_with_services.post("/api/profiles", json=_profile_payload("alpha"))
+
+        resp = api_client_with_services.get("/api/profiles")
+        names = [item["profile"]["name"] for item in resp.json()["profiles"]]
+        assert names == [BUILTIN_NAME, "alpha", "zeta"]
+
+
+class TestGetProfile:
+    def test_get_existing(self, api_client_with_services: TestClient) -> None:
+        resp = api_client_with_services.get(f"/api/profiles/{BUILTIN_NAME}")
+        assert resp.status_code == 200
+        assert resp.json()["profile"]["name"] == BUILTIN_NAME
+        assert resp.json()["is_builtin"] is True
+
+    def test_get_not_found(self, api_client_with_services: TestClient) -> None:
+        resp = api_client_with_services.get("/api/profiles/does-not-exist")
+        assert resp.status_code == 404
+
+
+class TestCreateProfile:
+    def test_create_returns_201(self, api_client_with_services: TestClient) -> None:
+        resp = api_client_with_services.post("/api/profiles", json=_profile_payload())
+        assert resp.status_code == 201
+        assert resp.json()["profile"]["name"] == "my-custom"
+        assert resp.json()["is_builtin"] is False
+
+    def test_create_conflict_with_builtin_is_409(
+        self, api_client_with_services: TestClient
+    ) -> None:
+        resp = api_client_with_services.post(
+            "/api/profiles", json=_profile_payload(BUILTIN_NAME)
+        )
+        assert resp.status_code == 409
+
+    def test_create_conflict_with_custom_is_409(
+        self, api_client_with_services: TestClient
+    ) -> None:
+        api_client_with_services.post("/api/profiles", json=_profile_payload())
+        resp = api_client_with_services.post("/api/profiles", json=_profile_payload())
+        assert resp.status_code == 409
+
+    def test_create_schema_violation_is_422(
+        self, api_client_with_services: TestClient
+    ) -> None:
+        payload = _profile_payload()
+        del payload["data_link_port"]
+        resp = api_client_with_services.post("/api/profiles", json=payload)
+        assert resp.status_code == 422
+
+    def test_create_unsafe_name_is_400(
+        self, api_client_with_services: TestClient
+    ) -> None:
+        resp = api_client_with_services.post(
+            "/api/profiles", json=_profile_payload("has/slash")
+        )
+        assert resp.status_code == 400
+
+
+class TestRenameProfile:
+    def test_rename_returns_updated_profile(
+        self, api_client_with_services: TestClient
+    ) -> None:
+        api_client_with_services.post(
+            "/api/profiles", json=_profile_payload("old-name")
+        )
+        resp = api_client_with_services.patch(
+            "/api/profiles/old-name", json={"new_name": "new-name"}
+        )
+        assert resp.status_code == 200
+        assert resp.json()["profile"]["name"] == "new-name"
+
+    def test_rename_builtin_is_403(self, api_client_with_services: TestClient) -> None:
+        resp = api_client_with_services.patch(
+            f"/api/profiles/{BUILTIN_NAME}", json={"new_name": "something-else"}
+        )
+        assert resp.status_code == 403
+
+    def test_rename_unknown_is_404(self, api_client_with_services: TestClient) -> None:
+        resp = api_client_with_services.patch(
+            "/api/profiles/does-not-exist", json={"new_name": "something-else"}
+        )
+        assert resp.status_code == 404
+
+    def test_rename_to_colliding_name_is_409(
+        self, api_client_with_services: TestClient
+    ) -> None:
+        api_client_with_services.post("/api/profiles", json=_profile_payload("first"))
+        api_client_with_services.post("/api/profiles", json=_profile_payload("second"))
+        resp = api_client_with_services.patch(
+            "/api/profiles/first", json={"new_name": "second"}
+        )
+        assert resp.status_code == 409
+
+    def test_rename_to_unsafe_name_is_400(
+        self, api_client_with_services: TestClient
+    ) -> None:
+        api_client_with_services.post(
+            "/api/profiles", json=_profile_payload("old-name")
+        )
+        resp = api_client_with_services.patch(
+            "/api/profiles/old-name", json={"new_name": "has/slash"}
+        )
+        assert resp.status_code == 400
+
+    def test_rename_to_same_name_is_a_noop_not_a_conflict(
+        self, api_client_with_services: TestClient
+    ) -> None:
+        api_client_with_services.post(
+            "/api/profiles", json=_profile_payload("same-name")
+        )
+        resp = api_client_with_services.patch(
+            "/api/profiles/same-name", json={"new_name": "same-name"}
+        )
+        assert resp.status_code == 200
+        assert resp.json()["profile"]["name"] == "same-name"
+
+
+class TestDeleteProfile:
+    def test_delete_returns_ok(self, api_client_with_services: TestClient) -> None:
+        api_client_with_services.post("/api/profiles", json=_profile_payload())
+        resp = api_client_with_services.delete("/api/profiles/my-custom")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+
+    def test_delete_builtin_is_403(self, api_client_with_services: TestClient) -> None:
+        resp = api_client_with_services.delete(f"/api/profiles/{BUILTIN_NAME}")
+        assert resp.status_code == 403
+
+    def test_delete_unknown_is_404(self, api_client_with_services: TestClient) -> None:
+        resp = api_client_with_services.delete("/api/profiles/does-not-exist")
+        assert resp.status_code == 404
+
+
+class TestExportImport:
+    def test_export_builtin(self, api_client_with_services: TestClient) -> None:
+        resp = api_client_with_services.get(f"/api/profiles/{BUILTIN_NAME}/export")
+        assert resp.status_code == 200
+        assert resp.json()["name"] == BUILTIN_NAME
+
+    def test_export_unknown_is_404(self, api_client_with_services: TestClient) -> None:
+        resp = api_client_with_services.get("/api/profiles/does-not-exist/export")
+        assert resp.status_code == 404
+
+    def test_roundtrip_export_then_import(
+        self, api_client_with_services: TestClient
+    ) -> None:
+        api_client_with_services.post("/api/profiles", json=_profile_payload("source"))
+        exported = api_client_with_services.get("/api/profiles/source/export").json()
+        api_client_with_services.delete("/api/profiles/source")
+
+        resp = api_client_with_services.post("/api/profiles/import", json=exported)
+        assert resp.status_code == 201
+        assert resp.json()["profile"]["name"] == "source"
+
+    def test_import_unknown_version_is_422(
+        self, api_client_with_services: TestClient
+    ) -> None:
+        payload = _profile_payload("importee")
+        payload["version"] = 999
+        resp = api_client_with_services.post("/api/profiles/import", json=payload)
+        assert resp.status_code == 422
+
+    def test_import_conflicting_name_is_409(
+        self, api_client_with_services: TestClient
+    ) -> None:
+        api_client_with_services.post("/api/profiles", json=_profile_payload("dup"))
+        resp = api_client_with_services.post(
+            "/api/profiles/import", json=_profile_payload("dup")
+        )
+        assert resp.status_code == 409
+
+    def test_import_unsafe_name_is_400(
+        self, api_client_with_services: TestClient
+    ) -> None:
+        resp = api_client_with_services.post(
+            "/api/profiles/import", json=_profile_payload("has/slash")
+        )
+        assert resp.status_code == 400
+
+
+class TestMalformedCustomFileDoesNotBreakListing:
+    def test_bad_file_skipped_others_still_list(
+        self, api_client_with_services: TestClient, mock_profile_store: ProfileStore
+    ) -> None:
+        api_client_with_services.post("/api/profiles", json=_profile_payload("good"))
+        bad_path = mock_profile_store.profiles_dir / "corrupt.yaml"
+        bad_path.write_text("{not valid yaml::", encoding="utf-8")
+
+        resp = api_client_with_services.get("/api/profiles")
+        assert resp.status_code == 200
+        names = [item["profile"]["name"] for item in resp.json()["profiles"]]
+        assert "good" in names
+        assert len(names) == 2  # builtin + good; corrupt.yaml silently skipped

--- a/tests/unit/test_profile_store.py
+++ b/tests/unit/test_profile_store.py
@@ -1,0 +1,267 @@
+"""Tests for sp_rtk_base.services.profile_store — profile persistence."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from sp_rtk_base.models.device_models import PortId, RtcmRowId
+from sp_rtk_base.models.profile_models import Profile
+from sp_rtk_base.profiles import BUILTIN_PROFILES
+from sp_rtk_base.services.profile_store import (
+    ProfileBusinessRuleError,
+    ProfileConflictError,
+    ProfileImmutableError,
+    ProfileNotFoundError,
+    ProfileStore,
+)
+
+BUILTIN_NAME = "ublox-f9p-base-standard"
+
+
+@pytest.fixture()
+def profiles_dir(tmp_path: Path) -> Path:
+    return tmp_path / "profiles"
+
+
+@pytest.fixture()
+def store(profiles_dir: Path) -> ProfileStore:
+    return ProfileStore(profiles_dir=profiles_dir)
+
+
+def _custom(name: str = "my-custom", **overrides: object) -> Profile:
+    kwargs: dict[str, object] = {
+        "name": name,
+        "version": 1,
+        "hardware": "ZED-F9P",
+        "data_link_port": [PortId.UART1],
+        "rtcm_stream": {"matrix": {RtcmRowId.RTCM_1005: {PortId.UART1: True}}},
+    }
+    kwargs.update(overrides)
+    return Profile.model_validate(kwargs)
+
+
+class TestListProfiles:
+    def test_lists_only_builtin_when_no_customs(self, store: ProfileStore) -> None:
+        profiles = store.list_profiles()
+        assert [p.name for p in profiles] == [BUILTIN_NAME]
+
+    def test_builtins_before_customs_alphabetical(self, store: ProfileStore) -> None:
+        store.create_profile(_custom("zeta"))
+        store.create_profile(_custom("alpha"))
+        profiles = store.list_profiles()
+        assert [p.name for p in profiles] == [BUILTIN_NAME, "alpha", "zeta"]
+
+    def test_skips_malformed_custom_file_with_warning(
+        self, store: ProfileStore, profiles_dir: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        store.create_profile(_custom("good"))
+        profiles_dir.mkdir(parents=True, exist_ok=True)
+        (profiles_dir / "bad.yaml").write_text("not: [valid, profile", encoding="utf-8")
+
+        with caplog.at_level("WARNING"):
+            profiles = store.list_profiles()
+
+        assert [p.name for p in profiles] == [BUILTIN_NAME, "good"]
+        assert "bad.yaml" in caplog.text
+
+    def test_skips_schema_invalid_custom_file(
+        self, store: ProfileStore, profiles_dir: Path
+    ) -> None:
+        store.create_profile(_custom("good"))
+        profiles_dir.mkdir(parents=True, exist_ok=True)
+        (profiles_dir / "invalid.yaml").write_text(
+            yaml.dump({"name": "invalid", "version": 999, "hardware": "ZED-F9P"}),
+            encoding="utf-8",
+        )
+
+        profiles = store.list_profiles()
+        assert [p.name for p in profiles] == [BUILTIN_NAME, "good"]
+
+
+class TestGetProfile:
+    def test_get_builtin(self, store: ProfileStore) -> None:
+        assert store.get_profile(BUILTIN_NAME) is BUILTIN_PROFILES[BUILTIN_NAME]
+
+    def test_get_custom(self, store: ProfileStore) -> None:
+        created = store.create_profile(_custom())
+        assert store.get_profile("my-custom") == created
+
+    def test_get_missing_returns_none(self, store: ProfileStore) -> None:
+        assert store.get_profile("does-not-exist") is None
+
+
+class TestIsBuiltin:
+    def test_true_for_builtin(self, store: ProfileStore) -> None:
+        assert store.is_builtin(BUILTIN_NAME) is True
+
+    def test_false_for_custom(self, store: ProfileStore) -> None:
+        store.create_profile(_custom())
+        assert store.is_builtin("my-custom") is False
+
+
+class TestCreateProfile:
+    def test_create_persists_to_disk(
+        self, store: ProfileStore, profiles_dir: Path
+    ) -> None:
+        store.create_profile(_custom())
+        assert (profiles_dir / "my-custom.yaml").exists()
+
+    def test_create_returns_profile(self, store: ProfileStore) -> None:
+        created = store.create_profile(_custom())
+        assert created.name == "my-custom"
+
+    def test_conflict_with_builtin(self, store: ProfileStore) -> None:
+        with pytest.raises(ProfileConflictError):
+            store.create_profile(_custom(BUILTIN_NAME))
+
+    def test_conflict_with_existing_custom(self, store: ProfileStore) -> None:
+        store.create_profile(_custom())
+        with pytest.raises(ProfileConflictError):
+            store.create_profile(_custom())
+
+    def test_builtin_never_modified(self, store: ProfileStore) -> None:
+        with pytest.raises(ProfileConflictError):
+            store.create_profile(_custom(BUILTIN_NAME))
+        assert BUILTIN_PROFILES[BUILTIN_NAME].hardware == "ZED-F9P"
+
+    @pytest.mark.parametrize("bad_name", ["has space", "has/slash", "../traverse", ""])
+    def test_unsafe_name_rejected(self, store: ProfileStore, bad_name: str) -> None:
+        if bad_name == "":
+            with pytest.raises(ValidationError):
+                _custom(bad_name)
+            return
+        with pytest.raises(ProfileBusinessRuleError):
+            store.create_profile(_custom(bad_name))
+
+
+class TestRenameProfile:
+    def test_rename_moves_file(self, store: ProfileStore, profiles_dir: Path) -> None:
+        store.create_profile(_custom("old-name"))
+        store.rename_profile("old-name", "new-name")
+        assert not (profiles_dir / "old-name.yaml").exists()
+        assert (profiles_dir / "new-name.yaml").exists()
+
+    def test_rename_returns_updated_profile(self, store: ProfileStore) -> None:
+        store.create_profile(_custom("old-name"))
+        renamed = store.rename_profile("old-name", "new-name")
+        assert renamed.name == "new-name"
+
+    def test_rename_builtin_is_forbidden(self, store: ProfileStore) -> None:
+        with pytest.raises(ProfileImmutableError):
+            store.rename_profile(BUILTIN_NAME, "something-else")
+
+    def test_rename_unknown_is_not_found(self, store: ProfileStore) -> None:
+        with pytest.raises(ProfileNotFoundError):
+            store.rename_profile("does-not-exist", "something-else")
+
+    def test_rename_to_existing_builtin_conflicts(self, store: ProfileStore) -> None:
+        store.create_profile(_custom("old-name"))
+        with pytest.raises(ProfileConflictError):
+            store.rename_profile("old-name", BUILTIN_NAME)
+
+    def test_rename_to_existing_custom_conflicts(self, store: ProfileStore) -> None:
+        store.create_profile(_custom("first"))
+        store.create_profile(_custom("second"))
+        with pytest.raises(ProfileConflictError):
+            store.rename_profile("first", "second")
+
+    def test_rename_to_unsafe_name_rejected(self, store: ProfileStore) -> None:
+        store.create_profile(_custom("old-name"))
+        with pytest.raises(ProfileBusinessRuleError):
+            store.rename_profile("old-name", "has/slash")
+
+    def test_rename_to_same_name_is_a_noop(
+        self, store: ProfileStore, profiles_dir: Path
+    ) -> None:
+        created = store.create_profile(_custom("same-name"))
+        renamed = store.rename_profile("same-name", "same-name")
+        assert renamed == created
+        assert (profiles_dir / "same-name.yaml").exists()
+
+
+class TestDeleteProfile:
+    def test_delete_removes_file(self, store: ProfileStore, profiles_dir: Path) -> None:
+        store.create_profile(_custom())
+        store.delete_profile("my-custom")
+        assert not (profiles_dir / "my-custom.yaml").exists()
+
+    def test_delete_builtin_is_forbidden(self, store: ProfileStore) -> None:
+        with pytest.raises(ProfileImmutableError):
+            store.delete_profile(BUILTIN_NAME)
+
+    def test_delete_unknown_is_not_found(self, store: ProfileStore) -> None:
+        with pytest.raises(ProfileNotFoundError):
+            store.delete_profile("does-not-exist")
+
+    def test_builtin_survives_repeated_delete_attempts(
+        self, store: ProfileStore
+    ) -> None:
+        for _ in range(3):
+            with pytest.raises(ProfileImmutableError):
+                store.delete_profile(BUILTIN_NAME)
+        assert store.get_profile(BUILTIN_NAME) is not None
+
+
+class TestExportImportRoundtrip:
+    def test_export_builtin(self, store: ProfileStore) -> None:
+        exported = store.export_profile(BUILTIN_NAME)
+        assert exported.name == BUILTIN_NAME
+
+    def test_export_unknown_is_not_found(self, store: ProfileStore) -> None:
+        with pytest.raises(ProfileNotFoundError):
+            store.export_profile("does-not-exist")
+
+    def test_roundtrip_through_export_import(self, store: ProfileStore) -> None:
+        store.create_profile(_custom("source"))
+        exported = store.export_profile("source")
+        store.delete_profile("source")
+
+        data = exported.model_dump(mode="json")
+        imported = store.import_profile(data)
+
+        assert imported == exported
+        assert store.get_profile("source") == exported
+
+    def test_import_unknown_version_is_422_shaped(self, store: ProfileStore) -> None:
+        data = _custom("importee").model_dump(mode="json")
+        data["version"] = 999
+        with pytest.raises(ValidationError, match="version"):
+            store.import_profile(data)
+
+    def test_import_conflicting_name(self, store: ProfileStore) -> None:
+        store.create_profile(_custom("dup"))
+        data = _custom("dup").model_dump(mode="json")
+        with pytest.raises(ProfileConflictError):
+            store.import_profile(data)
+
+
+class TestPathResolutionPrecedence:
+    def test_explicit_path_wins_over_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        env_dir = tmp_path / "env-profiles"
+        explicit_dir = tmp_path / "explicit-profiles"
+        monkeypatch.setenv("SP_RTK_BASE_PROFILES_DIR", str(env_dir))
+
+        store = ProfileStore(profiles_dir=explicit_dir)
+        assert store.profiles_dir == explicit_dir
+
+    def test_env_used_when_no_explicit_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        env_dir = tmp_path / "env-profiles"
+        monkeypatch.setenv("SP_RTK_BASE_PROFILES_DIR", str(env_dir))
+
+        store = ProfileStore()
+        assert store.profiles_dir == env_dir
+
+    def test_default_when_neither_given(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SP_RTK_BASE_PROFILES_DIR", raising=False)
+        from sp_rtk_base.services.profile_store import DEFAULT_PROFILES_DIR
+
+        store = ProfileStore()
+        assert store.profiles_dir == DEFAULT_PROFILES_DIR


### PR DESCRIPTION
## Summary
- Adds `ProfileStore`, merging built-in (read-only, shipped) and custom (one YAML file each, under a resolved profiles directory) GPS receiver profiles behind one read/write API.
- Wires list/get/create/rename/delete/export/import into `GET`/`POST`/`PATCH`/`DELETE /api/profiles`, with 409 on name collision, 403 on mutating a built-in, 404 on unknown name, 422 on schema violation (including an unknown `version` on import), and 400 on the filesystem-safe-name business rule.
- A malformed custom YAML file is skipped with a warning and never takes the rest of the listing down.

Closes #59

## Test plan
- [x] `uv run pytest` — 1198 passed, 92.2% coverage (100% on `profile_store.py` and `api/profiles.py`)
- [x] `uv run pyright src/` — clean
- [x] `uv run mypy` on touched files — clean
- [x] `uv run ruff check` / `ruff format --check` — clean
- [x] Two-axis `/code-review` (standards + spec vs. issue #59) run and findings addressed (self-rename-to-same-name no-op fix; deduped exception→status mapping in the API router)