### PR TITLE
feat(device): apply-config endpoint with read-back verify

### DIFF
--- a/src/sp_rtk_base/api/device.py
+++ b/src/sp_rtk_base/api/device.py
@@ -17,6 +17,7 @@ from sp_rtk_base.models.config_models import (
     InputProfile,
 )
 from sp_rtk_base.models.device_models import (
+    ApplyConfigResult,
     CurrentBaseConfig,
     DeviceStatus,
     FixedBaseConfig,
@@ -29,13 +30,14 @@ from sp_rtk_base.models.device_models import (
     SurveyInConfig,
     SurveyInProgress,
 )
+from sp_rtk_base.models.profile_models import ReceiverConfig
 from sp_rtk_base.services import (
     get_config_service,
     get_device_service,
     get_relay_service,
 )
 from sp_rtk_base.services.config_service import ConfigService
-from sp_rtk_base.services.device_service import DeviceService
+from sp_rtk_base.services.device_service import ApplyConfigRefusedError, DeviceService
 from sp_rtk_base.services.drivers import create_driver
 from sp_rtk_base.services.relay_service import RelayService
 
@@ -273,6 +275,38 @@ async def get_port_protocols(
     """Read the live in/out protocol state for UART1, UART2 and USB."""
     try:
         return await svc.get_port_protocols()
+    except RuntimeError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
+# Apply-config — the profile one-shot (issue #61)
+# ---------------------------------------------------------------------------
+
+
+@router.post("/apply-config", response_model=ApplyConfigResult)
+async def apply_config(
+    config: ReceiverConfig,
+    svc: DeviceService = Depends(get_device_service),
+) -> ApplyConfigResult:
+    """Apply a bare ``ReceiverConfig`` to the receiver, verified with a read-back.
+
+    An ordered series of layer=5 writes (see
+    ``DeviceService.apply_receiver_config`` for the exact sequence and
+    guards), followed by a read-back of the RTCM matrix. A read-back
+    mismatch still returns 200 with ``status: "failed"`` and a
+    per-cell diff — the writes are left in flash, nothing is rolled
+    back.
+
+    Status contract: 409 if not connected or the relay is running;
+    422 for a schema violation (handled automatically by the
+    ``ReceiverConfig`` body validation); 400 for a business-rule
+    refusal, with the failed rule named and nothing written.
+    """
+    try:
+        return await svc.apply_receiver_config(config)
+    except ApplyConfigRefusedError as exc:
+        raise HTTPException(status_code=400, detail=f"{exc.rule}: {exc}") from exc
     except RuntimeError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 

--- a/src/sp_rtk_base/models/device_models.py
+++ b/src/sp_rtk_base/models/device_models.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import enum
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
@@ -161,6 +162,19 @@ class BaseMode(str, enum.Enum):
     DISABLED = "disabled"
     SURVEY_IN = "survey_in"
     FIXED = "fixed"
+
+
+class DynModel(str, enum.Enum):
+    """``CFG_NAVSPG_DYNMODEL`` — the receiver's dynamics platform model."""
+
+    STATIONARY = "stationary"
+    PORTABLE = "portable"
+    PEDESTRIAN = "pedestrian"
+    AUTOMOTIVE = "automotive"
+    SEA = "sea"
+    AIRBORNE_1G = "airborne_1g"
+    AIRBORNE_2G = "airborne_2g"
+    AIRBORNE_4G = "airborne_4g"
 
 
 class CurrentBaseConfig(BaseModel):
@@ -339,6 +353,37 @@ class UbxProtocol(str, enum.Enum):
     UBX = "UBX"
     NMEA = "NMEA"
     RTCM3X = "RTCM3X"
+
+
+# ---------------------------------------------------------------------------
+# Apply-config read-back verify (issue #61)
+# ---------------------------------------------------------------------------
+
+
+class ApplyConfigCellDiff(BaseModel):
+    """One mismatched cell from the post-apply RTCM matrix read-back."""
+
+    row_id: RtcmRowId
+    port: PortId
+    expected: bool
+    actual: bool
+
+
+class ApplyConfigResult(BaseModel):
+    """Response for ``POST /api/device/apply-config``.
+
+    ``status="failed"`` means the post-apply read-back of the RTCM
+    matrix didn't match what was written — the writes are left in
+    flash (nothing is rolled back); ``diff`` lists every mismatched
+    cell. ``warnings`` carries non-blocking advisories (e.g. the
+    estimated-throughput check) that never affect ``status``.
+    """
+
+    status: Literal["ok", "failed"]
+    diff: list[ApplyConfigCellDiff] = Field(
+        default_factory=lambda: list[ApplyConfigCellDiff]()
+    )
+    warnings: list[str] = Field(default_factory=lambda: list[str]())
 
 
 class PortProtocolConfig(BaseModel):

--- a/src/sp_rtk_base/models/profile_models.py
+++ b/src/sp_rtk_base/models/profile_models.py
@@ -15,14 +15,13 @@ coordinate guard are service-level and belong to the apply ticket.
 
 from __future__ import annotations
 
-import enum
-
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from sp_rtk_base.models.device_models import (
     BaseMode as TmodeMode,
 )
 from sp_rtk_base.models.device_models import (
+    DynModel,
     GnssConstellation,
     PortId,
     RtcmRowId,
@@ -69,19 +68,6 @@ _SANE_BAUD_MAX = 921600
 # or declared by a profile. Port protocols reuse ``device_models.UbxProtocol``
 # for the same reason.
 # ---------------------------------------------------------------------------
-
-
-class DynModel(str, enum.Enum):
-    """``CFG_NAVSPG_DYNMODEL`` — the receiver's dynamics platform model."""
-
-    STATIONARY = "stationary"
-    PORTABLE = "portable"
-    PEDESTRIAN = "pedestrian"
-    AUTOMOTIVE = "automotive"
-    SEA = "sea"
-    AIRBORNE_1G = "airborne_1g"
-    AIRBORNE_2G = "airborne_2g"
-    AIRBORNE_4G = "airborne_4g"
 
 
 # ---------------------------------------------------------------------------

--- a/src/sp_rtk_base/services/device_service.py
+++ b/src/sp_rtk_base/services/device_service.py
@@ -15,6 +15,8 @@ from datetime import datetime, timezone
 from typing import Protocol
 
 from sp_rtk_base.models.device_models import (
+    ApplyConfigCellDiff,
+    ApplyConfigResult,
     CurrentBaseConfig,
     DeviceCapability,
     DeviceConnectionState,
@@ -23,15 +25,102 @@ from sp_rtk_base.models.device_models import (
     FixedBaseConfig,
     GnssConfig,
     GpsPosition,
+    PortId,
     PortProtocolConfig,
     RtcmMessageConfig,
     RtcmPortConfig,
+    RtcmRowId,
     SurveyInConfig,
     SurveyInProgress,
+    UbxProtocol,
 )
+from sp_rtk_base.models.device_models import (
+    BaseMode as TmodeMode,
+)
+from sp_rtk_base.models.profile_models import ReceiverConfig
 from sp_rtk_base.services.drivers.base import GpsReceiverDriver
 
 logger = logging.getLogger(__name__)
+
+
+class ApplyConfigRefusedError(Exception):
+    """Business-rule refusal for ``apply_receiver_config`` — device-state guards.
+
+    Raised before any write when a live-receiver-state precondition
+    isn't met (issue #61): the UBX-in liveness guard or the
+    ``tmode_mode: fixed`` coordinate guard. Carries the failed rule
+    name so the API can surface it in a 400 response.
+    """
+
+    def __init__(self, rule: str, message: str) -> None:
+        self.rule = rule
+        super().__init__(message)
+
+
+# ---------------------------------------------------------------------------
+# Non-blocking RTCM throughput estimate (issue #61)
+#
+# Approximate typical RTCM3 frame sizes in bytes at a moderate satellite
+# count. These are estimates for a heads-up warning only — not exact
+# wire measurements — so precision beyond "roughly right" isn't the
+# goal. MSM4/MSM7 sizes scale with tracked satellite count; the values
+# below assume a typical 8-12 satellites per constellation.
+# ---------------------------------------------------------------------------
+
+_APPROX_RTCM_FRAME_BYTES: dict[RtcmRowId, int] = {
+    RtcmRowId.RTCM_1005: 19,
+    RtcmRowId.RTCM_4072_0: 72,
+    RtcmRowId.RTCM_4072_1: 40,
+    RtcmRowId.RTCM_1074: 150,
+    RtcmRowId.RTCM_1077: 300,
+    RtcmRowId.RTCM_1084: 130,
+    RtcmRowId.RTCM_1087: 260,
+    RtcmRowId.RTCM_1094: 120,
+    RtcmRowId.RTCM_1097: 240,
+    RtcmRowId.RTCM_1124: 130,
+    RtcmRowId.RTCM_1127: 260,
+    RtcmRowId.RTCM_1230: 25,
+}
+
+# 8N1 serial framing: ~10 bits on the wire per payload byte (1 start +
+# 8 data + 1 stop), so baud / 10 approximates byte capacity per second.
+_BITS_PER_BYTE_ON_WIRE = 10.0
+
+# Warn once estimated RTCM throughput crosses this fraction of a
+# data-link port's baud capacity.
+_THROUGHPUT_WARN_THRESHOLD = 0.70
+
+
+def _throughput_warnings(
+    matrix: dict[RtcmRowId, dict[PortId, bool]],
+    data_link_ports: list[PortId],
+    meas_period_ms: int,
+    baud_rates: dict[PortId, int],
+) -> list[str]:
+    """Non-blocking advisories when estimated RTCM output nears port capacity."""
+    hz = 1000.0 / meas_period_ms
+    warnings: list[str] = []
+    for port in data_link_ports:
+        baud = baud_rates.get(port)
+        if not baud:
+            continue
+        bytes_per_sec = (
+            sum(
+                _APPROX_RTCM_FRAME_BYTES.get(row, 0)
+                for row, ports in matrix.items()
+                if ports.get(port, False)
+            )
+            * hz
+        )
+        capacity_bytes_per_sec = baud / _BITS_PER_BYTE_ON_WIRE
+        fraction = bytes_per_sec / capacity_bytes_per_sec
+        if fraction > _THROUGHPUT_WARN_THRESHOLD:
+            warnings.append(
+                f"Estimated RTCM throughput on {port.value} is "
+                f"~{round(fraction * 100)}% of its {baud} baud capacity "
+                "— consider a higher baud rate or fewer messages."
+            )
+    return warnings
 
 
 class DeviceService:
@@ -565,6 +654,162 @@ class DeviceService:
             self._state = DeviceConnectionState.CONNECTED
             self._last_error = str(exc)
             raise
+
+    # ------------------------------------------------------------------
+    # Apply-config — the profile one-shot (issue #61)
+    # ------------------------------------------------------------------
+
+    async def apply_receiver_config(self, config: ReceiverConfig) -> ApplyConfigResult:
+        """Apply a bare ``ReceiverConfig`` as an ordered series of layer=5 writes.
+
+        Sequence: guards -> measurement rate -> ports -> constellations
+        -> optimisations -> role fields (dyn_model, then tmode_mode) ->
+        the full RTCM matrix -> read-back verify. Baud is out of scope
+        here entirely — ``ReceiverConfig.baud`` is never read by this
+        method.
+
+        Guards run before any write and refuse with nothing written:
+
+        - **UBX-in liveness.** This console always manages the receiver
+          over its own USB connection — UART1/UART2 are reserved for
+          RTCM data-link output (``ReceiverConfig`` only allows those
+          two as ``data_link_port``). So "the connected port" is
+          always ``PortId.USB``; a submitted ``ports`` section that
+          would turn UBX off on USB IN is refused, since it would cut
+          the console's own control channel with nothing left to
+          write it back with.
+        - **Coordinate guard.** ``tmode_mode: fixed`` is refused unless
+          the receiver already holds a valid, non-zero position —
+          otherwise a fresh receiver becomes a base broadcasting 1005
+          from ECEF/LLH 0,0,0.
+
+        After the writes land, a non-blocking throughput estimate
+        checks each ``data_link_port`` against its live baud rate, and
+        a final read-back of the full RTCM matrix decides ``status``:
+        a mismatch returns ``status="failed"`` with a per-cell diff
+        (writes are left in flash, nothing is rolled back); a match
+        returns ``status="ok"``.
+
+        Raises:
+            RuntimeError: If not connected or relay is running.
+            ApplyConfigRefusedError: If a device-state guard rejects the
+                config before any write.
+        """
+        driver = self._require_connected()
+
+        if config.ports is not None:
+            usb_ports = config.ports.get(PortId.USB)
+            if usb_ports is not None and UbxProtocol.UBX not in usb_ports.in_:
+                raise ApplyConfigRefusedError(
+                    "ubx_in_liveness",
+                    "ports.USB.in must keep UBX enabled — the console manages "
+                    "the receiver over its own USB connection",
+                )
+
+        if config.tmode_mode == TmodeMode.FIXED:
+            current_base = await asyncio.to_thread(driver.get_base_config)
+            if (
+                current_base.latitude == 0.0
+                and current_base.longitude == 0.0
+                and current_base.altitude_m == 0.0
+            ):
+                raise ApplyConfigRefusedError(
+                    "tmode_fixed_requires_coordinates",
+                    "tmode_mode=fixed requires the receiver to already hold a "
+                    "valid, non-zero position — survey-in or restore a saved "
+                    "position first",
+                )
+
+        self._state = DeviceConnectionState.CONFIGURING
+        try:
+            await asyncio.to_thread(
+                driver.configure_measurement_rate, config.meas_period_ms
+            )
+
+            if config.ports:
+                in_map = {port: cfg.in_ for port, cfg in config.ports.items()}
+                out_map = {port: cfg.out for port, cfg in config.ports.items()}
+                await asyncio.to_thread(
+                    driver.configure_port_protocols, in_map, out_map
+                )
+
+            if config.constellations is not None:
+                current_gnss = await asyncio.to_thread(driver.get_gnss_config)
+                wanted = set(config.constellations)
+                updated_gnss = GnssConfig(
+                    systems=[
+                        system.model_copy(
+                            update={"enabled": system.constellation in wanted}
+                        )
+                        for system in current_gnss.systems
+                    ]
+                )
+                await asyncio.to_thread(driver.configure_gnss, updated_gnss)
+
+            await asyncio.to_thread(
+                driver.configure_optimisations,
+                config.elevation_mask_deg,
+                config.bds_b2_enabled,
+                config.spi_enabled,
+            )
+
+            if config.dyn_model is not None:
+                await asyncio.to_thread(driver.configure_dyn_model, config.dyn_model)
+            if config.tmode_mode is not None:
+                await asyncio.to_thread(driver.configure_tmode_mode, config.tmode_mode)
+
+            await asyncio.to_thread(driver.apply_rtcm_matrix, config.rtcm_stream.matrix)
+
+            self._state = DeviceConnectionState.CONNECTED
+        except Exception as exc:
+            self._state = DeviceConnectionState.CONNECTED
+            self._last_error = str(exc)
+            raise
+
+        baud_rates = await asyncio.to_thread(driver.get_uart_baud_rates)
+        warnings = _throughput_warnings(
+            config.rtcm_stream.matrix,
+            config.data_link_port,
+            config.meas_period_ms,
+            baud_rates,
+        )
+
+        actual_rtcm = await asyncio.to_thread(driver.get_rtcm_port_config)
+        diff = self._diff_rtcm_matrix(config.rtcm_stream.matrix, actual_rtcm)
+        if diff:
+            logger.warning(
+                "apply-config read-back mismatch: %d cell(s) differ", len(diff)
+            )
+            return ApplyConfigResult(status="failed", diff=diff, warnings=warnings)
+
+        logger.info("apply-config applied and read-back verified")
+        return ApplyConfigResult(status="ok", warnings=warnings)
+
+    @staticmethod
+    def _diff_rtcm_matrix(
+        expected: dict[RtcmRowId, dict[PortId, bool]],
+        actual: RtcmPortConfig,
+    ) -> list[ApplyConfigCellDiff]:
+        """Diff the intended RTCM matrix against a live read-back.
+
+        Covers all 36 cells (12 rows x UART1/UART2/USB) — the same
+        scope ``apply_rtcm_matrix`` writes.
+        """
+        diffs: list[ApplyConfigCellDiff] = []
+        for row in RtcmRowId:
+            for port in (PortId.UART1, PortId.UART2, PortId.USB):
+                expected_on = expected.get(row, {}).get(port, False)
+                actual_on = actual.messages.get(row, {}).get(port.value, 0) > 0
+                if expected_on != actual_on:
+                    diffs.append(
+                        ApplyConfigCellDiff(
+                            row_id=row,
+                            port=port,
+                            expected=expected_on,
+                            actual=actual_on,
+                        )
+                    )
+        return diffs
 
     # ------------------------------------------------------------------
     # Status polling

--- a/src/sp_rtk_base/services/device_service.py
+++ b/src/sp_rtk_base/services/device_service.py
@@ -92,15 +92,19 @@ _THROUGHPUT_WARN_THRESHOLD = 0.70
 
 
 def _throughput_warnings(
-    matrix: dict[RtcmRowId, dict[PortId, bool]],
-    data_link_ports: list[PortId],
-    meas_period_ms: int,
-    baud_rates: dict[PortId, int],
+    config: ReceiverConfig, baud_rates: dict[PortId, int]
 ) -> list[str]:
-    """Non-blocking advisories when estimated RTCM output nears port capacity."""
-    hz = 1000.0 / meas_period_ms
+    """Non-blocking advisories when estimated RTCM output nears port capacity.
+
+    Takes the whole ``ReceiverConfig`` rather than its three relevant
+    fields individually — ``rtcm_stream.matrix``, ``data_link_port``
+    and ``meas_period_ms`` only ever travel together for this check,
+    and the config already bundles them.
+    """
+    matrix = config.rtcm_stream.matrix
+    hz = 1000.0 / config.meas_period_ms
     warnings: list[str] = []
-    for port in data_link_ports:
+    for port in config.data_link_port:
         baud = baud_rates.get(port)
         if not baud:
             continue
@@ -665,11 +669,16 @@ class DeviceService:
         Sequence: guards -> measurement rate -> ports -> constellations
         -> optimisations -> role fields (dyn_model, then tmode_mode) ->
         the full RTCM matrix -> read-back verify. Baud is out of scope
-        here entirely — ``ReceiverConfig.baud`` is never read by this
-        method.
+        here entirely — a submitted non-null ``ReceiverConfig.baud`` is
+        rejected pre-write rather than silently ignored (see the follow-up
+        ticket for baud support).
 
         Guards run before any write and refuse with nothing written:
 
+        - **Baud out of scope.** A non-null ``baud`` with either UART
+          value set is refused — applying it would mean reopening the
+          serial link this very request is using, which is explicitly
+          the follow-up ticket's job, not this one's.
         - **UBX-in liveness.** This console always manages the receiver
           over its own USB connection — UART1/UART2 are reserved for
           RTCM data-link output (``ReceiverConfig`` only allows those
@@ -696,6 +705,15 @@ class DeviceService:
                 config before any write.
         """
         driver = self._require_connected()
+
+        if config.baud is not None and (
+            config.baud.uart1 is not None or config.baud.uart2 is not None
+        ):
+            raise ApplyConfigRefusedError(
+                "baud_out_of_scope",
+                "baud is out of scope for apply-config — it would disturb "
+                "the console's own link; leave it unset",
+            )
 
         if config.ports is not None:
             usb_ports = config.ports.get(PortId.USB)
@@ -767,12 +785,7 @@ class DeviceService:
             raise
 
         baud_rates = await asyncio.to_thread(driver.get_uart_baud_rates)
-        warnings = _throughput_warnings(
-            config.rtcm_stream.matrix,
-            config.data_link_port,
-            config.meas_period_ms,
-            baud_rates,
-        )
+        warnings = _throughput_warnings(config, baud_rates)
 
         actual_rtcm = await asyncio.to_thread(driver.get_rtcm_port_config)
         diff = self._diff_rtcm_matrix(config.rtcm_stream.matrix, actual_rtcm)

--- a/src/sp_rtk_base/services/drivers/base.py
+++ b/src/sp_rtk_base/services/drivers/base.py
@@ -10,18 +10,23 @@ from __future__ import annotations
 import abc
 
 from sp_rtk_base.models.device_models import (
+    BaseMode,
     CurrentBaseConfig,
     DeviceCapability,
     DeviceInfo,
+    DynModel,
     FixedBaseConfig,
     GnssConfig,
     GpsPosition,
+    PortId,
     PortProtocolConfig,
     RtcmMessageConfig,
     RtcmPortConfig,
+    RtcmRowId,
     SerialPortInfo,
     SurveyInConfig,
     SurveyInProgress,
+    UbxProtocol,
 )
 
 
@@ -194,6 +199,130 @@ class GpsReceiverDriver(abc.ABC):
         Raises:
             ConnectionError: If not connected.
             RuntimeError: If save fails.
+        """
+
+    # ------------------------------------------------------------------
+    # Apply-config primitives (issue #61)
+    #
+    # Lower-level writers the apply-config service orchestrates in a
+    # fixed order. Each is independently callable and independently
+    # verified — none of them know about ``ReceiverConfig``, keeping
+    # the profile schema out of the vendor-neutral driver layer.
+    # ------------------------------------------------------------------
+
+    @abc.abstractmethod
+    def configure_port_protocols(
+        self,
+        in_protocols: dict[PortId, list[UbxProtocol]],
+        out_protocols: dict[PortId, list[UbxProtocol]],
+    ) -> None:
+        """Assertive per-port in/out protocol write for the ports given.
+
+        Only ports present in either mapping are touched — a port with
+        no entry in either dict keeps its current state untouched.
+
+        Args:
+            in_protocols: port -> exactly the input protocols that
+                should be enabled (every other protocol on that port
+                is turned off).
+            out_protocols: same, for output protocols.
+
+        Raises:
+            ConnectionError: If not connected.
+            RuntimeError: If the write fails.
+        """
+
+    @abc.abstractmethod
+    def configure_measurement_rate(self, period_ms: int) -> None:
+        """Write the measurement period in milliseconds.
+
+        Args:
+            period_ms: Raw ``CFG_RATE_MEAS`` period in ms (not Hz).
+                ``CFG_RATE_NAV`` is pinned to 1 alongside it.
+
+        Raises:
+            ConnectionError: If not connected.
+            RuntimeError: If the write fails.
+        """
+
+    @abc.abstractmethod
+    def configure_dyn_model(self, model: DynModel) -> None:
+        """Write the receiver's dynamics platform model.
+
+        Args:
+            model: Desired dynamics class.
+
+        Raises:
+            ConnectionError: If not connected.
+            RuntimeError: If the write fails.
+        """
+
+    @abc.abstractmethod
+    def configure_tmode_mode(self, mode: BaseMode) -> None:
+        """Write ``CFG_TMODE_MODE`` directly, without touching position keys.
+
+        A plain mode assertion, not a full base-mode transition —
+        callers that need survey-in/fixed-base position writes should
+        use ``configure_survey_in``/``configure_fixed_base`` instead.
+        Any coordinate precondition for ``fixed`` mode is the caller's
+        responsibility.
+
+        Args:
+            mode: Desired TMODE mode.
+
+        Raises:
+            ConnectionError: If not connected.
+            RuntimeError: If the write fails.
+        """
+
+    @abc.abstractmethod
+    def configure_optimisations(
+        self,
+        elevation_mask_deg: int | None,
+        bds_b2_enabled: bool | None,
+        spi_enabled: bool | None,
+    ) -> None:
+        """Write only the optimisation fields provided; ``None`` means leave untouched.
+
+        Args:
+            elevation_mask_deg: Minimum satellite elevation, degrees.
+            bds_b2_enabled: Whether the BeiDou B2 signal is enabled.
+            spi_enabled: Whether the SPI interface is enabled.
+
+        Raises:
+            ConnectionError: If not connected.
+            RuntimeError: If the write fails.
+        """
+
+    @abc.abstractmethod
+    def apply_rtcm_matrix(self, matrix: dict[RtcmRowId, dict[PortId, bool]]) -> None:
+        """Assertive write of all 36 cells (12 rows x UART1/UART2/USB).
+
+        Every cell is written explicitly, including zeros, so a row
+        enabled by a previous profile/session that isn't in ``matrix``
+        ends up off rather than surviving as a silent superset.
+
+        Args:
+            matrix: row id -> {port: enabled}. A missing cell means off.
+
+        Raises:
+            ConnectionError: If not connected.
+            RuntimeError: If the write fails.
+        """
+
+    @abc.abstractmethod
+    def get_uart_baud_rates(self) -> dict[PortId, int]:
+        """Read the live UART1/UART2 baud rates.
+
+        Used only for the non-blocking apply-config throughput
+        estimate — baud itself is never written by apply-config.
+
+        Returns:
+            Baud rate for UART1 and UART2 (USB has no baud rate).
+
+        Raises:
+            ConnectionError: If not connected.
+            RuntimeError: If the read fails.
         """
 
     # ------------------------------------------------------------------

--- a/src/sp_rtk_base/services/drivers/fake.py
+++ b/src/sp_rtk_base/services/drivers/fake.py
@@ -48,10 +48,14 @@ import time
 from datetime import datetime, timezone
 
 from sp_rtk_base.models.device_models import (
+    ALL_RTCM_MESSAGE_IDS as _ALL_RTCM_IDS,
+)
+from sp_rtk_base.models.device_models import (
     BaseMode,
     CurrentBaseConfig,
     DeviceCapability,
     DeviceInfo,
+    DynModel,
     FixedBaseConfig,
     GnssConfig,
     GnssConstellation,
@@ -224,6 +228,19 @@ class FakeGpsDriver(GpsReceiverDriver):
             ]
         )
 
+        # Apply-config primitives (issue #61) — plain in-memory state,
+        # defaults chosen to match the shipped built-in profile
+        # (docs/zed-f9p-base-station-config-reference.md).
+        self._dyn_model: DynModel = DynModel.PORTABLE
+        self._elevation_mask_deg: int = 15
+        self._bds_b2_enabled: bool = False
+        self._spi_enabled: bool = True
+        self._meas_period_ms: int = 1000
+        self._uart_baud_rates: dict[PortId, int] = {
+            PortId.UART1: 57600,
+            PortId.UART2: 115200,
+        }
+
     # ------------------------------------------------------------------
     # Identity
     # ------------------------------------------------------------------
@@ -368,6 +385,83 @@ class FakeGpsDriver(GpsReceiverDriver):
         Real drivers might raise on NAK; the fake never does.
         """
         self._ensure_connected()
+
+    # ------------------------------------------------------------------
+    # Apply-config primitives (issue #61)
+    # ------------------------------------------------------------------
+
+    def configure_port_protocols(
+        self,
+        in_protocols: dict[PortId, list[UbxProtocol]],
+        out_protocols: dict[PortId, list[UbxProtocol]],
+    ) -> None:
+        """Store the per-port protocol write in memory.
+
+        Only ports present in either mapping are touched, mirroring
+        ``UbloxDriver``'s assertive-per-touched-port semantics.
+        """
+        self._ensure_connected()
+        new_in = dict(self._port_protocols.in_protocols)
+        new_out = dict(self._port_protocols.out_protocols)
+        for port, protocols in in_protocols.items():
+            new_in[port] = list(protocols)
+        for port, protocols in out_protocols.items():
+            new_out[port] = list(protocols)
+        self._port_protocols = PortProtocolConfig(
+            in_protocols=new_in, out_protocols=new_out
+        )
+
+    def configure_measurement_rate(self, period_ms: int) -> None:
+        """Store the measurement period in memory."""
+        self._ensure_connected()
+        self._meas_period_ms = period_ms
+
+    def configure_dyn_model(self, model: DynModel) -> None:
+        """Store the dynamics model in memory."""
+        self._ensure_connected()
+        self._dyn_model = model
+
+    def configure_tmode_mode(self, mode: BaseMode) -> None:
+        """Store the TMODE mode, leaving any existing position untouched."""
+        self._ensure_connected()
+        self._base_config = self._base_config.model_copy(update={"mode": mode})
+
+    def configure_optimisations(
+        self,
+        elevation_mask_deg: int | None,
+        bds_b2_enabled: bool | None,
+        spi_enabled: bool | None,
+    ) -> None:
+        """Store only the optimisation fields provided."""
+        self._ensure_connected()
+        if elevation_mask_deg is not None:
+            self._elevation_mask_deg = elevation_mask_deg
+        if bds_b2_enabled is not None:
+            self._bds_b2_enabled = bds_b2_enabled
+        if spi_enabled is not None:
+            self._spi_enabled = spi_enabled
+
+    def apply_rtcm_matrix(self, matrix: dict[RtcmRowId, dict[PortId, bool]]) -> None:
+        """Store the assertive 12x3 RTCM matrix write in memory.
+
+        I2C/SPI columns (which the matrix doesn't claim) are preserved
+        from whatever the fake driver already held for them.
+        """
+        self._ensure_connected()
+        updated: dict[RtcmRowId, dict[str, int]] = {}
+        for row in _ALL_RTCM_IDS:
+            cell = dict(self._rtcm_ports.messages.get(row, {}))
+            for port in (PortId.UART1, PortId.UART2, PortId.USB):
+                cell[port.value] = int(matrix.get(row, {}).get(port, False))
+            cell.setdefault("I2C", 0)
+            cell.setdefault("SPI", 0)
+            updated[row] = cell
+        self._rtcm_ports = RtcmPortConfig(messages=updated)
+
+    def get_uart_baud_rates(self) -> dict[PortId, int]:
+        """Return the fixed in-memory UART baud rates."""
+        self._ensure_connected()
+        return dict(self._uart_baud_rates)
 
     # ------------------------------------------------------------------
     # GNSS constellation configuration

--- a/src/sp_rtk_base/services/drivers/ublox.py
+++ b/src/sp_rtk_base/services/drivers/ublox.py
@@ -31,6 +31,7 @@ from sp_rtk_base.models.device_models import (
     CurrentBaseConfig,
     DeviceCapability,
     DeviceInfo,
+    DynModel,
     FixedBaseConfig,
     GnssConfig,
     GnssConstellation,
@@ -142,6 +143,34 @@ def _protocol_key(
         protocol: Protocol to query.
     """
     return f"{_PROTOCOL_PORT_PREFIXES[port]}{direction}PROT_{protocol.value}"
+
+
+# ---------------------------------------------------------------------------
+# Apply-config primitives (issue #61)
+# ---------------------------------------------------------------------------
+
+# u-blox CFG_NAVSPG_DYNMODEL values. 1 is reserved/unused on the wire.
+_DYN_MODEL_VALUES: dict[DynModel, int] = {
+    DynModel.PORTABLE: 0,
+    DynModel.STATIONARY: 2,
+    DynModel.PEDESTRIAN: 3,
+    DynModel.AUTOMOTIVE: 4,
+    DynModel.SEA: 5,
+    DynModel.AIRBORNE_1G: 6,
+    DynModel.AIRBORNE_2G: 7,
+    DynModel.AIRBORNE_4G: 8,
+}
+
+# u-blox CFG_TMODE_MODE values — same mapping ``_parse_cfg_tmode`` reads back.
+_TMODE_MODE_VALUES: dict[BaseMode, int] = {
+    BaseMode.DISABLED: 0,
+    BaseMode.SURVEY_IN: 1,
+    BaseMode.FIXED: 2,
+}
+
+# Ports the RTCM matrix write covers — deliberately excludes I2C/SPI,
+# which the profile schema doesn't claim (see RtcmStreamConfig).
+_MATRIX_PORTS: tuple[PortId, ...] = (PortId.UART1, PortId.UART2, PortId.USB)
 
 
 class UbloxDriver(GpsReceiverDriver):
@@ -1206,6 +1235,148 @@ class UbloxDriver(GpsReceiverDriver):
             "GNSS constellations configured: %s",
             [c.value for c in enabled],
         )
+
+    # ------------------------------------------------------------------
+    # Apply-config primitives (issue #61)
+    # ------------------------------------------------------------------
+
+    def configure_port_protocols(
+        self,
+        in_protocols: dict[PortId, list[UbxProtocol]],
+        out_protocols: dict[PortId, list[UbxProtocol]],
+    ) -> None:
+        """Assertive per-port protocol write for exactly the ports given.
+
+        Only ports present in either mapping are touched. For a
+        touched port+direction, every one of the three protocol keys
+        is written explicitly (on and off) — this is what makes the
+        write assertive rather than additive.
+        """
+        cfg_data: list[tuple[str, int]] = []
+        for port in set(in_protocols) | set(out_protocols):
+            if port in in_protocols:
+                wanted_in = set(in_protocols[port])
+                for protocol in UbxProtocol:
+                    cfg_data.append(
+                        (
+                            _protocol_key(port, "IN", protocol),
+                            int(protocol in wanted_in),
+                        )
+                    )
+            if port in out_protocols:
+                wanted_out = set(out_protocols[port])
+                for protocol in UbxProtocol:
+                    cfg_data.append(
+                        (
+                            _protocol_key(port, "OUT", protocol),
+                            int(protocol in wanted_out),
+                        )
+                    )
+
+        if not cfg_data:
+            return
+        with self._lock:
+            self._write_and_verify_locked(
+                cfg_data, layer=5, label="Port protocol config"
+            )
+
+    def configure_measurement_rate(self, period_ms: int) -> None:
+        """Write ``CFG_RATE_MEAS=period_ms`` and pin ``CFG_RATE_NAV=1``.
+
+        ``period_ms`` is already the raw measurement period in
+        milliseconds — no Hz conversion happens here or anywhere else
+        on this path (the UI does that conversion for display only).
+        """
+        cfg_data = [("CFG_RATE_MEAS", period_ms), ("CFG_RATE_NAV", 1)]
+        with self._lock:
+            self._write_and_verify_locked(cfg_data, layer=5, label="Measurement rate")
+
+    def configure_dyn_model(self, model: DynModel) -> None:
+        """Write ``CFG_NAVSPG_DYNMODEL`` for an arbitrary dynamics class.
+
+        General-purpose sibling of ``_apply_stationary_dyn_model_locked``,
+        which stays as-is (hard-coded stationary) since it's called from
+        the survey-in/fixed-base transition paths that issue #38 covers.
+        """
+        with self._lock:
+            self._write_and_verify_locked(
+                [("CFG_NAVSPG_DYNMODEL", _DYN_MODEL_VALUES[model])],
+                layer=5,
+                label="Dynamics model",
+            )
+
+    def configure_tmode_mode(self, mode: BaseMode) -> None:
+        """Write ``CFG_TMODE_MODE`` directly, without touching position keys.
+
+        A plain mode assertion for apply-config's role-fields step —
+        NOT a full base-mode transition. Coordinate preconditions for
+        ``fixed`` mode are the caller's responsibility.
+        """
+        with self._lock:
+            self._write_and_verify_locked(
+                [("CFG_TMODE_MODE", _TMODE_MODE_VALUES[mode])],
+                layer=5,
+                label="TMODE mode",
+            )
+
+    def configure_optimisations(
+        self,
+        elevation_mask_deg: int | None,
+        bds_b2_enabled: bool | None,
+        spi_enabled: bool | None,
+    ) -> None:
+        """Write only the optimisation fields provided.
+
+        Each field is independently optional — ``None`` means leave
+        the receiver's current value untouched. Unlike ``ports`` and
+        ``apply_rtcm_matrix``, this write is NOT assertive.
+        """
+        cfg_data: list[tuple[str, int]] = []
+        if elevation_mask_deg is not None:
+            cfg_data.append(("CFG_NAVSPG_INFIL_MINELEV", elevation_mask_deg))
+        if bds_b2_enabled is not None:
+            cfg_data.append(("CFG_SIGNAL_BDS_B2_ENA", int(bds_b2_enabled)))
+        if spi_enabled is not None:
+            cfg_data.append(("CFG_SPI_ENABLED", int(spi_enabled)))
+
+        if not cfg_data:
+            return
+        with self._lock:
+            self._write_and_verify_locked(
+                cfg_data, layer=5, label="Optimisation settings"
+            )
+
+    def apply_rtcm_matrix(self, matrix: dict[RtcmRowId, dict[PortId, bool]]) -> None:
+        """Assertive write of all 36 cells (12 rows x UART1/UART2/USB).
+
+        Deliberately a single write with no internal retry-and-raise,
+        unlike this driver's other layer=5 writers: the apply-config
+        endpoint owns the read-back verify for this specific write as
+        a first-class part of its contract (a per-cell diff returned
+        to the caller with a 200, nothing rolled back) rather than
+        raising here.
+        """
+        cfg_data = [
+            (_rtcm_key(row, port.value), int(matrix.get(row, {}).get(port, False)))
+            for row in _ALL_RTCM_IDS
+            for port in _MATRIX_PORTS
+        ]
+        with self._lock:
+            self._send_cfg_valset_locked(cfg_data, layer=5)
+
+    def get_uart_baud_rates(self) -> dict[PortId, int]:
+        """Read the live UART1/UART2 baud rates.
+
+        Used only for apply-config's non-blocking throughput estimate.
+        """
+        with self._lock:
+            raw = self._read_cfg_keys_locked(
+                ["CFG_UART1_BAUDRATE", "CFG_UART2_BAUDRATE"]
+            )
+        return {
+            PortId.UART1: raw["CFG_UART1_BAUDRATE"],
+            PortId.UART2: raw["CFG_UART2_BAUDRATE"],
+        }
 
     def save_to_flash(self) -> None:
         """Save current RAM config to BBR + Flash (layers 7)."""

--- a/tests/unit/test_api_device.py
+++ b/tests/unit/test_api_device.py
@@ -565,6 +565,113 @@ class TestBaseConfig:
 
 
 # ---------------------------------------------------------------------------
+# Apply-config — the profile one-shot (issue #61)
+# ---------------------------------------------------------------------------
+
+_MINIMAL_APPLY_BODY: dict[str, object] = {
+    "data_link_port": ["UART1"],
+    "rtcm_stream": {"matrix": {"1005": {"UART1": True}}},
+}
+
+
+class TestApplyConfig:
+    """Tests for POST /api/device/apply-config."""
+
+    def test_apply_config_ok(
+        self,
+        client: TestClient,
+        mock_device_service: MagicMock,
+    ) -> None:
+        from sp_rtk_base.models.device_models import ApplyConfigResult
+
+        mock_device_service.apply_receiver_config = AsyncMock(
+            return_value=ApplyConfigResult(status="ok")
+        )
+        resp = client.post("/api/device/apply-config", json=_MINIMAL_APPLY_BODY)
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+        assert resp.json()["diff"] == []
+
+    def test_apply_config_failed_with_diff(
+        self,
+        client: TestClient,
+        mock_device_service: MagicMock,
+    ) -> None:
+        from sp_rtk_base.models.device_models import (
+            ApplyConfigCellDiff,
+            ApplyConfigResult,
+            PortId,
+            RtcmRowId,
+        )
+
+        mock_device_service.apply_receiver_config = AsyncMock(
+            return_value=ApplyConfigResult(
+                status="failed",
+                diff=[
+                    ApplyConfigCellDiff(
+                        row_id=RtcmRowId.RTCM_1005,
+                        port=PortId.UART1,
+                        expected=True,
+                        actual=False,
+                    )
+                ],
+            )
+        )
+        resp = client.post("/api/device/apply-config", json=_MINIMAL_APPLY_BODY)
+        # Read-back mismatch is still a 200 — writes are left in flash.
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "failed"
+        assert body["diff"] == [
+            {
+                "row_id": "1005",
+                "port": "UART1",
+                "expected": True,
+                "actual": False,
+            }
+        ]
+
+    def test_apply_config_not_connected(
+        self,
+        client: TestClient,
+        mock_device_service: MagicMock,
+    ) -> None:
+        mock_device_service.apply_receiver_config = AsyncMock(
+            side_effect=RuntimeError("Device not connected"),
+        )
+        resp = client.post("/api/device/apply-config", json=_MINIMAL_APPLY_BODY)
+        assert resp.status_code == 409
+
+    def test_apply_config_business_rule_refusal(
+        self,
+        client: TestClient,
+        mock_device_service: MagicMock,
+    ) -> None:
+        from sp_rtk_base.services.device_service import ApplyConfigRefusedError
+
+        mock_device_service.apply_receiver_config = AsyncMock(
+            side_effect=ApplyConfigRefusedError(
+                "ubx_in_liveness", "ports.USB.in must keep UBX enabled"
+            ),
+        )
+        resp = client.post("/api/device/apply-config", json=_MINIMAL_APPLY_BODY)
+        assert resp.status_code == 400
+        assert "ubx_in_liveness" in resp.json()["detail"]
+
+    def test_apply_config_schema_violation(
+        self,
+        client: TestClient,
+    ) -> None:
+        """Missing ``data_link_port`` is a schema violation — 422,
+        handled entirely by pydantic before the service is called."""
+        resp = client.post(
+            "/api/device/apply-config",
+            json={"rtcm_stream": {"matrix": {"1005": {"UART1": True}}}},
+        )
+        assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
 # Handoff — device → relay
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_device_service.py
+++ b/tests/unit/test_device_service.py
@@ -27,6 +27,7 @@ from sp_rtk_base.models.device_models import (
     UbxProtocol,
 )
 from sp_rtk_base.models.profile_models import (
+    BaudConfig,
     PortProtocolSet,
     ReceiverConfig,
     RtcmStreamConfig,
@@ -406,6 +407,26 @@ class TestApplyReceiverConfig:
         svc.set_driver(_make_mock_driver())
         with pytest.raises(RuntimeError, match="Device not connected"):
             await svc.apply_receiver_config(_minimal_config())
+
+    @pytest.mark.asyncio()
+    async def test_baud_out_of_scope_refused_before_any_write(
+        self, connected_svc: DeviceService
+    ) -> None:
+        assert connected_svc.driver is not None
+        config = _minimal_config(baud=BaudConfig(uart1=57600))
+
+        with pytest.raises(ApplyConfigRefusedError) as exc_info:
+            await connected_svc.apply_receiver_config(config)
+
+        assert exc_info.value.rule == "baud_out_of_scope"
+        connected_svc.driver.configure_measurement_rate.assert_not_called()  # type: ignore[union-attr]
+
+    @pytest.mark.asyncio()
+    async def test_baud_omitted_is_allowed(self, connected_svc: DeviceService) -> None:
+        result = await connected_svc.apply_receiver_config(
+            _minimal_config(baud=BaudConfig())
+        )
+        assert result.status == "ok"
 
     @pytest.mark.asyncio()
     async def test_ubx_in_liveness_guard_refuses_before_any_write(

--- a/tests/unit/test_device_service.py
+++ b/tests/unit/test_device_service.py
@@ -13,13 +13,25 @@ from sp_rtk_base.models.device_models import (
     DeviceCapability,
     DeviceConnectionState,
     DeviceInfo,
+    DynModel,
     FixedBaseConfig,
+    GnssConfig,
+    GnssConstellation,
+    GnssSystemConfig,
+    PortId,
     RtcmMessageConfig,
+    RtcmPortConfig,
     RtcmRowId,
     SurveyInConfig,
     SurveyInProgress,
+    UbxProtocol,
 )
-from sp_rtk_base.services.device_service import DeviceService
+from sp_rtk_base.models.profile_models import (
+    PortProtocolSet,
+    ReceiverConfig,
+    RtcmStreamConfig,
+)
+from sp_rtk_base.services.device_service import ApplyConfigRefusedError, DeviceService
 from sp_rtk_base.services.drivers.base import GpsReceiverDriver
 
 # ---------------------------------------------------------------------------
@@ -346,6 +358,310 @@ class TestConfiguration:
         assert connected_svc.state == DeviceConnectionState.CONNECTED
         status = connected_svc.get_status()
         assert status.last_error == "NAK"
+
+
+# ---------------------------------------------------------------------------
+# Tests: apply-config (issue #61)
+# ---------------------------------------------------------------------------
+
+
+def _minimal_config(**overrides: object) -> ReceiverConfig:
+    """A minimal valid ``ReceiverConfig`` — 1005 enabled on the one data-link port."""
+    defaults: dict[str, object] = {
+        "data_link_port": [PortId.UART1],
+        "rtcm_stream": RtcmStreamConfig(
+            matrix={RtcmRowId.RTCM_1005: {PortId.UART1: True}}
+        ),
+    }
+    defaults.update(overrides)
+    return ReceiverConfig(**defaults)  # type: ignore[arg-type]
+
+
+class TestApplyReceiverConfig:
+    """Tests for ``DeviceService.apply_receiver_config`` (issue #61)."""
+
+    @pytest.fixture()
+    def connected_svc(self) -> DeviceService:
+        svc = DeviceService()
+        driver = _make_mock_driver()
+        driver.get_base_config.return_value = CurrentBaseConfig(mode=BaseMode.DISABLED)
+        driver.get_gnss_config.return_value = GnssConfig(systems=[])
+        # Matches ``_minimal_config()``'s matrix by default so tests that
+        # don't care about the read-back diff see status="ok".
+        driver.get_rtcm_port_config.return_value = RtcmPortConfig(
+            messages={RtcmRowId.RTCM_1005: {"UART1": 1}}
+        )
+        driver.get_uart_baud_rates.return_value = {
+            PortId.UART1: 57600,
+            PortId.UART2: 115200,
+        }
+        svc.set_driver(driver)
+        svc._state = DeviceConnectionState.CONNECTED
+        svc._info = DeviceInfo(vendor="MockVendor", model="MockModel")
+        return svc
+
+    @pytest.mark.asyncio()
+    async def test_not_connected_raises(self) -> None:
+        svc = DeviceService()
+        svc.set_driver(_make_mock_driver())
+        with pytest.raises(RuntimeError, match="Device not connected"):
+            await svc.apply_receiver_config(_minimal_config())
+
+    @pytest.mark.asyncio()
+    async def test_ubx_in_liveness_guard_refuses_before_any_write(
+        self, connected_svc: DeviceService
+    ) -> None:
+        assert connected_svc.driver is not None
+        config = _minimal_config(
+            ports={PortId.USB: PortProtocolSet(**{"in": [UbxProtocol.NMEA], "out": []})}
+        )
+
+        with pytest.raises(ApplyConfigRefusedError) as exc_info:
+            await connected_svc.apply_receiver_config(config)
+
+        assert exc_info.value.rule == "ubx_in_liveness"
+        connected_svc.driver.configure_measurement_rate.assert_not_called()  # type: ignore[union-attr]
+        connected_svc.driver.apply_rtcm_matrix.assert_not_called()  # type: ignore[union-attr]
+
+    @pytest.mark.asyncio()
+    async def test_ubx_in_present_on_usb_is_allowed(
+        self, connected_svc: DeviceService
+    ) -> None:
+        config = _minimal_config(
+            ports={
+                PortId.USB: PortProtocolSet(
+                    **{"in": [UbxProtocol.UBX], "out": [UbxProtocol.NMEA]}
+                )
+            }
+        )
+        result = await connected_svc.apply_receiver_config(config)
+        assert result.status == "ok"
+
+    @pytest.mark.asyncio()
+    async def test_tmode_fixed_without_coordinates_refused(
+        self, connected_svc: DeviceService
+    ) -> None:
+        assert connected_svc.driver is not None
+        connected_svc.driver.get_base_config.return_value = CurrentBaseConfig(  # type: ignore[union-attr]
+            mode=BaseMode.DISABLED, latitude=0.0, longitude=0.0, altitude_m=0.0
+        )
+        config = _minimal_config(tmode_mode=BaseMode.FIXED)
+
+        with pytest.raises(ApplyConfigRefusedError) as exc_info:
+            await connected_svc.apply_receiver_config(config)
+
+        assert exc_info.value.rule == "tmode_fixed_requires_coordinates"
+        connected_svc.driver.configure_measurement_rate.assert_not_called()  # type: ignore[union-attr]
+
+    @pytest.mark.asyncio()
+    async def test_tmode_fixed_with_coordinates_succeeds(
+        self, connected_svc: DeviceService
+    ) -> None:
+        assert connected_svc.driver is not None
+        connected_svc.driver.get_base_config.return_value = CurrentBaseConfig(  # type: ignore[union-attr]
+            mode=BaseMode.FIXED, latitude=47.0, longitude=8.0, altitude_m=400.0
+        )
+        config = _minimal_config(tmode_mode=BaseMode.FIXED)
+
+        result = await connected_svc.apply_receiver_config(config)
+
+        assert result.status == "ok"
+        connected_svc.driver.configure_tmode_mode.assert_called_once_with(  # type: ignore[union-attr]
+            BaseMode.FIXED
+        )
+
+    @pytest.mark.asyncio()
+    async def test_write_order_matches_the_specified_sequence(
+        self, connected_svc: DeviceService
+    ) -> None:
+        assert connected_svc.driver is not None
+        config = _minimal_config(
+            ports={
+                PortId.UART1: PortProtocolSet(
+                    **{"in": [UbxProtocol.UBX], "out": [UbxProtocol.RTCM3X]}
+                )
+            },
+            constellations=[GnssConstellation.GPS],
+            elevation_mask_deg=10,
+            dyn_model=DynModel.STATIONARY,
+            tmode_mode=BaseMode.DISABLED,
+        )
+
+        await connected_svc.apply_receiver_config(config)
+
+        write_methods = {
+            "configure_measurement_rate",
+            "configure_port_protocols",
+            "configure_gnss",
+            "configure_optimisations",
+            "configure_dyn_model",
+            "configure_tmode_mode",
+            "apply_rtcm_matrix",
+        }
+        order: list[str] = [
+            call[0]
+            for call in connected_svc.driver.method_calls  # type: ignore[union-attr]
+            if call[0] in write_methods
+        ]
+        assert order == [
+            "configure_measurement_rate",
+            "configure_port_protocols",
+            "configure_gnss",
+            "configure_optimisations",
+            "configure_dyn_model",
+            "configure_tmode_mode",
+            "apply_rtcm_matrix",
+        ]
+
+    @pytest.mark.asyncio()
+    async def test_ports_not_written_when_omitted(
+        self, connected_svc: DeviceService
+    ) -> None:
+        assert connected_svc.driver is not None
+        await connected_svc.apply_receiver_config(_minimal_config())
+        connected_svc.driver.configure_port_protocols.assert_not_called()  # type: ignore[union-attr]
+
+    @pytest.mark.asyncio()
+    async def test_constellations_flip_enabled_and_preserve_channels(
+        self, connected_svc: DeviceService
+    ) -> None:
+        driver = connected_svc.driver
+        assert isinstance(driver, MagicMock)
+        driver.get_gnss_config.return_value = GnssConfig(
+            systems=[
+                GnssSystemConfig(
+                    constellation=GnssConstellation.GPS,
+                    enabled=True,
+                    min_channels=8,
+                    max_channels=16,
+                ),
+                GnssSystemConfig(
+                    constellation=GnssConstellation.GALILEO,
+                    enabled=False,
+                    min_channels=4,
+                    max_channels=12,
+                ),
+            ]
+        )
+        config = _minimal_config(constellations=[GnssConstellation.GALILEO])
+
+        await connected_svc.apply_receiver_config(config)
+
+        written: GnssConfig = driver.configure_gnss.call_args[0][0]
+        by_constellation: dict[GnssConstellation, GnssSystemConfig] = {
+            s.constellation: s for s in written.systems
+        }
+        assert by_constellation[GnssConstellation.GPS].enabled is False
+        assert by_constellation[GnssConstellation.GALILEO].enabled is True
+        # Channel tuning is preserved from the live read, not clobbered.
+        assert by_constellation[GnssConstellation.GALILEO].min_channels == 4
+        assert by_constellation[GnssConstellation.GALILEO].max_channels == 12
+
+    @pytest.mark.asyncio()
+    async def test_dyn_model_and_tmode_mode_omitted_write_neither_key(
+        self, connected_svc: DeviceService
+    ) -> None:
+        assert connected_svc.driver is not None
+        await connected_svc.apply_receiver_config(_minimal_config())
+        connected_svc.driver.configure_dyn_model.assert_not_called()  # type: ignore[union-attr]
+        connected_svc.driver.configure_tmode_mode.assert_not_called()  # type: ignore[union-attr]
+
+    @pytest.mark.asyncio()
+    async def test_optimisations_always_invoked(
+        self, connected_svc: DeviceService
+    ) -> None:
+        """The driver call always happens; per-field omission is the
+        driver's job (each ``None`` there means leave untouched)."""
+        assert connected_svc.driver is not None
+        await connected_svc.apply_receiver_config(_minimal_config())
+        connected_svc.driver.configure_optimisations.assert_called_once_with(  # type: ignore[union-attr]
+            None, None, None
+        )
+
+    @pytest.mark.asyncio()
+    async def test_meas_period_ms_passed_through_unconverted(
+        self, connected_svc: DeviceService
+    ) -> None:
+        assert connected_svc.driver is not None
+        await connected_svc.apply_receiver_config(_minimal_config(meas_period_ms=333))
+        connected_svc.driver.configure_measurement_rate.assert_called_once_with(  # type: ignore[union-attr]
+            333
+        )
+
+    @pytest.mark.asyncio()
+    async def test_read_back_match_returns_ok(
+        self, connected_svc: DeviceService
+    ) -> None:
+        assert connected_svc.driver is not None
+        connected_svc.driver.get_rtcm_port_config.return_value = RtcmPortConfig(  # type: ignore[union-attr]
+            messages={RtcmRowId.RTCM_1005: {"UART1": 1}}
+        )
+        result = await connected_svc.apply_receiver_config(_minimal_config())
+        assert result.status == "ok"
+        assert result.diff == []
+
+    @pytest.mark.asyncio()
+    async def test_read_back_mismatch_returns_failed_with_diff(
+        self, connected_svc: DeviceService
+    ) -> None:
+        """A mismatch is a 200-with-diff outcome, not an exception —
+        the writes are left in flash, nothing is rolled back."""
+        assert connected_svc.driver is not None
+        connected_svc.driver.get_rtcm_port_config.return_value = RtcmPortConfig(  # type: ignore[union-attr]
+            messages={RtcmRowId.RTCM_1005: {"UART1": 0}}
+        )
+        result = await connected_svc.apply_receiver_config(_minimal_config())
+
+        assert result.status == "failed"
+        assert len(result.diff) == 1
+        cell = result.diff[0]
+        assert cell.row_id == RtcmRowId.RTCM_1005
+        assert cell.port == PortId.UART1
+        assert cell.expected is True
+        assert cell.actual is False
+
+    @pytest.mark.asyncio()
+    async def test_throughput_warning_when_over_threshold(
+        self, connected_svc: DeviceService
+    ) -> None:
+        assert connected_svc.driver is not None
+        connected_svc.driver.get_uart_baud_rates.return_value = {  # type: ignore[union-attr]
+            PortId.UART1: 9600,
+            PortId.UART2: 115200,
+        }
+        heavy_matrix = RtcmStreamConfig(
+            matrix={
+                RtcmRowId.RTCM_1005: {PortId.UART1: True},
+                RtcmRowId.RTCM_1077: {PortId.UART1: True},
+                RtcmRowId.RTCM_1087: {PortId.UART1: True},
+                RtcmRowId.RTCM_1097: {PortId.UART1: True},
+            }
+        )
+        connected_svc.driver.get_rtcm_port_config.return_value = RtcmPortConfig(  # type: ignore[union-attr]
+            messages={
+                row: {"UART1": 1 if ports.get(PortId.UART1) else 0}
+                for row, ports in heavy_matrix.matrix.items()
+            }
+        )
+        config = _minimal_config(rtcm_stream=heavy_matrix)
+
+        result = await connected_svc.apply_receiver_config(config)
+
+        assert result.status == "ok"
+        assert len(result.warnings) == 1
+        assert "UART1" in result.warnings[0]
+
+    @pytest.mark.asyncio()
+    async def test_no_throughput_warning_under_threshold(
+        self, connected_svc: DeviceService
+    ) -> None:
+        assert connected_svc.driver is not None
+        connected_svc.driver.get_uart_baud_rates.return_value = {  # type: ignore[union-attr]
+            PortId.UART1: 115200,
+            PortId.UART2: 115200,
+        }
+        result = await connected_svc.apply_receiver_config(_minimal_config())
+        assert result.warnings == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_driver_registry.py
+++ b/tests/unit/test_driver_registry.py
@@ -9,14 +9,18 @@ from sp_rtk_base.models.device_models import (
     CurrentBaseConfig,
     DeviceCapability,
     DeviceInfo,
+    DynModel,
     FixedBaseConfig,
     GnssConfig,
     GpsPosition,
+    PortId,
     PortProtocolConfig,
     RtcmMessageConfig,
     RtcmPortConfig,
+    RtcmRowId,
     SurveyInConfig,
     SurveyInProgress,
+    UbxProtocol,
 )
 from sp_rtk_base.services.drivers import (
     _DRIVER_REGISTRY,  # pyright: ignore[reportPrivateUsage]
@@ -97,6 +101,36 @@ class StubDriver(GpsReceiverDriver):
 
     def get_base_config(self) -> CurrentBaseConfig:
         return CurrentBaseConfig(mode=BaseMode.DISABLED)
+
+    def configure_port_protocols(
+        self,
+        in_protocols: dict[PortId, list[UbxProtocol]],
+        out_protocols: dict[PortId, list[UbxProtocol]],
+    ) -> None:
+        pass
+
+    def configure_measurement_rate(self, period_ms: int) -> None:
+        pass
+
+    def configure_dyn_model(self, model: DynModel) -> None:
+        pass
+
+    def configure_tmode_mode(self, mode: BaseMode) -> None:
+        pass
+
+    def configure_optimisations(
+        self,
+        elevation_mask_deg: int | None,
+        bds_b2_enabled: bool | None,
+        spi_enabled: bool | None,
+    ) -> None:
+        pass
+
+    def apply_rtcm_matrix(self, matrix: dict[RtcmRowId, dict[PortId, bool]]) -> None:
+        pass
+
+    def get_uart_baud_rates(self) -> dict[PortId, int]:
+        return {}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_fake_driver.py
+++ b/tests/unit/test_fake_driver.py
@@ -1,3 +1,4 @@
+# pyright: reportPrivateUsage=false
 """Unit tests for the in-memory ``FakeGpsDriver``.
 
 The fake driver is used by the Playwright e2e suite to drive UI paths
@@ -39,15 +40,18 @@ import pytest
 from sp_rtk_base.models.device_models import (
     BaseMode,
     DeviceCapability,
+    DynModel,
     FixedBaseConfig,
     GnssConfig,
     GnssConstellation,
     GnssSystemConfig,
     GpsFixType,
+    PortId,
     RtcmMessageConfig,
     RtcmPortConfig,
     RtcmRowId,
     SurveyInConfig,
+    UbxProtocol,
 )
 from sp_rtk_base.services.drivers.base import GpsReceiverDriver
 from sp_rtk_base.services.drivers.fake import (
@@ -243,6 +247,46 @@ class TestDisconnectedGuards:
         with pytest.raises(ConnectionError):
             driver.get_base_config()
 
+    def test_configure_port_protocols_requires_connection(
+        self, driver: FakeGpsDriver
+    ) -> None:
+        with pytest.raises(ConnectionError):
+            driver.configure_port_protocols({}, {})
+
+    def test_configure_measurement_rate_requires_connection(
+        self, driver: FakeGpsDriver
+    ) -> None:
+        with pytest.raises(ConnectionError):
+            driver.configure_measurement_rate(1000)
+
+    def test_configure_dyn_model_requires_connection(
+        self, driver: FakeGpsDriver
+    ) -> None:
+        with pytest.raises(ConnectionError):
+            driver.configure_dyn_model(DynModel.STATIONARY)
+
+    def test_configure_tmode_mode_requires_connection(
+        self, driver: FakeGpsDriver
+    ) -> None:
+        with pytest.raises(ConnectionError):
+            driver.configure_tmode_mode(BaseMode.DISABLED)
+
+    def test_configure_optimisations_requires_connection(
+        self, driver: FakeGpsDriver
+    ) -> None:
+        with pytest.raises(ConnectionError):
+            driver.configure_optimisations(None, None, None)
+
+    def test_apply_rtcm_matrix_requires_connection(self, driver: FakeGpsDriver) -> None:
+        with pytest.raises(ConnectionError):
+            driver.apply_rtcm_matrix({})
+
+    def test_get_uart_baud_rates_requires_connection(
+        self, driver: FakeGpsDriver
+    ) -> None:
+        with pytest.raises(ConnectionError):
+            driver.get_uart_baud_rates()
+
 
 # ---------------------------------------------------------------------------
 # Configuration round-trips
@@ -349,6 +393,75 @@ class TestConfigurationRoundTrips:
     ) -> None:
         """save_to_flash returns without raising when connected."""
         connected_driver.save_to_flash()  # should not raise
+
+    def test_configure_port_protocols_only_touches_given_ports(
+        self, connected_driver: FakeGpsDriver
+    ) -> None:
+        before_uart2 = connected_driver.get_port_protocols().enabled_in(PortId.UART2)
+
+        connected_driver.configure_port_protocols(
+            in_protocols={PortId.UART1: [UbxProtocol.UBX]},
+            out_protocols={PortId.UART1: [UbxProtocol.RTCM3X]},
+        )
+
+        after = connected_driver.get_port_protocols()
+        assert after.enabled_in(PortId.UART1) == [UbxProtocol.UBX]
+        assert after.enabled_out(PortId.UART1) == [UbxProtocol.RTCM3X]
+        assert after.enabled_in(PortId.UART2) == before_uart2
+
+    def test_configure_measurement_rate_stores_value(
+        self, connected_driver: FakeGpsDriver
+    ) -> None:
+        connected_driver.configure_measurement_rate(333)
+        assert connected_driver._meas_period_ms == 333
+
+    def test_configure_dyn_model_stores_value(
+        self, connected_driver: FakeGpsDriver
+    ) -> None:
+        connected_driver.configure_dyn_model(DynModel.STATIONARY)
+        assert connected_driver._dyn_model is DynModel.STATIONARY
+
+    def test_configure_tmode_mode_preserves_existing_position(
+        self, connected_driver: FakeGpsDriver
+    ) -> None:
+        connected_driver.configure_fixed_base(
+            FixedBaseConfig(latitude=1.0, longitude=2.0, altitude_m=3.0)
+        )
+        connected_driver.configure_tmode_mode(BaseMode.DISABLED)
+
+        current = connected_driver.get_base_config()
+        assert current.mode is BaseMode.DISABLED
+        assert current.latitude == pytest.approx(1.0)
+        assert current.longitude == pytest.approx(2.0)
+
+    def test_configure_optimisations_partial_update(
+        self, connected_driver: FakeGpsDriver
+    ) -> None:
+        connected_driver.configure_optimisations(
+            elevation_mask_deg=20, bds_b2_enabled=None, spi_enabled=None
+        )
+        assert connected_driver._elevation_mask_deg == 20
+        assert connected_driver._bds_b2_enabled is False  # unchanged default
+
+    def test_apply_rtcm_matrix_round_trip(
+        self, connected_driver: FakeGpsDriver
+    ) -> None:
+        matrix = {
+            RtcmRowId.RTCM_1005: {PortId.UART1: True, PortId.USB: False},
+        }
+        connected_driver.apply_rtcm_matrix(matrix)
+
+        out = connected_driver.get_rtcm_port_config()
+        assert out.messages[RtcmRowId.RTCM_1005]["UART1"] == 1
+        assert out.messages[RtcmRowId.RTCM_1005]["USB"] == 0
+        # A row not present in the matrix at all ends up off.
+        assert out.messages[RtcmRowId.RTCM_1230]["UART1"] == 0
+
+    def test_get_uart_baud_rates_returns_defaults(
+        self, connected_driver: FakeGpsDriver
+    ) -> None:
+        rates = connected_driver.get_uart_baud_rates()
+        assert rates == {PortId.UART1: 57600, PortId.UART2: 115200}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_ublox_driver.py
+++ b/tests/unit/test_ublox_driver.py
@@ -19,11 +19,15 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from sp_rtk_base.models.device_models import (
+    BaseMode,
     DeviceCapability,
+    DynModel,
     FixedBaseConfig,
+    PortId,
     RtcmMessageConfig,
     RtcmRowId,
     SurveyInConfig,
+    UbxProtocol,
 )
 from sp_rtk_base.services.drivers.ublox import UbloxDriver
 
@@ -2011,3 +2015,380 @@ class TestDeviceServiceCancelConnect:
         mock_driver.cancel_connect.assert_called_once()
         assert svc.state == DeviceConnectionState.DISCONNECTED
         assert svc.get_status().last_error == "Connection cancelled"
+
+
+# ---------------------------------------------------------------------------
+# Apply-config primitives (issue #61)
+# ---------------------------------------------------------------------------
+
+
+def _connect_driver(
+    mock_serial_cls: MagicMock,
+    mock_reader_cls: MagicMock,
+    mock_ubx_msg: MagicMock,
+    responses: list[object],
+) -> tuple[UbloxDriver, MagicMock]:
+    """Connect a ``UbloxDriver`` against mocked serial/reader/UBXMessage.
+
+    ``responses`` are queued *after* the MON-VER response ``connect()``
+    consumes, in the order the driver under test will read them.
+    """
+    ser = MagicMock()
+    ser.is_open = True
+    mock_serial_cls.return_value = ser
+
+    reader = MagicMock()
+    reader.read.side_effect = [
+        (b"", _make_mon_ver_response()),
+        *[(b"", r) for r in responses],
+    ]
+    mock_reader_cls.return_value = reader
+
+    mock_msg = MagicMock()
+    mock_msg.serialize.return_value = b"\x00"
+    mock_ubx_msg.config_set.return_value = mock_msg
+
+    driver = UbloxDriver()
+    driver.connect("/dev/ttyUSB0")
+    return driver, reader
+
+
+class TestConfigurePortProtocols:
+    """Tests for ``UbloxDriver.configure_port_protocols`` (issue #61)."""
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_writes_assertive_keys_for_touched_ports_only(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        """Only UART1 is present in either mapping, so only its six
+        IN/OUT protocol keys should be written — UART2/USB untouched."""
+        read_back = SimpleNamespace(
+            identity="CFG-VALGET",
+            CFG_UART1INPROT_UBX=1,
+            CFG_UART1INPROT_NMEA=0,
+            CFG_UART1INPROT_RTCM3X=0,
+            CFG_UART1OUTPROT_UBX=0,
+            CFG_UART1OUTPROT_NMEA=0,
+            CFG_UART1OUTPROT_RTCM3X=1,
+        )
+        driver, _reader = _connect_driver(
+            mock_serial_cls,
+            mock_reader_cls,
+            mock_ubx_msg,
+            [_make_ack_response(), read_back],
+        )
+
+        driver.configure_port_protocols(
+            in_protocols={PortId.UART1: [UbxProtocol.UBX]},
+            out_protocols={PortId.UART1: [UbxProtocol.RTCM3X]},
+        )
+
+        _, _, cfg_data = mock_ubx_msg.config_set.call_args[0]
+        written = dict(cfg_data)
+        assert written == {
+            "CFG_UART1INPROT_UBX": 1,
+            "CFG_UART1INPROT_NMEA": 0,
+            "CFG_UART1INPROT_RTCM3X": 0,
+            "CFG_UART1OUTPROT_UBX": 0,
+            "CFG_UART1OUTPROT_NMEA": 0,
+            "CFG_UART1OUTPROT_RTCM3X": 1,
+        }
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_empty_mappings_write_nothing(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        driver, _reader = _connect_driver(
+            mock_serial_cls, mock_reader_cls, mock_ubx_msg, []
+        )
+
+        driver.configure_port_protocols(in_protocols={}, out_protocols={})
+
+        mock_ubx_msg.config_set.assert_not_called()
+
+
+class TestConfigureMeasurementRate:
+    """Tests for ``UbloxDriver.configure_measurement_rate`` (issue #61)."""
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_writes_meas_and_pins_nav_to_one(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        """meas_period_ms is a raw ms value passed straight through —
+        no Hz conversion — and CFG_RATE_NAV is always pinned to 1."""
+        read_back = SimpleNamespace(
+            identity="CFG-VALGET", CFG_RATE_MEAS=333, CFG_RATE_NAV=1
+        )
+        driver, _reader = _connect_driver(
+            mock_serial_cls,
+            mock_reader_cls,
+            mock_ubx_msg,
+            [_make_ack_response(), read_back],
+        )
+
+        driver.configure_measurement_rate(333)
+
+        _, _, cfg_data = mock_ubx_msg.config_set.call_args[0]
+        assert dict(cfg_data) == {"CFG_RATE_MEAS": 333, "CFG_RATE_NAV": 1}
+
+
+class TestConfigureDynModel:
+    """Tests for ``UbloxDriver.configure_dyn_model`` (issue #61)."""
+
+    @pytest.mark.parametrize(
+        ("model", "expected_value"),
+        [
+            (DynModel.PORTABLE, 0),
+            (DynModel.STATIONARY, 2),
+            (DynModel.AIRBORNE_4G, 8),
+        ],
+    )
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_writes_mapped_value(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+        model: DynModel,
+        expected_value: int,
+    ) -> None:
+        driver, _reader = _connect_driver(
+            mock_serial_cls,
+            mock_reader_cls,
+            mock_ubx_msg,
+            [
+                _make_ack_response(),
+                SimpleNamespace(
+                    identity="CFG-VALGET", CFG_NAVSPG_DYNMODEL=expected_value
+                ),
+            ],
+        )
+
+        driver.configure_dyn_model(model)
+
+        _, _, cfg_data = mock_ubx_msg.config_set.call_args[0]
+        assert dict(cfg_data) == {"CFG_NAVSPG_DYNMODEL": expected_value}
+
+
+class TestConfigureTmodeMode:
+    """Tests for ``UbloxDriver.configure_tmode_mode`` (issue #61)."""
+
+    @pytest.mark.parametrize(
+        ("mode", "expected_value"),
+        [
+            (BaseMode.DISABLED, 0),
+            (BaseMode.SURVEY_IN, 1),
+            (BaseMode.FIXED, 2),
+        ],
+    )
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_writes_mapped_value_without_position_keys(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+        mode: BaseMode,
+        expected_value: int,
+    ) -> None:
+        driver, _reader = _connect_driver(
+            mock_serial_cls,
+            mock_reader_cls,
+            mock_ubx_msg,
+            [
+                _make_ack_response(),
+                SimpleNamespace(identity="CFG-VALGET", CFG_TMODE_MODE=expected_value),
+            ],
+        )
+
+        driver.configure_tmode_mode(mode)
+
+        _, _, cfg_data = mock_ubx_msg.config_set.call_args[0]
+        assert dict(cfg_data) == {"CFG_TMODE_MODE": expected_value}
+
+
+class TestConfigureOptimisations:
+    """Tests for ``UbloxDriver.configure_optimisations`` (issue #61)."""
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_writes_only_provided_fields(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        read_back = SimpleNamespace(identity="CFG-VALGET", CFG_NAVSPG_INFIL_MINELEV=10)
+        driver, _reader = _connect_driver(
+            mock_serial_cls,
+            mock_reader_cls,
+            mock_ubx_msg,
+            [_make_ack_response(), read_back],
+        )
+
+        driver.configure_optimisations(
+            elevation_mask_deg=10, bds_b2_enabled=None, spi_enabled=None
+        )
+
+        _, _, cfg_data = mock_ubx_msg.config_set.call_args[0]
+        assert dict(cfg_data) == {"CFG_NAVSPG_INFIL_MINELEV": 10}
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_all_none_writes_nothing(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        driver, _reader = _connect_driver(
+            mock_serial_cls, mock_reader_cls, mock_ubx_msg, []
+        )
+
+        driver.configure_optimisations(
+            elevation_mask_deg=None, bds_b2_enabled=None, spi_enabled=None
+        )
+
+        mock_ubx_msg.config_set.assert_not_called()
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_writes_all_three_fields_when_all_provided(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        read_back = SimpleNamespace(
+            identity="CFG-VALGET",
+            CFG_NAVSPG_INFIL_MINELEV=15,
+            CFG_SIGNAL_BDS_B2_ENA=0,
+            CFG_SPI_ENABLED=1,
+        )
+        driver, _reader = _connect_driver(
+            mock_serial_cls,
+            mock_reader_cls,
+            mock_ubx_msg,
+            [_make_ack_response(), read_back],
+        )
+
+        driver.configure_optimisations(
+            elevation_mask_deg=15, bds_b2_enabled=False, spi_enabled=True
+        )
+
+        _, _, cfg_data = mock_ubx_msg.config_set.call_args[0]
+        assert dict(cfg_data) == {
+            "CFG_NAVSPG_INFIL_MINELEV": 15,
+            "CFG_SIGNAL_BDS_B2_ENA": 0,
+            "CFG_SPI_ENABLED": 1,
+        }
+
+
+class TestApplyRtcmMatrix:
+    """Tests for ``UbloxDriver.apply_rtcm_matrix`` (issue #61)."""
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_writes_all_36_cells_including_zeros(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        """A row not present in ``matrix`` at all must still be written
+        as an explicit 0 — a previously-enabled message left out of a
+        profile must end up off, not survive as a silent superset."""
+        driver, _reader = _connect_driver(
+            mock_serial_cls, mock_reader_cls, mock_ubx_msg, [_make_ack_response()]
+        )
+
+        matrix = {
+            RtcmRowId.RTCM_1005: {PortId.UART1: True, PortId.UART2: True},
+            RtcmRowId.RTCM_1077: {PortId.UART1: True},
+        }
+        driver.apply_rtcm_matrix(matrix)
+
+        _, _, cfg_data = mock_ubx_msg.config_set.call_args[0]
+        written = dict(cfg_data)
+        assert len(written) == 36
+        assert written["CFG_MSGOUT_RTCM_3X_TYPE1005_UART1"] == 1
+        assert written["CFG_MSGOUT_RTCM_3X_TYPE1005_UART2"] == 1
+        assert written["CFG_MSGOUT_RTCM_3X_TYPE1005_USB"] == 0
+        assert written["CFG_MSGOUT_RTCM_3X_TYPE1077_UART1"] == 1
+        assert written["CFG_MSGOUT_RTCM_3X_TYPE1077_UART2"] == 0
+        # A row entirely absent from the matrix — explicit zeros everywhere.
+        assert written["CFG_MSGOUT_RTCM_3X_TYPE1230_UART1"] == 0
+        assert written["CFG_MSGOUT_RTCM_3X_TYPE1230_UART2"] == 0
+        assert written["CFG_MSGOUT_RTCM_3X_TYPE1230_USB"] == 0
+        # I2C/SPI are never claimed by the matrix.
+        assert not any(key.endswith(("_I2C", "_SPI")) for key in written)
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_single_write_no_internal_retry(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        """Unlike this driver's other layer=5 writers, apply_rtcm_matrix
+        does not read back or retry internally — the apply-config
+        endpoint owns that verification step."""
+        driver, reader = _connect_driver(
+            mock_serial_cls, mock_reader_cls, mock_ubx_msg, [_make_ack_response()]
+        )
+
+        driver.apply_rtcm_matrix({})
+
+        assert mock_ubx_msg.config_set.call_count == 1
+        # Exactly MON-VER + ACK consumed — no extra VALGET poll/read.
+        assert reader.read.call_count == 2
+
+
+class TestGetUartBaudRates:
+    """Tests for ``UbloxDriver.get_uart_baud_rates`` (issue #61)."""
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_reads_uart1_and_uart2_baud(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        read_back = SimpleNamespace(
+            identity="CFG-VALGET",
+            CFG_UART1_BAUDRATE=57600,
+            CFG_UART2_BAUDRATE=115200,
+        )
+        driver, _reader = _connect_driver(
+            mock_serial_cls, mock_reader_cls, mock_ubx_msg, [read_back]
+        )
+
+        result = driver.get_uart_baud_rates()
+
+        assert result == {PortId.UART1: 57600, PortId.UART2: 115200}


### PR DESCRIPTION
## Summary
- Adds `POST /api/device/apply-config`: applies a bare `ReceiverConfig` as an ordered series of layer=5 writes (measurement rate → ports → constellations → optimisations → dyn_model → tmode_mode → RTCM matrix), then verifies with a read-back of the RTCM matrix.
- Pre-write guards refuse with nothing written: baud is explicitly out of scope and rejected (not silently ignored), the UBX-in liveness guard protects the console's own USB management link, and the coordinate guard blocks `tmode_mode: fixed` without an existing valid position.
- Adds new driver primitives (`configure_port_protocols`, `configure_measurement_rate`, `configure_dyn_model`, `configure_tmode_mode`, `configure_optimisations`, `apply_rtcm_matrix`, `get_uart_baud_rates`) across `GpsReceiverDriver`, `UbloxDriver`, and `FakeGpsDriver`.
- Adds a non-blocking RTCM throughput warning against live UART baud rates.
- Status contract: 409 not connected, 422 schema violation, 400 business-rule refusal naming the failed rule; a read-back mismatch is a 200 with `status: "failed"` and a per-cell diff, writes left in flash.

Closes #61.

## Test plan
- [x] Full unit suite: 1287 passed, 92.79% coverage (gate 90%)
- [x] `pyright src/`: 0 errors
- [x] `mypy src/`: no issues
- [x] `ruff check`: all checks passed
- [x] New tests cover write ordering, omitted-field semantics, guard refusals, constellation-channel preservation, and read-back diff/ok paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)