### PR TITLE
feat(hardware): resolve hardware identity, confidence tiers, and the compatibility filter

### DIFF
--- a/src/sp_rtk_base/api/profiles.py
+++ b/src/sp_rtk_base/api/profiles.py
@@ -19,8 +19,17 @@ from sp_rtk_base.models.api_models import (
     ProfileRenameRequest,
     RelayActionResponse,
 )
+from sp_rtk_base.models.hardware_identity import (
+    HARDWARE_UNKNOWN,
+    HardwareConfidence,
+    default_selection,
+    identity_from_target,
+    incompatible_reason,
+    is_compatible,
+)
 from sp_rtk_base.models.profile_models import Profile
-from sp_rtk_base.services import get_profile_store
+from sp_rtk_base.services import get_device_service, get_profile_store
+from sp_rtk_base.services.device_service import DeviceService
 from sp_rtk_base.services.profile_store import (
     ProfileBusinessRuleError,
     ProfileConflictError,
@@ -61,13 +70,39 @@ def _detail(store: ProfileStore, profile: Profile) -> ProfileDetailResponse:
 @router.get("", response_model=ProfileListResponse)
 async def list_profiles(
     store: ProfileStore = Depends(get_profile_store),
+    device: DeviceService = Depends(get_device_service),
 ) -> ProfileListResponse:
-    """List every profile, built-ins before customs, alphabetical within each."""
+    """List every profile, built-ins before customs, alphabetical within each.
+
+    Tags each profile with its compatibility against the connected
+    receiver's resolved hardware identity (see ``models.hardware_identity``)
+    and carries that identity plus the deterministic default pick.
+    """
+    info = device.device_info
+    identity = identity_from_target(
+        info.hardware_target if info else HARDWARE_UNKNOWN,
+        info.hardware_confidence if info else HardwareConfidence.UNKNOWN,
+    )
+
+    profiles = store.list_profiles()
     items = [
-        ProfileListItem(profile=p, is_builtin=store.is_builtin(p.name))
-        for p in store.list_profiles()
+        ProfileListItem(
+            profile=p,
+            is_builtin=store.is_builtin(p.name),
+            compatible=is_compatible(identity, p.hardware),
+            incompatible_reason=incompatible_reason(identity, p.hardware),
+        )
+        for p in profiles
     ]
-    return ProfileListResponse(profiles=items, count=len(items))
+    return ProfileListResponse(
+        profiles=items,
+        count=len(items),
+        hardware_target=identity.target,
+        hardware_confidence=identity.confidence,
+        default_selection=default_selection(
+            identity, [(p.name, p.hardware) for p in profiles]
+        ),
+    )
 
 
 @router.get("/{name}", response_model=ProfileDetailResponse)

--- a/src/sp_rtk_base/models/api_models.py
+++ b/src/sp_rtk_base/models/api_models.py
@@ -11,6 +11,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
+from sp_rtk_base.models.hardware_identity import HardwareConfidence, HardwareTarget
 from sp_rtk_base.models.net_provision_models import ActiveLink
 from sp_rtk_base.models.profile_models import Profile
 
@@ -319,13 +320,23 @@ class ProfileListItem(BaseModel):
 
     profile: Profile
     is_builtin: bool
+    compatible: bool
+    incompatible_reason: str | None = None
 
 
 class ProfileListResponse(BaseModel):
-    """Every profile, built-ins before customs, alphabetical within each."""
+    """Every profile, built-ins before customs, alphabetical within each.
+
+    Also carries the connected receiver's resolved identity — see
+    ``models.hardware_identity`` — so the picker can grey out incompatible
+    profiles and suggest a default without re-deriving compatibility itself.
+    """
 
     profiles: list[ProfileListItem]
     count: int
+    hardware_target: HardwareTarget
+    hardware_confidence: HardwareConfidence
+    default_selection: str | None
 
 
 class ProfileDetailResponse(BaseModel):

--- a/src/sp_rtk_base/models/device_models.py
+++ b/src/sp_rtk_base/models/device_models.py
@@ -12,6 +12,12 @@ from datetime import datetime
 
 from pydantic import BaseModel, Field
 
+from sp_rtk_base.models.hardware_identity import (
+    HARDWARE_UNKNOWN,
+    HardwareConfidence,
+    HardwareTarget,
+)
+
 # ---------------------------------------------------------------------------
 # Connection state
 # ---------------------------------------------------------------------------
@@ -69,6 +75,15 @@ class DeviceInfo(BaseModel):
     hardware_version: str = Field(default="", description="Hardware version string")
     serial_number: str = Field(
         default="", description="Device serial number if available"
+    )
+    hardware_target: HardwareTarget = Field(
+        default=HARDWARE_UNKNOWN,
+        description="Resolved identity target: a specific model, a family "
+        "token, or 'unknown' (see models.hardware_identity)",
+    )
+    hardware_confidence: HardwareConfidence = Field(
+        default=HardwareConfidence.UNKNOWN,
+        description="How hardware_target was obtained",
     )
 
 

--- a/src/sp_rtk_base/models/hardware_identity.py
+++ b/src/sp_rtk_base/models/hardware_identity.py
@@ -1,0 +1,226 @@
+"""Hardware identity resolution — ``HardwareTarget``, confidence tiers, and
+the one-line compatibility filter.
+
+Identity resolves through an ordered tier ladder, each tier attached to a
+confidence, because a receiver's fallback chain can otherwise store a guess
+in the same field as a real read — which would let an unrecognised receiver
+be confidently mis-identified as a known one:
+
+| Tier | Source                                                | Confidence |
+|------|--------------------------------------------------------|------------|
+| 1    | ``MOD=`` in a MON-VER extension                         | confirmed  |
+| 2    | an explicit model string in an extension                | confirmed  |
+| 3    | ``HW_VERSION_MODEL_MAP[hwVersion]`` (module ID)          | confirmed  |
+| 4    | firmware-family heuristic (``"HPG"`` -> ``ZED-F9P``)     | inferred   |
+| 5    | ``PROTVER`` generation heuristic (family only)           | inferred   |
+| —    | nothing matches                                          | unknown    |
+
+Tiers 1-3 are deterministic reads of something the receiver reports about
+itself and can never misidentify one physical unit as another. Tiers 4 and
+5 are guesses, which is why ``target`` alone is never enough to satisfy a
+specific-model compatibility match — see :func:`is_compatible`.
+
+``HardwareTarget`` is deliberately a plain ``str``, not a closed enum: a
+new receiver is supported by dropping a profile YAML tagged with its
+``MOD=`` string, not by editing this module (tiers 1-2 pass that string
+through verbatim). Only the deterministic/heuristic *fallback* tables
+(tiers 3-5) are a fixed catalog, because they exist to cover receivers that
+can't report `MOD=` at all.
+"""
+
+from __future__ import annotations
+
+import enum
+from collections.abc import Iterable
+
+from pydantic import BaseModel, Field
+
+HardwareTarget = str
+
+#: Token meaning "compatible with every receiver". This is the source of
+#: truth — ``profile_models`` re-exports it rather than defining its own.
+HARDWARE_ANY: HardwareTarget = "any"
+
+#: Sentinel target when nothing at all resolves.
+HARDWARE_UNKNOWN: HardwareTarget = "unknown"
+
+
+class HardwareConfidence(str, enum.Enum):
+    """How the resolved :class:`HardwareIdentity` target was obtained."""
+
+    CONFIRMED = "confirmed"
+    INFERRED = "inferred"
+    UNKNOWN = "unknown"
+
+
+#: Deterministic hardware-version (``hwVersion``) -> model lookup (tier 3).
+HW_VERSION_MODEL_MAP: dict[str, str] = {
+    "00190000": "ZED-F9P",
+    "001B0000": "ZED-F9R",
+    "00180000": "NEO-M9N",
+}
+
+#: Firmware-family substring heuristic (tier 4). A guess, hence ``inferred``.
+FIRMWARE_FAMILY_MODEL_MAP: dict[str, str] = {
+    "HPG": "ZED-F9P",
+    "ADR": "ZED-F9R",
+}
+
+#: Chip-generation family each known model belongs to, so a family- or
+#: `any`-tagged profile can still match a specifically-identified receiver.
+MODEL_FAMILY: dict[str, str] = {
+    "ZED-F9P": "gen9",
+    "ZED-F9R": "gen9",
+    "NEO-M9N": "gen9",
+}
+
+#: Last-resort, family-only heuristic (tier 5): the ``PROTVER`` major
+#: version alone, tried only once MOD=, an explicit model string,
+#: hwVersion, and the firmware-family heuristic have all failed to name a
+#: model. As coarse a guess as tier 4 — hence also ``inferred`` — but kept
+#: separate because it names a generation, not a module, so it can never
+#: satisfy a specific-model match either way.
+PROTVER_MAJOR_FAMILY_MAP: dict[int, str] = {
+    27: "gen9",
+    28: "gen9",
+    29: "gen9",
+    30: "gen9",
+    31: "gen9",
+    32: "gen9",
+    33: "gen9",
+}
+
+#: Every family token any tier above can produce. Only "gen9" is wired up —
+#: no shipped receiver or PROTVER range yet backs a "gen10" token, so it's
+#: left out rather than added speculatively; adding a gen10 receiver is a
+#: one-line addition to the maps above, same as the X20P story.
+KNOWN_FAMILY_TOKENS: frozenset[str] = frozenset(MODEL_FAMILY.values()) | frozenset(
+    PROTVER_MAJOR_FAMILY_MAP.values()
+)
+
+#: Every model this app can confirm or infer by any tier — the catalog
+#: ``profile_models.KNOWN_HARDWARE_MODELS`` re-exports, so a ``Profile``
+#: can target any model this resolver can actually produce.
+KNOWN_MODEL_TOKENS: frozenset[str] = frozenset(MODEL_FAMILY)
+
+
+class HardwareIdentity(BaseModel):
+    """A resolved receiver identity: a target plus how sure we are of it."""
+
+    target: HardwareTarget = Field(
+        description="A specific model, a family token, or 'unknown'"
+    )
+    confidence: HardwareConfidence
+    families: frozenset[str] = Field(default_factory=frozenset)
+
+    @property
+    def is_specific_model(self) -> bool:
+        """Whether ``target`` names an actual model rather than a family."""
+        return (
+            self.target != HARDWARE_UNKNOWN and self.target not in KNOWN_FAMILY_TOKENS
+        )
+
+
+def identity_from_target(
+    target: HardwareTarget, confidence: HardwareConfidence
+) -> HardwareIdentity:
+    """Build a :class:`HardwareIdentity`, deriving ``families`` from *target*."""
+    families: frozenset[str]
+    if target in MODEL_FAMILY:
+        families = frozenset({MODEL_FAMILY[target]})
+    elif target in KNOWN_FAMILY_TOKENS:
+        families = frozenset({target})
+    else:
+        families = frozenset()
+    return HardwareIdentity(target=target, confidence=confidence, families=families)
+
+
+def resolve_hardware_identity(
+    *,
+    mod: str = "",
+    explicit_model: str = "",
+    hw_version: str = "",
+    firmware: str = "",
+    protocol_version: str = "",
+) -> HardwareIdentity:
+    """Resolve receiver identity from parsed MON-VER fields, per the tier ladder.
+
+    Never raises — an unresolvable receiver comes back as
+    ``target="unknown"`` / ``confidence=unknown`` rather than an error, so
+    connect is never gated on identity.
+    """
+    model = mod.strip() or explicit_model.strip()
+    if model:
+        return identity_from_target(model, HardwareConfidence.CONFIRMED)
+
+    mapped = HW_VERSION_MODEL_MAP.get(hw_version.strip())
+    if mapped:
+        return identity_from_target(mapped, HardwareConfidence.CONFIRMED)
+
+    for marker, guessed_model in FIRMWARE_FAMILY_MODEL_MAP.items():
+        if marker in firmware:
+            return identity_from_target(guessed_model, HardwareConfidence.INFERRED)
+
+    family = _family_from_protver(protocol_version)
+    if family:
+        return identity_from_target(family, HardwareConfidence.INFERRED)
+
+    return identity_from_target(HARDWARE_UNKNOWN, HardwareConfidence.UNKNOWN)
+
+
+def _family_from_protver(protocol_version: str) -> str | None:
+    major = protocol_version.strip().split(".", 1)[0]
+    if not major.isdigit():
+        return None
+    return PROTVER_MAJOR_FAMILY_MAP.get(int(major))
+
+
+def is_compatible(device: HardwareIdentity, profile_hardware: str) -> bool:
+    """The one-line compatibility rule.
+
+    A profile is compatible iff its ``hardware`` tag is the device's
+    *confirmed* specific-model target, one of the device's families, or the
+    universal ``"any"`` token. A guessed (``inferred``) or absent
+    (``unknown``) identity can never satisfy the specific-model branch —
+    only ``confirmed`` identity unlocks a specific-model profile.
+    """
+    specific_match = (
+        device.confidence == HardwareConfidence.CONFIRMED
+        and device.target == profile_hardware
+    )
+    return (
+        specific_match
+        or profile_hardware in device.families
+        or profile_hardware == HARDWARE_ANY
+    )
+
+
+def incompatible_reason(device: HardwareIdentity, profile_hardware: str) -> str | None:
+    """Human-readable reason a profile is greyed out, or ``None`` if compatible."""
+    if is_compatible(device, profile_hardware):
+        return None
+    if device.confidence != HardwareConfidence.CONFIRMED:
+        return (
+            "receiver hardware is unconfirmed — only family- or any-tagged "
+            "profiles are enabled"
+        )
+    return f"not for this hardware ({device.target})"
+
+
+def default_selection(
+    device: HardwareIdentity, profiles: Iterable[tuple[str, str]]
+) -> str | None:
+    """The deterministic default pick, or ``None``.
+
+    ``profiles`` is ``(name, hardware)`` pairs in fixed display order
+    (built-ins before customs, alphabetical within each group — the
+    caller owns that ordering). Returns the first compatible profile's
+    name, or ``None`` whenever confidence is not ``confirmed`` — the
+    default is never a guess.
+    """
+    if device.confidence != HardwareConfidence.CONFIRMED:
+        return None
+    for name, hardware in profiles:
+        if is_compatible(device, hardware):
+            return name
+    return None

--- a/src/sp_rtk_base/models/profile_models.py
+++ b/src/sp_rtk_base/models/profile_models.py
@@ -28,24 +28,27 @@ from sp_rtk_base.models.device_models import (
     RtcmRowId,
     UbxProtocol,
 )
+from sp_rtk_base.models.hardware_identity import (
+    HARDWARE_ANY,
+    KNOWN_FAMILY_TOKENS,
+    KNOWN_MODEL_TOKENS,
+)
 
 # ---------------------------------------------------------------------------
 # Hardware target tokens
+#
+# The identity-resolution catalog lives in ``hardware_identity`` — the
+# hardware-detection ticket (#60) that owns it — and is re-exported here so
+# a ``Profile`` can target any model or family that resolver can actually
+# produce, plus ``HARDWARE_ANY``.
 # ---------------------------------------------------------------------------
 
-#: Verbatim MON-VER MOD= model ids this app can target directly. The only
-#: entry needed today is the one built-in's hardware tag; the hardware-
-#: detection ticket owns the full identity catalog.
-KNOWN_HARDWARE_MODELS: frozenset[str] = frozenset({"ZED-F9P"})
+#: Verbatim MON-VER MOD= model ids a profile may target directly.
+KNOWN_HARDWARE_MODELS: frozenset[str] = KNOWN_MODEL_TOKENS
 
 #: Generation-level fallback tokens (a profile compatible with a whole
-#: hardware family rather than one specific model). Empty for now — no
-#: profile targets a family yet, and the token names themselves are the
-#: hardware-detection ticket's design to make, not this schema's to guess.
-KNOWN_HARDWARE_FAMILIES: frozenset[str] = frozenset()
-
-#: Token meaning "compatible with every receiver".
-HARDWARE_ANY: str = "any"
+#: hardware family rather than one specific model).
+KNOWN_HARDWARE_FAMILIES: frozenset[str] = KNOWN_FAMILY_TOKENS
 
 #: Schema major versions this running app understands.
 KNOWN_PROFILE_VERSIONS: frozenset[int] = frozenset({1})

--- a/src/sp_rtk_base/services/drivers/ublox.py
+++ b/src/sp_rtk_base/services/drivers/ublox.py
@@ -47,6 +47,7 @@ from sp_rtk_base.models.device_models import (
     SurveyInProgress,
     UbxProtocol,
 )
+from sp_rtk_base.models.hardware_identity import resolve_hardware_identity
 from sp_rtk_base.services.drivers.base import GpsReceiverDriver
 
 logger = logging.getLogger(__name__)
@@ -1737,18 +1738,12 @@ class UbloxDriver(GpsReceiverDriver):
         ser.reset_input_buffer()
         ser.write(poll_msg.serialize())
 
-        model = "Unknown"
         sw_version_str = ""
         fwver = ""
         protocol = ""
         hardware = ""
-
-        # Hardware version → model lookup for common u-blox receivers
-        _hw_model_map: dict[str, str] = {
-            "00190000": "ZED-F9P",
-            "001B0000": "ZED-F9R",
-            "00180000": "NEO-M9N",
-        }
+        mod = ""
+        explicit_model = ""
 
         deadline = time.monotonic() + self.CONNECT_TIMEOUT
 
@@ -1814,26 +1809,33 @@ class UbloxDriver(GpsReceiverDriver):
                                 # e.g. "PROTVER=27.31" → "27.31"
                                 protocol = ext_str.split("=", 1)[1].strip()
                             elif "MOD=" in ext_str:
-                                model = ext_str.split("=", 1)[1].strip()
+                                mod = ext_str.split("=", 1)[1].strip()
                             elif any(
                                 m in ext_str
                                 for m in ("ZED-", "NEO-", "MAX-", "SAM-", "LEA-")
                             ):
-                                model = ext_str.strip()
+                                explicit_model = ext_str.strip()
 
                         # Firmware: prefer FWVER (HPG version), fallback to swVersion
                         firmware = fwver if fwver else sw_version_str
 
-                        # Fallback: infer model from hardware version
-                        if model == "Unknown" and hardware in _hw_model_map:
-                            model = _hw_model_map[hardware]
-
-                        # Fallback: infer from firmware string
-                        if model == "Unknown":
-                            if "HPG" in firmware:
-                                model = "ZED-F9P"
-                            elif "ADR" in firmware:
-                                model = "ZED-F9R"
+                        # Confidence-tiered identity resolution — see
+                        # models.hardware_identity for the tier ladder.
+                        # A guessed model (tiers 4-5, `inferred`) is never
+                        # indistinguishable from a real read (tiers 1-3,
+                        # `confirmed`): both are surfaced, but only a
+                        # `confirmed` target can unlock a specific-model
+                        # profile match.
+                        identity = resolve_hardware_identity(
+                            mod=mod,
+                            explicit_model=explicit_model,
+                            hw_version=hardware,
+                            firmware=firmware,
+                            protocol_version=protocol,
+                        )
+                        model = (
+                            identity.target if identity.is_specific_model else "Unknown"
+                        )
 
                         return DeviceInfo(
                             vendor="u-blox",
@@ -1841,6 +1843,8 @@ class UbloxDriver(GpsReceiverDriver):
                             firmware_version=firmware,
                             protocol_version=protocol,
                             hardware_version=hardware,
+                            hardware_target=identity.target,
+                            hardware_confidence=identity.confidence,
                         )
             except Exception:
                 continue

--- a/tests/unit/test_api_profiles.py
+++ b/tests/unit/test_api_profiles.py
@@ -3,12 +3,56 @@
 from __future__ import annotations
 
 from typing import Any
+from unittest.mock import MagicMock
 
+import pytest
 from fastapi.testclient import TestClient
 
+from sp_rtk_base.app import create_api_app
+from sp_rtk_base.models.device_models import DeviceInfo
+from sp_rtk_base.models.hardware_identity import HardwareConfidence
+from sp_rtk_base.services import get_device_service, get_profile_store
+from sp_rtk_base.services.config_service import ConfigService
+from sp_rtk_base.services.device_service import DeviceService
+from sp_rtk_base.services.metrics_service import MetricsService
 from sp_rtk_base.services.profile_store import ProfileStore
 
 BUILTIN_NAME = "ublox-f9p-base-standard"
+
+
+@pytest.fixture()
+def mock_device_service() -> DeviceService:
+    """Create a mock DeviceService, disconnected (device_info=None) by default."""
+    svc = MagicMock(spec=DeviceService)
+    svc.device_info = None
+    return svc
+
+
+@pytest.fixture()
+def api_client_with_device(
+    mock_config_service: ConfigService,
+    mock_relay_service: MagicMock,
+    mock_event_bridge: MagicMock,
+    mock_metrics_service: MetricsService,
+    mock_profile_store: ProfileStore,
+    mock_device_service: DeviceService,
+) -> TestClient:
+    """``api_client_with_services`` plus an overridable device service."""
+    from sp_rtk_base.services import (
+        get_config_service,
+        get_event_bridge,
+        get_metrics_service,
+        get_relay_service,
+    )
+
+    app = create_api_app()
+    app.dependency_overrides[get_config_service] = lambda: mock_config_service
+    app.dependency_overrides[get_relay_service] = lambda: mock_relay_service
+    app.dependency_overrides[get_event_bridge] = lambda: mock_event_bridge
+    app.dependency_overrides[get_metrics_service] = lambda: mock_metrics_service
+    app.dependency_overrides[get_profile_store] = lambda: mock_profile_store
+    app.dependency_overrides[get_device_service] = lambda: mock_device_service
+    return TestClient(app)
 
 
 def _profile_payload(name: str = "my-custom", **overrides: Any) -> dict[str, Any]:
@@ -231,3 +275,71 @@ class TestMalformedCustomFileDoesNotBreakListing:
         names = [item["profile"]["name"] for item in resp.json()["profiles"]]
         assert "good" in names
         assert len(names) == 2  # builtin + good; corrupt.yaml silently skipped
+
+
+class TestHardwareIdentityInListing:
+    """GET /api/profiles carries the resolved receiver identity and tags
+    each profile with compatibility against it (issue #60)."""
+
+    def test_no_device_is_unknown_with_no_default_and_incompatible_builtin(
+        self, api_client_with_device: TestClient
+    ) -> None:
+        resp = api_client_with_device.get("/api/profiles")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["hardware_target"] == "unknown"
+        assert data["hardware_confidence"] == "unknown"
+        assert data["default_selection"] is None
+
+        builtin = next(
+            item for item in data["profiles"] if item["profile"]["name"] == BUILTIN_NAME
+        )
+        assert builtin["compatible"] is False
+        assert builtin["incompatible_reason"] is not None
+
+    def test_confirmed_matching_device_defaults_to_it_and_is_compatible(
+        self,
+        api_client_with_device: TestClient,
+        mock_device_service: DeviceService,
+    ) -> None:
+        mock_device_service.device_info = DeviceInfo(  # type: ignore[misc]
+            vendor="u-blox",
+            model="ZED-F9P",
+            hardware_target="ZED-F9P",
+            hardware_confidence=HardwareConfidence.CONFIRMED,
+        )
+
+        resp = api_client_with_device.get("/api/profiles")
+        data = resp.json()
+        assert data["hardware_target"] == "ZED-F9P"
+        assert data["hardware_confidence"] == "confirmed"
+        assert data["default_selection"] == BUILTIN_NAME
+
+        builtin = next(
+            item for item in data["profiles"] if item["profile"]["name"] == BUILTIN_NAME
+        )
+        assert builtin["compatible"] is True
+        assert builtin["incompatible_reason"] is None
+
+    def test_inferred_identity_never_unlocks_a_specific_model_default(
+        self,
+        api_client_with_device: TestClient,
+        mock_device_service: DeviceService,
+    ) -> None:
+        mock_device_service.device_info = DeviceInfo(  # type: ignore[misc]
+            vendor="u-blox",
+            model="ZED-F9P",
+            hardware_target="ZED-F9P",
+            hardware_confidence=HardwareConfidence.INFERRED,
+        )
+
+        resp = api_client_with_device.get("/api/profiles")
+        data = resp.json()
+        assert data["hardware_confidence"] == "inferred"
+        assert data["default_selection"] is None
+
+        builtin = next(
+            item for item in data["profiles"] if item["profile"]["name"] == BUILTIN_NAME
+        )
+        assert builtin["compatible"] is False
+        assert "unconfirmed" in (builtin["incompatible_reason"] or "")

--- a/tests/unit/test_hardware_identity.py
+++ b/tests/unit/test_hardware_identity.py
@@ -1,0 +1,180 @@
+"""Tests for hardware identity resolution and the compatibility filter.
+
+Covers the tier ladder (models.hardware_identity.resolve_hardware_identity),
+the one-line compatibility rule, the incompatible-reason messaging, and
+deterministic default selection.
+"""
+
+from __future__ import annotations
+
+from sp_rtk_base.models.hardware_identity import (
+    HARDWARE_ANY,
+    HARDWARE_UNKNOWN,
+    HardwareConfidence,
+    HardwareIdentity,
+    default_selection,
+    identity_from_target,
+    incompatible_reason,
+    is_compatible,
+    resolve_hardware_identity,
+)
+
+
+class TestResolveHardwareIdentityTiers:
+    """The five-tier resolution ladder, each attached to a confidence."""
+
+    def test_tier1_mod_extension_is_confirmed(self) -> None:
+        identity = resolve_hardware_identity(mod="ZED-F9P")
+        assert identity.target == "ZED-F9P"
+        assert identity.confidence == HardwareConfidence.CONFIRMED
+        assert identity.families == frozenset({"gen9"})
+
+    def test_tier2_explicit_model_string_is_confirmed(self) -> None:
+        identity = resolve_hardware_identity(explicit_model="NEO-M9N")
+        assert identity.target == "NEO-M9N"
+        assert identity.confidence == HardwareConfidence.CONFIRMED
+
+    def test_tier1_takes_priority_over_tier2(self) -> None:
+        identity = resolve_hardware_identity(mod="ZED-F9P", explicit_model="NEO-M9N")
+        assert identity.target == "ZED-F9P"
+
+    def test_tier3_hw_version_lookup_is_confirmed(self) -> None:
+        identity = resolve_hardware_identity(hw_version="00190000")
+        assert identity.target == "ZED-F9P"
+        assert identity.confidence == HardwareConfidence.CONFIRMED
+
+    def test_tier3_unrecognised_hw_version_falls_through(self) -> None:
+        identity = resolve_hardware_identity(hw_version="deadbeef")
+        assert identity.confidence == HardwareConfidence.UNKNOWN
+
+    def test_tier4_firmware_family_heuristic_is_inferred(self) -> None:
+        identity = resolve_hardware_identity(firmware="EXT CORE HPG 1.32")
+        assert identity.target == "ZED-F9P"
+        assert identity.confidence == HardwareConfidence.INFERRED
+        assert identity.families == frozenset({"gen9"})
+
+    def test_tier4_adr_firmware_maps_to_f9r(self) -> None:
+        identity = resolve_hardware_identity(firmware="EXT CORE ADR 1.32")
+        assert identity.target == "ZED-F9R"
+        assert identity.confidence == HardwareConfidence.INFERRED
+
+    def test_tier5_protver_family_only_is_inferred(self) -> None:
+        identity = resolve_hardware_identity(protocol_version="27.31")
+        assert identity.target == "gen9"
+        assert identity.confidence == HardwareConfidence.INFERRED
+        assert identity.families == frozenset({"gen9"})
+        assert identity.is_specific_model is False
+
+    def test_nothing_matches_is_unknown(self) -> None:
+        identity = resolve_hardware_identity()
+        assert identity.target == HARDWARE_UNKNOWN
+        assert identity.confidence == HardwareConfidence.UNKNOWN
+        assert identity.families == frozenset()
+
+    def test_unrecognised_protver_falls_through_to_unknown(self) -> None:
+        identity = resolve_hardware_identity(protocol_version="99.0")
+        assert identity.confidence == HardwareConfidence.UNKNOWN
+
+    def test_never_raises_on_garbage_input(self) -> None:
+        identity = resolve_hardware_identity(
+            mod="",
+            explicit_model="",
+            hw_version="???",
+            firmware="",
+            protocol_version="",
+        )
+        assert identity.confidence == HardwareConfidence.UNKNOWN
+
+    def test_unrecognised_mod_string_passes_through_verbatim_confirmed(self) -> None:
+        # A new receiver (e.g. ZED-X20P) is supported by adding a profile
+        # tagged with its MOD= string, not by editing this module — MOD=
+        # is trusted verbatim regardless of whether it's in any catalog.
+        identity = resolve_hardware_identity(mod="ZED-X20P")
+        assert identity.target == "ZED-X20P"
+        assert identity.confidence == HardwareConfidence.CONFIRMED
+        assert identity.families == frozenset()
+
+
+class TestIsCompatible:
+    """The one-line rule: specific-model, family, any, and the non-matches."""
+
+    def test_confirmed_specific_model_match(self) -> None:
+        device = identity_from_target("ZED-F9P", HardwareConfidence.CONFIRMED)
+        assert is_compatible(device, "ZED-F9P") is True
+
+    def test_inferred_specific_model_never_matches(self) -> None:
+        # A guessed model can never unlock a specific-model profile.
+        device = identity_from_target("ZED-F9P", HardwareConfidence.INFERRED)
+        assert is_compatible(device, "ZED-F9P") is False
+
+    def test_family_match_regardless_of_confidence(self) -> None:
+        device = identity_from_target("gen9", HardwareConfidence.INFERRED)
+        assert is_compatible(device, "gen9") is True
+
+    def test_any_always_matches(self) -> None:
+        device = identity_from_target(HARDWARE_UNKNOWN, HardwareConfidence.UNKNOWN)
+        assert is_compatible(device, HARDWARE_ANY) is True
+
+    def test_non_match(self) -> None:
+        device = identity_from_target("ZED-F9P", HardwareConfidence.CONFIRMED)
+        assert is_compatible(device, "ZED-F9R") is False
+
+    def test_confirmed_model_family_tagged_profile_matches_via_family(self) -> None:
+        device = identity_from_target("ZED-F9P", HardwareConfidence.CONFIRMED)
+        assert is_compatible(device, "gen9") is True
+
+
+class TestIncompatibleReason:
+    def test_none_when_compatible(self) -> None:
+        device = identity_from_target("ZED-F9P", HardwareConfidence.CONFIRMED)
+        assert incompatible_reason(device, "ZED-F9P") is None
+
+    def test_names_the_hardware_when_confirmed_but_non_matching(self) -> None:
+        device = identity_from_target("ZED-F9P", HardwareConfidence.CONFIRMED)
+        reason = incompatible_reason(device, "ZED-F9R")
+        assert reason is not None
+        assert "ZED-F9P" in reason
+
+    def test_unconfirmed_reason_does_not_leak_a_specific_guess(self) -> None:
+        device = identity_from_target("ZED-F9P", HardwareConfidence.INFERRED)
+        reason = incompatible_reason(device, "ZED-F9P")
+        assert reason is not None
+        assert "unconfirmed" in reason
+        assert "ZED-F9P" not in reason
+
+
+class TestDefaultSelection:
+    _ordered = [("ublox-f9p-base-standard", "ZED-F9P"), ("zzz-custom", "any")]
+
+    def test_picks_first_compatible_in_order(self) -> None:
+        device = identity_from_target("ZED-F9P", HardwareConfidence.CONFIRMED)
+        assert default_selection(device, self._ordered) == "ublox-f9p-base-standard"
+
+    def test_null_when_no_compatible_profile(self) -> None:
+        device = identity_from_target("ZED-F9R", HardwareConfidence.CONFIRMED)
+        assert default_selection(device, [("f9p-only", "ZED-F9P")]) is None
+
+    def test_null_when_confidence_is_inferred(self) -> None:
+        device = identity_from_target("ZED-F9P", HardwareConfidence.INFERRED)
+        assert default_selection(device, self._ordered) is None
+
+    def test_null_when_confidence_is_unknown(self) -> None:
+        device = identity_from_target(HARDWARE_UNKNOWN, HardwareConfidence.UNKNOWN)
+        assert default_selection(device, self._ordered) is None
+
+
+class TestHardwareIdentityIsSpecificModel:
+    def test_specific_model_is_specific(self) -> None:
+        assert HardwareIdentity(
+            target="ZED-F9P", confidence=HardwareConfidence.CONFIRMED
+        ).is_specific_model
+
+    def test_family_token_is_not_specific(self) -> None:
+        assert not HardwareIdentity(
+            target="gen9", confidence=HardwareConfidence.INFERRED
+        ).is_specific_model
+
+    def test_unknown_is_not_specific(self) -> None:
+        assert not HardwareIdentity(
+            target=HARDWARE_UNKNOWN, confidence=HardwareConfidence.UNKNOWN
+        ).is_specific_model

--- a/tests/unit/test_profile_models.py
+++ b/tests/unit/test_profile_models.py
@@ -215,8 +215,12 @@ class TestProfile:
         with pytest.raises(ValidationError, match="version"):
             Profile.model_validate(kwargs)
 
-    @pytest.mark.parametrize("hardware", ["ZED-F9P", "any"])
+    @pytest.mark.parametrize(
+        "hardware", ["ZED-F9P", "ZED-F9R", "NEO-M9N", "gen9", "any"]
+    )
     def test_known_hardware_tokens_accepted(self, hardware: str) -> None:
+        # The model/family catalog is owned by the hardware-detection
+        # ticket (#60) and re-exported from models.hardware_identity.
         kwargs = self._profile_kwargs()
         kwargs["hardware"] = hardware
         profile = Profile.model_validate(kwargs)
@@ -229,10 +233,10 @@ class TestProfile:
             Profile.model_validate(kwargs)
 
     def test_unregistered_family_token_rejected(self) -> None:
-        # No family tokens are registered yet — that catalog belongs to
-        # the (not-yet-built) hardware-detection ticket, not this schema.
+        # "gen10" has no shipped receiver or PROTVER range backing it yet
+        # (see hardware_identity.KNOWN_FAMILY_TOKENS) — not a valid target.
         kwargs = self._profile_kwargs()
-        kwargs["hardware"] = "gen9"
+        kwargs["hardware"] = "gen10"
         with pytest.raises(ValidationError, match="hardware"):
             Profile.model_validate(kwargs)
 

--- a/tests/unit/test_ublox_driver.py
+++ b/tests/unit/test_ublox_driver.py
@@ -231,6 +231,30 @@ class TestUbloxDriverConnect:
             exclusive=True,
         )
 
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_connect_reports_confirmed_hardware_identity(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+    ) -> None:
+        """MOD=ZED-F9P (tier 1) is a real read, not a guess."""
+        from sp_rtk_base.models.hardware_identity import HardwareConfidence
+
+        ser = MagicMock()
+        ser.is_open = True
+        mock_serial_cls.return_value = ser
+
+        reader = MagicMock()
+        reader.read.return_value = (b"", _make_mon_ver_response())
+        mock_reader_cls.return_value = reader
+
+        driver = UbloxDriver()
+        info = driver.connect("/dev/ttyUSB0")
+
+        assert info.hardware_target == "ZED-F9P"
+        assert info.hardware_confidence == HardwareConfidence.CONFIRMED
+
     @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
     def test_connect_serial_exception(self, mock_serial_cls: MagicMock) -> None:
         import serial  # type: ignore[import-untyped]
