### PR TITLE
feat(device): write baud last and reopen the link on apply-config

### DIFF
--- a/src/sp_rtk_base/api/device.py
+++ b/src/sp_rtk_base/api/device.py
@@ -37,7 +37,11 @@ from sp_rtk_base.services import (
     get_relay_service,
 )
 from sp_rtk_base.services.config_service import ConfigService
-from sp_rtk_base.services.device_service import ApplyConfigRefusedError, DeviceService
+from sp_rtk_base.services.device_service import (
+    ApplyConfigLinkLostError,
+    ApplyConfigRefusedError,
+    DeviceService,
+)
 from sp_rtk_base.services.drivers import create_driver
 from sp_rtk_base.services.relay_service import RelayService
 
@@ -301,10 +305,16 @@ async def apply_config(
     Status contract: 409 if not connected or the relay is running;
     422 for a schema violation (handled automatically by the
     ``ReceiverConfig`` body validation); 400 for a business-rule
-    refusal, with the failed rule named and nothing written.
+    refusal, with the failed rule named and nothing written; 502 if a
+    UART1 baud write lands but the console's own link can't be
+    reopened at the new baud or the previous one (issue #62) — the
+    receiver's flash write stands, only the console's own connection
+    needs a power-cycle or manual reconnect at the new baud rate.
     """
     try:
         return await svc.apply_receiver_config(config)
+    except ApplyConfigLinkLostError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
     except ApplyConfigRefusedError as exc:
         raise HTTPException(status_code=400, detail=f"{exc.rule}: {exc}") from exc
     except RuntimeError as exc:

--- a/src/sp_rtk_base/services/device_service.py
+++ b/src/sp_rtk_base/services/device_service.py
@@ -57,6 +57,30 @@ class ApplyConfigRefusedError(Exception):
         super().__init__(message)
 
 
+class ApplyConfigLinkLostError(Exception):
+    """The receiver was reconfigured but its own management link couldn't be reopened.
+
+    Raised by ``apply_receiver_config`` (issue #62) when a UART1 baud
+    write lands but reopening the console's own connection at the new
+    baud fails, and a single retry at the previous baud also can't
+    restore contact. The flash write stands — nothing is rolled back,
+    since writing the old baud back would fight the write that just
+    landed, and retrying the old rate forever would just hang. Carries
+    both bauds so the caller can name a concrete recovery step: power-
+    cycle the receiver, or reconnect manually at ``new_baud``.
+    """
+
+    def __init__(self, previous_baud: int, new_baud: int) -> None:
+        self.previous_baud = previous_baud
+        self.new_baud = new_baud
+        super().__init__(
+            "Receiver reconfigured but link lost — could not reopen the "
+            f"console's connection at the new baud ({new_baud}) or the "
+            f"previous baud ({previous_baud}). Power-cycle the receiver "
+            "or reconnect manually at the new baud rate."
+        )
+
+
 # ---------------------------------------------------------------------------
 # Non-blocking RTCM throughput estimate (issue #61)
 #
@@ -668,17 +692,14 @@ class DeviceService:
 
         Sequence: guards -> measurement rate -> ports -> constellations
         -> optimisations -> role fields (dyn_model, then tmode_mode) ->
-        the full RTCM matrix -> read-back verify. Baud is out of scope
-        here entirely — a submitted non-null ``ReceiverConfig.baud`` is
-        rejected pre-write rather than silently ignored (see the follow-up
-        ticket for baud support).
+        the full RTCM matrix -> baud -> reopen (if UART1's baud changed)
+        -> read-back verify. Baud is written **last**, after every other
+        key has landed, and only once every other write's ACK is safely
+        in — a baud change is the one write that can move the console's
+        own management link out from under this very request (issue #62).
 
         Guards run before any write and refuse with nothing written:
 
-        - **Baud out of scope.** A non-null ``baud`` with either UART
-          value set is refused — applying it would mean reopening the
-          serial link this very request is using, which is explicitly
-          the follow-up ticket's job, not this one's.
         - **UBX-in liveness.** This console always manages the receiver
           over its own USB connection — UART1/UART2 are reserved for
           RTCM data-link output (``ReceiverConfig`` only allows those
@@ -692,6 +713,25 @@ class DeviceService:
           otherwise a fresh receiver becomes a base broadcasting 1005
           from ECEF/LLH 0,0,0.
 
+        ``config.baud.uart1`` is treated as the port the console's own
+        management link is on, per the documented deployment (FTDI ->
+        UART1 at 57600, see docs/zed-f9p-base-station-config-reference.md)
+        — a separate, narrower premise from the UBX-in guard's "always
+        USB" one above; the two guard different concerns (which named
+        port must keep UBX in, vs. which physical serial link this
+        process itself has open) and issue #62 doesn't ask for them to
+        be reconciled. When ``uart1`` is set, this reopens the
+        connection at the new baud once the write lands, before
+        anything else runs. Reopening is deterministic — the baud was
+        just written — so one attempt normally suffices; a failure
+        retries once at the previous baud purely to leave the caller
+        with *some* link back, then raises ``ApplyConfigLinkLostError``
+        regardless of that retry's outcome: the flash write stands
+        either way (rolling it back would fight the write that just
+        landed, and retrying the old rate forever would hang).
+        ``config.baud.uart2`` never triggers a reopen — it isn't the
+        port this console is on.
+
         After the writes land, a non-blocking throughput estimate
         checks each ``data_link_port`` against its live baud rate, and
         a final read-back of the full RTCM matrix decides ``status``:
@@ -703,17 +743,11 @@ class DeviceService:
             RuntimeError: If not connected or relay is running.
             ApplyConfigRefusedError: If a device-state guard rejects the
                 config before any write.
+            ApplyConfigLinkLostError: If a UART1 baud write lands but
+                reopening the console's own link fails at both the new
+                and the previous baud.
         """
         driver = self._require_connected()
-
-        if config.baud is not None and (
-            config.baud.uart1 is not None or config.baud.uart2 is not None
-        ):
-            raise ApplyConfigRefusedError(
-                "baud_out_of_scope",
-                "baud is out of scope for apply-config — it would disturb "
-                "the console's own link; leave it unset",
-            )
 
         if config.ports is not None:
             usb_ports = config.ports.get(PortId.USB)
@@ -778,11 +812,21 @@ class DeviceService:
 
             await asyncio.to_thread(driver.apply_rtcm_matrix, config.rtcm_stream.matrix)
 
+            if config.baud is not None and (
+                config.baud.uart1 is not None or config.baud.uart2 is not None
+            ):
+                await asyncio.to_thread(
+                    driver.configure_baud, config.baud.uart1, config.baud.uart2
+                )
+
             self._state = DeviceConnectionState.CONNECTED
         except Exception as exc:
             self._state = DeviceConnectionState.CONNECTED
             self._last_error = str(exc)
             raise
+
+        if config.baud is not None and config.baud.uart1 is not None:
+            await self._reopen_after_baud_write(driver, config.baud.uart1)
 
         baud_rates = await asyncio.to_thread(driver.get_uart_baud_rates)
         warnings = _throughput_warnings(config, baud_rates)
@@ -797,6 +841,59 @@ class DeviceService:
 
         logger.info("apply-config applied and read-back verified")
         return ApplyConfigResult(status="ok", warnings=warnings)
+
+    async def _reopen_after_baud_write(
+        self, driver: GpsReceiverDriver, new_baud: int
+    ) -> None:
+        """Reopen the console's own link after a UART1 baud write (issue #62).
+
+        Reopening is deterministic — the new baud was just written —
+        so a single attempt normally suffices. A failure retries once
+        at the previous baud purely to leave the caller with *some*
+        link back if possible, then raises ``ApplyConfigLinkLostError``
+        regardless of whether that retry itself succeeded: the flash
+        write stands either way, since writing the old baud back would
+        fight the write that just landed, and retrying the old rate
+        forever would hang.
+        """
+        previous_baud = self._baud_rate
+        assert (
+            previous_baud is not None
+        )  # set by connect(), which _require_connected() guarantees ran
+
+        try:
+            info = await asyncio.to_thread(driver.reconnect_at_baud, new_baud)
+            self._baud_rate = new_baud
+            self._info = info
+            return
+        except Exception as exc:
+            logger.warning(
+                "apply-config: reopen at new baud %d failed (%s), retrying "
+                "once at previous baud %d",
+                new_baud,
+                exc,
+                previous_baud,
+            )
+
+        try:
+            info = await asyncio.to_thread(driver.reconnect_at_baud, previous_baud)
+            self._baud_rate = previous_baud
+            self._info = info
+            self._state = DeviceConnectionState.CONNECTED
+        except Exception as exc:
+            logger.warning(
+                "apply-config: retry at previous baud %d also failed (%s)",
+                previous_baud,
+                exc,
+            )
+            self._state = DeviceConnectionState.DISCONNECTED
+
+        self._last_error = (
+            f"Receiver reconfigured but link lost — could not reopen at "
+            f"the new baud ({new_baud}) or the previous baud ({previous_baud})"
+        )
+        logger.error(self._last_error)
+        raise ApplyConfigLinkLostError(previous_baud, new_baud)
 
     @staticmethod
     def _diff_rtcm_matrix(

--- a/src/sp_rtk_base/services/drivers/base.py
+++ b/src/sp_rtk_base/services/drivers/base.py
@@ -314,8 +314,9 @@ class GpsReceiverDriver(abc.ABC):
     def get_uart_baud_rates(self) -> dict[PortId, int]:
         """Read the live UART1/UART2 baud rates.
 
-        Used only for the non-blocking apply-config throughput
-        estimate — baud itself is never written by apply-config.
+        Used for the non-blocking apply-config throughput estimate,
+        and as the "previous baud" to fall back to if a baud write's
+        reopen fails (issue #62).
 
         Returns:
             Baud rate for UART1 and UART2 (USB has no baud rate).
@@ -323,6 +324,41 @@ class GpsReceiverDriver(abc.ABC):
         Raises:
             ConnectionError: If not connected.
             RuntimeError: If the read fails.
+        """
+
+    @abc.abstractmethod
+    def configure_baud(self, uart1: int | None, uart2: int | None) -> None:
+        """Write only the UART baud fields provided; ``None`` means leave untouched.
+
+        Written last by the apply-config service, after every other
+        key — a baud change on the port the console's own management
+        link uses (UART1, per the documented FTDI deployment) must
+        not disturb the ACK of any earlier write still in flight
+        (issue #62). USB has no baud rate and isn't a parameter here.
+
+        Raises:
+            ConnectionError: If not connected.
+            RuntimeError: If the write fails.
+        """
+
+    @abc.abstractmethod
+    def reconnect_at_baud(self, baud_rate: int) -> DeviceInfo:
+        """Reopen the serial connection on the same port at a new baud rate.
+
+        Called immediately after a ``configure_baud`` write changes
+        UART1's baud — the port this console's own management link
+        uses — so the read-back verify that follows has a live link
+        to run against (issue #62).
+
+        Returns:
+            Refreshed device identity from the reconnected receiver.
+
+        Raises:
+            RuntimeError: If the driver was never connected (no saved
+                port to reopen).
+            ConnectionError: If the device doesn't respond at the
+                given baud.
+            TimeoutError: If the device doesn't respond in time.
         """
 
     # ------------------------------------------------------------------

--- a/src/sp_rtk_base/services/drivers/fake.py
+++ b/src/sp_rtk_base/services/drivers/fake.py
@@ -463,6 +463,20 @@ class FakeGpsDriver(GpsReceiverDriver):
         self._ensure_connected()
         return dict(self._uart_baud_rates)
 
+    def configure_baud(self, uart1: int | None, uart2: int | None) -> None:
+        """Store only the UART baud fields provided (issue #62)."""
+        self._ensure_connected()
+        if uart1 is not None:
+            self._uart_baud_rates[PortId.UART1] = uart1
+        if uart2 is not None:
+            self._uart_baud_rates[PortId.UART2] = uart2
+
+    def reconnect_at_baud(self, baud_rate: int) -> DeviceInfo:
+        """Simulate reopening at a new baud — no I/O, always succeeds."""
+        self._ensure_connected()
+        self._baud_rate = baud_rate
+        return self._device_info
+
     # ------------------------------------------------------------------
     # GNSS constellation configuration
     # ------------------------------------------------------------------

--- a/src/sp_rtk_base/services/drivers/ublox.py
+++ b/src/sp_rtk_base/services/drivers/ublox.py
@@ -1378,6 +1378,48 @@ class UbloxDriver(GpsReceiverDriver):
             PortId.UART2: raw["CFG_UART2_BAUDRATE"],
         }
 
+    def configure_baud(self, uart1: int | None, uart2: int | None) -> None:
+        """Write only the UART baud fields provided (issue #62).
+
+        Deliberately the last apply-config write — see the module's
+        write-ordering rationale in ``DeviceService.apply_receiver_config``.
+        """
+        cfg_data: list[tuple[str, int]] = []
+        if uart1 is not None:
+            cfg_data.append(("CFG_UART1_BAUDRATE", uart1))
+        if uart2 is not None:
+            cfg_data.append(("CFG_UART2_BAUDRATE", uart2))
+
+        if not cfg_data:
+            return
+        with self._lock:
+            self._send_cfg_valset_locked(cfg_data, layer=5)
+
+    def reconnect_at_baud(self, baud_rate: int) -> DeviceInfo:
+        """Reopen the serial port at ``baud_rate`` without resetting the receiver.
+
+        Unlike ``reset_and_reconnect``, this doesn't touch the chip.
+        A baud write's ACK goes out over the wire at the *old* baud,
+        just before the UART peripheral itself switches — by the time
+        ``configure_baud`` returns, the receiver side is already done.
+        Only the host's own pyserial handle needs to reopen at the
+        new rate and redo the MON-VER handshake to confirm the link
+        is live (issue #62).
+
+        Raises:
+            RuntimeError: If the driver was never connected (no saved
+                port to reopen).
+        """
+        if self._port is None:
+            raise RuntimeError(
+                "Cannot reopen at a new baud — driver was never connected "
+                "(no saved port to reopen)."
+            )
+        port = self._port
+        with self._lock:
+            self._cleanup()
+        return self.connect(port, baud_rate)
+
     def save_to_flash(self) -> None:
         """Save current RAM config to BBR + Flash (layers 7)."""
         # CFG-CFG: save current config to all non-volatile layers

--- a/tests/unit/test_api_device.py
+++ b/tests/unit/test_api_device.py
@@ -670,6 +670,24 @@ class TestApplyConfig:
         )
         assert resp.status_code == 422
 
+    def test_apply_config_link_lost(
+        self,
+        client: TestClient,
+        mock_device_service: MagicMock,
+    ) -> None:
+        """A UART1 baud write that strands the console's own link is a
+        distinct 502 — not a generic apply failure (issue #62)."""
+        from sp_rtk_base.services.device_service import ApplyConfigLinkLostError
+
+        mock_device_service.apply_receiver_config = AsyncMock(
+            side_effect=ApplyConfigLinkLostError(previous_baud=57600, new_baud=115200),
+        )
+        resp = client.post("/api/device/apply-config", json=_MINIMAL_APPLY_BODY)
+        assert resp.status_code == 502
+        detail = resp.json()["detail"]
+        assert "57600" in detail
+        assert "115200" in detail
+
 
 # ---------------------------------------------------------------------------
 # Handoff — device → relay

--- a/tests/unit/test_device_service.py
+++ b/tests/unit/test_device_service.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, PropertyMock
+from unittest.mock import MagicMock, PropertyMock, call
 
 import pytest
 
@@ -32,7 +32,11 @@ from sp_rtk_base.models.profile_models import (
     ReceiverConfig,
     RtcmStreamConfig,
 )
-from sp_rtk_base.services.device_service import ApplyConfigRefusedError, DeviceService
+from sp_rtk_base.services.device_service import (
+    ApplyConfigLinkLostError,
+    ApplyConfigRefusedError,
+    DeviceService,
+)
 from sp_rtk_base.services.drivers.base import GpsReceiverDriver
 
 # ---------------------------------------------------------------------------
@@ -399,6 +403,7 @@ class TestApplyReceiverConfig:
         svc.set_driver(driver)
         svc._state = DeviceConnectionState.CONNECTED
         svc._info = DeviceInfo(vendor="MockVendor", model="MockModel")
+        svc._baud_rate = 57600
         return svc
 
     @pytest.mark.asyncio()
@@ -409,24 +414,158 @@ class TestApplyReceiverConfig:
             await svc.apply_receiver_config(_minimal_config())
 
     @pytest.mark.asyncio()
-    async def test_baud_out_of_scope_refused_before_any_write(
-        self, connected_svc: DeviceService
-    ) -> None:
-        assert connected_svc.driver is not None
-        config = _minimal_config(baud=BaudConfig(uart1=57600))
-
-        with pytest.raises(ApplyConfigRefusedError) as exc_info:
-            await connected_svc.apply_receiver_config(config)
-
-        assert exc_info.value.rule == "baud_out_of_scope"
-        connected_svc.driver.configure_measurement_rate.assert_not_called()  # type: ignore[union-attr]
-
-    @pytest.mark.asyncio()
     async def test_baud_omitted_is_allowed(self, connected_svc: DeviceService) -> None:
         result = await connected_svc.apply_receiver_config(
             _minimal_config(baud=BaudConfig())
         )
         assert result.status == "ok"
+
+    @pytest.mark.asyncio()
+    async def test_baud_written_last_after_every_other_key(
+        self, connected_svc: DeviceService
+    ) -> None:
+        driver = connected_svc.driver
+        assert driver is not None
+        driver.reconnect_at_baud.return_value = DeviceInfo(  # type: ignore[union-attr]
+            vendor="MockVendor", model="MockModel"
+        )
+        config = _minimal_config(
+            baud=BaudConfig(uart1=115200),
+            dyn_model=DynModel.STATIONARY,
+            tmode_mode=BaseMode.DISABLED,
+        )
+
+        await connected_svc.apply_receiver_config(config)
+
+        write_methods = {
+            "configure_measurement_rate",
+            "configure_optimisations",
+            "configure_dyn_model",
+            "configure_tmode_mode",
+            "apply_rtcm_matrix",
+            "configure_baud",
+        }
+        order: list[str] = [
+            call_[0]
+            for call_ in driver.method_calls  # type: ignore[union-attr]
+            if call_[0] in write_methods
+        ]
+        assert order[-1] == "configure_baud"
+        driver.configure_baud.assert_called_once_with(115200, None)  # type: ignore[union-attr]
+
+    @pytest.mark.asyncio()
+    async def test_baud_uart1_and_uart2_both_written(
+        self, connected_svc: DeviceService
+    ) -> None:
+        driver = connected_svc.driver
+        assert driver is not None
+        driver.reconnect_at_baud.return_value = DeviceInfo(  # type: ignore[union-attr]
+            vendor="MockVendor", model="MockModel"
+        )
+        config = _minimal_config(baud=BaudConfig(uart1=115200, uart2=38400))
+
+        await connected_svc.apply_receiver_config(config)
+
+        driver.configure_baud.assert_called_once_with(115200, 38400)  # type: ignore[union-attr]
+
+    @pytest.mark.asyncio()
+    async def test_baud_uart2_only_does_not_reopen(
+        self, connected_svc: DeviceService
+    ) -> None:
+        """UART2 isn't the port this console's own link is on — no reopen."""
+        driver = connected_svc.driver
+        assert driver is not None
+        config = _minimal_config(baud=BaudConfig(uart2=38400))
+
+        result = await connected_svc.apply_receiver_config(config)
+
+        assert result.status == "ok"
+        driver.configure_baud.assert_called_once_with(None, 38400)  # type: ignore[union-attr]
+        driver.reconnect_at_baud.assert_not_called()  # type: ignore[union-attr]
+
+    @pytest.mark.asyncio()
+    async def test_baud_uart1_reopens_before_read_back_verify(
+        self, connected_svc: DeviceService
+    ) -> None:
+        driver = connected_svc.driver
+        assert driver is not None
+        driver.reconnect_at_baud.return_value = DeviceInfo(  # type: ignore[union-attr]
+            vendor="MockVendor", model="MockModel"
+        )
+        config = _minimal_config(baud=BaudConfig(uart1=115200))
+
+        result = await connected_svc.apply_receiver_config(config)
+
+        assert result.status == "ok"
+        driver.reconnect_at_baud.assert_called_once_with(115200)  # type: ignore[union-attr]
+        order = [
+            call_[0]
+            for call_ in driver.method_calls  # type: ignore[union-attr]
+            if call_[0] in {"reconnect_at_baud", "get_rtcm_port_config"}
+        ]
+        assert order == ["reconnect_at_baud", "get_rtcm_port_config"]
+
+    @pytest.mark.asyncio()
+    async def test_baud_uart1_reopen_success_updates_tracked_baud(
+        self, connected_svc: DeviceService
+    ) -> None:
+        driver = connected_svc.driver
+        assert driver is not None
+        connected_svc._baud_rate = 57600  # pyright: ignore[reportPrivateUsage]
+        driver.reconnect_at_baud.return_value = DeviceInfo(  # type: ignore[union-attr]
+            vendor="MockVendor", model="MockModel"
+        )
+        config = _minimal_config(baud=BaudConfig(uart1=115200))
+
+        await connected_svc.apply_receiver_config(config)
+
+        assert connected_svc._baud_rate == 115200  # pyright: ignore[reportPrivateUsage]
+
+    @pytest.mark.asyncio()
+    async def test_baud_uart1_reopen_failure_retries_at_previous_baud_then_raises(
+        self, connected_svc: DeviceService
+    ) -> None:
+        driver = connected_svc.driver
+        assert driver is not None
+        connected_svc._baud_rate = 57600  # pyright: ignore[reportPrivateUsage]
+        driver.reconnect_at_baud.side_effect = ConnectionError(  # type: ignore[union-attr]
+            "no response"
+        )
+        config = _minimal_config(baud=BaudConfig(uart1=115200))
+
+        with pytest.raises(ApplyConfigLinkLostError) as exc_info:
+            await connected_svc.apply_receiver_config(config)
+
+        assert exc_info.value.previous_baud == 57600
+        assert exc_info.value.new_baud == 115200
+        driver.reconnect_at_baud.assert_has_calls(  # type: ignore[union-attr]
+            [call(115200), call(57600)]
+        )
+        assert connected_svc.state == DeviceConnectionState.DISCONNECTED
+        driver.get_rtcm_port_config.assert_not_called()  # type: ignore[union-attr]
+
+    @pytest.mark.asyncio()
+    async def test_baud_uart1_reopen_retry_recovers_link_but_still_raises(
+        self, connected_svc: DeviceService
+    ) -> None:
+        """Even a successful previous-baud retry still surfaces the
+        distinct error — the flash write stands and the caller must
+        act, not just silently limp along at the stale baud."""
+        driver = connected_svc.driver
+        assert driver is not None
+        connected_svc._baud_rate = 57600  # pyright: ignore[reportPrivateUsage]
+        driver.reconnect_at_baud.side_effect = [  # type: ignore[union-attr]
+            ConnectionError("no response at new baud"),
+            DeviceInfo(vendor="MockVendor", model="MockModel"),
+        ]
+        config = _minimal_config(baud=BaudConfig(uart1=115200))
+
+        with pytest.raises(ApplyConfigLinkLostError):
+            await connected_svc.apply_receiver_config(config)
+
+        assert connected_svc.state == DeviceConnectionState.CONNECTED
+        assert connected_svc._baud_rate == 57600  # pyright: ignore[reportPrivateUsage]
+        driver.get_rtcm_port_config.assert_not_called()  # type: ignore[union-attr]
 
     @pytest.mark.asyncio()
     async def test_ubx_in_liveness_guard_refuses_before_any_write(

--- a/tests/unit/test_driver_registry.py
+++ b/tests/unit/test_driver_registry.py
@@ -132,6 +132,12 @@ class StubDriver(GpsReceiverDriver):
     def get_uart_baud_rates(self) -> dict[PortId, int]:
         return {}
 
+    def configure_baud(self, uart1: int | None, uart2: int | None) -> None:
+        pass
+
+    def reconnect_at_baud(self, baud_rate: int) -> DeviceInfo:
+        return DeviceInfo(vendor="StubVendor", model="StubModel")
+
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/tests/unit/test_fake_driver.py
+++ b/tests/unit/test_fake_driver.py
@@ -463,6 +463,24 @@ class TestConfigurationRoundTrips:
         rates = connected_driver.get_uart_baud_rates()
         assert rates == {PortId.UART1: 57600, PortId.UART2: 115200}
 
+    def test_configure_baud_stores_only_provided_fields(
+        self, connected_driver: FakeGpsDriver
+    ) -> None:
+        connected_driver.configure_baud(115200, None)
+        rates = connected_driver.get_uart_baud_rates()
+        assert rates == {PortId.UART1: 115200, PortId.UART2: 115200}
+
+        connected_driver.configure_baud(None, 38400)
+        rates = connected_driver.get_uart_baud_rates()
+        assert rates == {PortId.UART1: 115200, PortId.UART2: 38400}
+
+    def test_reconnect_at_baud_updates_baud_and_returns_device_info(
+        self, connected_driver: FakeGpsDriver
+    ) -> None:
+        info = connected_driver.reconnect_at_baud(115200)
+        assert info.model == "FAKE-F9P"
+        assert connected_driver._baud_rate == 115200
+
 
 # ---------------------------------------------------------------------------
 # Position fixture

--- a/tests/unit/test_profile_models.py
+++ b/tests/unit/test_profile_models.py
@@ -134,6 +134,22 @@ class TestReceiverConfig:
     def test_baud_has_no_usb_field(self) -> None:
         assert "usb" not in {f.lower() for f in ReceiverConfig.model_fields}
 
+    def test_baud_usb_key_rejected(self) -> None:
+        """USB CDC has no baud rate — ``BaudConfig`` forbids the key
+        outright rather than silently ignoring it (issue #62)."""
+        kwargs = _base_kwargs()
+        kwargs["baud"] = {"uart1": 57600, "usb": 9600}
+        with pytest.raises(ValidationError):
+            ReceiverConfig.model_validate(kwargs)
+
+    def test_baud_uart2_only_accepted(self) -> None:
+        kwargs = _base_kwargs()
+        kwargs["baud"] = {"uart2": 38400}
+        config = ReceiverConfig.model_validate(kwargs)
+        assert config.baud is not None
+        assert config.baud.uart1 is None
+        assert config.baud.uart2 == 38400
+
     @pytest.mark.parametrize("elevation_mask_deg", [-1, 91])
     def test_elevation_mask_deg_out_of_range_rejected(
         self, elevation_mask_deg: int

--- a/tests/unit/test_ublox_driver.py
+++ b/tests/unit/test_ublox_driver.py
@@ -2392,3 +2392,134 @@ class TestGetUartBaudRates:
         result = driver.get_uart_baud_rates()
 
         assert result == {PortId.UART1: 57600, PortId.UART2: 115200}
+
+
+class TestConfigureBaud:
+    """Tests for ``UbloxDriver.configure_baud`` (issue #62)."""
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_writes_only_uart1_when_uart2_omitted(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        driver, _reader = _connect_driver(
+            mock_serial_cls, mock_reader_cls, mock_ubx_msg, [_make_ack_response()]
+        )
+
+        driver.configure_baud(115200, None)
+
+        layer, _, cfg_data = mock_ubx_msg.config_set.call_args[0]
+        assert layer == 5
+        assert dict(cfg_data) == {"CFG_UART1_BAUDRATE": 115200}
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_writes_both_fields_when_both_provided(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        driver, _reader = _connect_driver(
+            mock_serial_cls, mock_reader_cls, mock_ubx_msg, [_make_ack_response()]
+        )
+
+        driver.configure_baud(115200, 38400)
+
+        _, _, cfg_data = mock_ubx_msg.config_set.call_args[0]
+        assert dict(cfg_data) == {
+            "CFG_UART1_BAUDRATE": 115200,
+            "CFG_UART2_BAUDRATE": 38400,
+        }
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_no_write_when_both_omitted(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        driver, _reader = _connect_driver(
+            mock_serial_cls, mock_reader_cls, mock_ubx_msg, []
+        )
+
+        driver.configure_baud(None, None)
+
+        mock_ubx_msg.config_set.assert_not_called()
+
+
+class TestReconnectAtBaud:
+    """Tests for ``UbloxDriver.reconnect_at_baud`` (issue #62)."""
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_reopens_same_port_at_new_baud(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        """Does not touch the chip — closes and reopens the host's own
+        serial handle, then redoes the MON-VER handshake."""
+        first_ser = MagicMock()
+        first_ser.is_open = True
+        second_ser = MagicMock()
+        second_ser.is_open = True
+        mock_serial_cls.side_effect = [first_ser, second_ser]
+
+        reader = MagicMock()
+        reader.read.side_effect = [
+            (b"", _make_mon_ver_response()),
+            (b"", _make_mon_ver_response()),
+        ]
+        mock_reader_cls.return_value = reader
+
+        driver = UbloxDriver()
+        driver.connect("/dev/ttyUSB0", 57600)
+
+        info = driver.reconnect_at_baud(115200)
+
+        assert info.model == "ZED-F9P"
+        first_ser.close.assert_called_once()
+        mock_serial_cls.assert_called_with(
+            port="/dev/ttyUSB0",
+            baudrate=115200,
+            timeout=3.0,
+            exclusive=True,
+        )
+        assert driver.is_connected is True
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_reopen_failure_raises_connection_error(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+    ) -> None:
+        first_ser = MagicMock()
+        first_ser.is_open = True
+        mock_serial_cls.side_effect = [first_ser, ConnectionError("no response")]
+
+        reader = MagicMock()
+        reader.read.return_value = (b"", _make_mon_ver_response())
+        mock_reader_cls.return_value = reader
+
+        driver = UbloxDriver()
+        driver.connect("/dev/ttyUSB0", 57600)
+
+        with pytest.raises(ConnectionError):
+            driver.reconnect_at_baud(115200)
+        assert driver.is_connected is False
+
+    def test_never_connected_raises_runtime_error(self) -> None:
+        driver = UbloxDriver()
+        with pytest.raises(RuntimeError, match="never connected"):
+            driver.reconnect_at_baud(115200)


### PR DESCRIPTION
## Summary
- `baud` in a `ReceiverConfig` is now written last during apply-config, at layer=5, after every other key has landed.
- If `baud.uart1` is set — the port the documented deployment's console link is on — the console reopens its own serial connection at the new baud before the RTCM read-back verify runs. `baud.uart2` never triggers a reopen.
- A failed reopen retries once at the previous baud, then raises a distinct `ApplyConfigLinkLostError` (mapped to HTTP 502) naming both bauds. The flash write is never rolled back.
- Removes the #61-era guard that unconditionally rejected any non-null `baud` in apply-config.
- Adds `configure_baud`/`reconnect_at_baud` to the `GpsReceiverDriver` ABC, implemented in `UbloxDriver` and `FakeGpsDriver`.

Closes #62.

## Test plan
- [x] `uv run pytest` — full unit suite (1305 tests) passes, coverage 92.91% (gate 90%)
- [x] `uv run pyright src/` — clean
- [x] `uv run mypy src/` — clean
- [x] `uv run ruff check` / `ruff format --check` — clean
- [x] New tests assert: baud written last, reopen runs before read-back verify, uart2-only doesn't reopen, retry-then-raise semantics (including the retry-succeeds-but-still-raises edge case), USB excluded from `BaudConfig`
- [x] Ran `/code-review` (Standards + Spec axes); addressed both findings before pushing (swallowed exception in retry logging; a docstring inconsistency with the pre-existing UBX-in-liveness guard's "always USB" assumption)

🤖 Generated with [Claude Code](https://claude.com/claude-code)