@@ -1449,6 +1473,111 @@ class TestMonVerParsing:
         driver = UbloxDriver()
         info = driver.connect("/dev/ttyUSB0")
         assert info.model == "NEO-M9N"
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_mon_ver_hw_version_only_is_confirmed(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        """No MOD=/explicit model — hwVersion tier-3 lookup still confirms."""
+        from sp_rtk_base.models.hardware_identity import HardwareConfidence
+
+        ser = MagicMock()
+        ser.is_open = True
+        mock_serial_cls.return_value = ser
+
+        mon_ver = SimpleNamespace(
+            identity="MON-VER",
+            swVersion="EXT CORE 1.00",
+            hwVersion="00190000",
+            extension_00=None,
+        )
+
+        reader = MagicMock()
+        reader.read.return_value = (b"", mon_ver)
+        mock_reader_cls.return_value = reader
+
+        driver = UbloxDriver()
+        info = driver.connect("/dev/ttyUSB0")
+        assert info.model == "ZED-F9P"
+        assert info.hardware_target == "ZED-F9P"
+        assert info.hardware_confidence == HardwareConfidence.CONFIRMED
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_mon_ver_firmware_heuristic_is_inferred_not_confirmed(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        """No MOD=, no explicit model, unrecognised hwVersion — only the
+        firmware-family heuristic hits, so the guess must be `inferred`,
+        never indistinguishable from a real read."""
+        from sp_rtk_base.models.hardware_identity import HardwareConfidence
+
+        ser = MagicMock()
+        ser.is_open = True
+        mock_serial_cls.return_value = ser
+
+        mon_ver = SimpleNamespace(
+            identity="MON-VER",
+            swVersion="EXT CORE 1.00",
+            hwVersion="ffffffff",
+            extension_00="FWVER=HPG 1.32",
+            extension_01=None,
+        )
+
+        reader = MagicMock()
+        reader.read.return_value = (b"", mon_ver)
+        mock_reader_cls.return_value = reader
+
+        driver = UbloxDriver()
+        info = driver.connect("/dev/ttyUSB0")
+        # Displayed the same as a confirmed F9P, but confidence tells the
+        # truth — this is what unlocks/blocks a specific-model profile.
+        assert info.model == "ZED-F9P"
+        assert info.hardware_target == "ZED-F9P"
+        assert info.hardware_confidence == HardwareConfidence.INFERRED
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_mon_ver_nothing_resolves_is_unknown(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        """A receiver this app cannot identify at all — connect still
+        succeeds; identity comes back `unknown` rather than a bad guess."""
+        from sp_rtk_base.models.hardware_identity import HardwareConfidence
+
+        ser = MagicMock()
+        ser.is_open = True
+        mock_serial_cls.return_value = ser
+
+        mon_ver = SimpleNamespace(
+            identity="MON-VER",
+            swVersion="EXT CORE 1.00",
+            hwVersion="ffffffff",
+            extension_00=None,
+        )
+
+        reader = MagicMock()
+        reader.read.return_value = (b"", mon_ver)
+        mock_reader_cls.return_value = reader
+
+        driver = UbloxDriver()
+        info = driver.connect("/dev/ttyUSB0")
+        assert info.model == "Unknown"
+        assert info.hardware_target == "unknown"
+        assert info.hardware_confidence == HardwareConfidence.UNKNOWN
 
 
 class TestParseCfgTmode:


### PR DESCRIPTION
## Summary

- Adds `models/hardware_identity.py`: a five-tier resolution ladder (`MOD=`, an explicit model string, deterministic `hwVersion` lookup — all `confirmed`; firmware-family heuristic, PROTVER-generation fallback — both `inferred`; else `unknown`), the one-line compatibility rule (specific-model match gated on `confirmed` confidence, family match, `"any"` match), and deterministic default selection (`null` unless confidence is `confirmed`).
- `services/drivers/ublox.py`'s `_poll_mon_ver` now delegates to this resolver instead of storing a guessed model indistinguishably from a real `MOD=` read.
- `GET /api/profiles` now carries `hardware_target`, `hardware_confidence`, `default_selection`, and per-profile `compatible`/`incompatible_reason`.
- Consolidated `profile_models.py`'s hardware-token catalog (`KNOWN_HARDWARE_MODELS`/`KNOWN_HARDWARE_FAMILIES`/`HARDWARE_ANY`) to re-export `hardware_identity`'s, closing the two-sources-of-truth gap that module's own comments left open for this ticket to fill.

Closes #60.

## Test plan

- [x] `uv run pytest` — 1236 passed, 92.64% coverage (gate is 90%)
- [x] `uv run pyright src/` — clean
- [x] `uv run mypy src/` — clean
- [x] `uv run ruff check`/`format --check` — clean
- [x] New `tests/unit/test_hardware_identity.py` covers all five tiers, the compatibility rule's specific-model/family/`any`/non-match branches, `incompatible_reason` messaging, and `default_selection`'s null-unless-confirmed rule
- [x] Extended `test_ublox_driver.py` (tier 3/4/5 fallback paths, unresolved-identity-doesn't-block-connect) and `test_api_profiles.py` (hardware wiring into the list response)
- [x] Ran `/code-review` (Standards + Spec axes); one real finding (stale hardware catalog duplication) fixed before this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)