### PR TITLE
fix: retire legacy USB-only RTCM path and base-mode force-applies

### DIFF
--- a/src/sp_rtk_base/api/device.py
+++ b/src/sp_rtk_base/api/device.py
@@ -18,13 +18,13 @@ from sp_rtk_base.models.config_models import (
 )
 from sp_rtk_base.models.device_models import (
     ApplyConfigResult,
+    BaseInvariantsCheck,
     CurrentBaseConfig,
     DeviceStatus,
     FixedBaseConfig,
     GnssConfig,
     GpsPosition,
     PortProtocolConfig,
-    RtcmMessageConfig,
     RtcmPortConfig,
     SerialPortInfo,
     SurveyInConfig,
@@ -226,21 +226,42 @@ async def configure_fixed_base(
     )
 
 
-@router.post("/configure/rtcm", response_model=DeviceActionResponse)
-async def configure_rtcm_messages(
-    config: RtcmMessageConfig,
+@router.get("/base-invariants", response_model=BaseInvariantsCheck)
+async def check_base_invariants(
     svc: DeviceService = Depends(get_device_service),
-) -> DeviceActionResponse:
-    """Configure RTCM message output on the receiver."""
+) -> BaseInvariantsCheck:
+    """Pre-flight check for the base invariants (issue #63).
+
+    Non-blocking: an empty ``warnings`` list means the live receiver
+    already matches the built-in base profile's dynamics-model and
+    RTCM-on-data-link-port invariants. A non-empty list is advisory
+    only — it never refuses a survey-in start.
+    """
     try:
-        await svc.configure_rtcm_messages(config)
+        return await svc.check_base_invariants()
     except RuntimeError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 
-    return DeviceActionResponse(
-        status="ok",
-        message=f"RTCM messages configured: {config.message_id_values}",
-    )
+
+@router.post("/apply-base-invariants", response_model=ApplyConfigResult)
+async def apply_base_invariants(
+    svc: DeviceService = Depends(get_device_service),
+) -> ApplyConfigResult:
+    """One-click remedy for a ``check_base_invariants`` warning (issue #63).
+
+    Applies the built-in base profile via the same
+    ``apply_receiver_config`` pipeline as ``POST /apply-config``, minus
+    baud (see ``DeviceService.apply_base_invariants``) — so this can
+    never trigger the 502 link-lost case ``POST /apply-config`` can.
+    Same status contract otherwise: 409 not connected/relay running,
+    400 business-rule refusal.
+    """
+    try:
+        return await svc.apply_base_invariants()
+    except ApplyConfigRefusedError as exc:
+        raise HTTPException(status_code=400, detail=f"{exc.rule}: {exc}") from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
 
 
 @router.post("/save", response_model=DeviceActionResponse)

--- a/src/sp_rtk_base/models/device_models.py
+++ b/src/sp_rtk_base/models/device_models.py
@@ -221,47 +221,16 @@ class RtcmRowId(str, enum.Enum):
     RTCM_1230 = "1230"
 
 
-class RtcmMessageConfig(BaseModel):
-    """RTCM message output selection (simple, single-port).
+class BaseInvariantsCheck(BaseModel):
+    """Result of the pre-flight base-invariants check (issue #63).
 
-    Standard RTCM 3.x rows for base station operation:
-    - 1005: Station ARP (position)
-    - 1077: GPS MSM7
-    - 1087: GLONASS MSM7
-    - 1097: Galileo MSM7
-    - 1127: BeiDou MSM7
-    - 1230: GLONASS code-phase biases
+    Non-blocking advisories only — ``warnings`` never prevents a
+    survey-in from starting. Empty means the live receiver config
+    already matches the built-in base profile's dynamics-model and
+    RTCM-on-data-link-port invariants.
     """
 
-    message_ids: list[RtcmRowId] = Field(
-        default_factory=lambda: [
-            RtcmRowId.RTCM_1005,
-            RtcmRowId.RTCM_1077,
-            RtcmRowId.RTCM_1087,
-            RtcmRowId.RTCM_1097,
-            RtcmRowId.RTCM_1127,
-            RtcmRowId.RTCM_1230,
-        ],
-        description="RTCM row IDs to enable on the receiver",
-    )
-    rate_hz: int = Field(
-        default=1,
-        ge=1,
-        le=10,
-        description="Output rate in Hz (messages per second)",
-    )
-
-    @property
-    def message_id_values(self) -> list[str]:
-        """Plain string values, for logging/display.
-
-        A bare f-string/list of ``RtcmRowId`` members renders via
-        ``repr()`` (e.g. ``<RtcmRowId.RTCM_1005: '1005'>``) rather than
-        the enum's string value, since Python only special-cases the
-        mixed-in ``__str__`` for a single member, not one nested in a
-        list.
-        """
-        return [m.value for m in self.message_ids]
+    warnings: list[str] = Field(default_factory=lambda: list[str]())
 
 
 class RtcmOutputPort(str, enum.Enum):

--- a/src/sp_rtk_base/services/device_service.py
+++ b/src/sp_rtk_base/services/device_service.py
@@ -17,6 +17,7 @@ from typing import Protocol
 from sp_rtk_base.models.device_models import (
     ApplyConfigCellDiff,
     ApplyConfigResult,
+    BaseInvariantsCheck,
     CurrentBaseConfig,
     DeviceCapability,
     DeviceConnectionState,
@@ -27,7 +28,6 @@ from sp_rtk_base.models.device_models import (
     GpsPosition,
     PortId,
     PortProtocolConfig,
-    RtcmMessageConfig,
     RtcmPortConfig,
     RtcmRowId,
     SurveyInConfig,
@@ -38,6 +38,7 @@ from sp_rtk_base.models.device_models import (
     BaseMode as TmodeMode,
 )
 from sp_rtk_base.models.profile_models import ReceiverConfig
+from sp_rtk_base.profiles import BUILTIN_PROFILES
 from sp_rtk_base.services.drivers.base import GpsReceiverDriver
 
 logger = logging.getLogger(__name__)
@@ -113,6 +114,14 @@ _BITS_PER_BYTE_ON_WIRE = 10.0
 # Warn once estimated RTCM throughput crosses this fraction of a
 # data-link port's baud capacity.
 _THROUGHPUT_WARN_THRESHOLD = 0.70
+
+# The built-in profile whose ``ports``/``dyn_model``/``rtcm_stream``
+# values define "the base invariants" for the survey-in pre-flight
+# check (issue #63) and its one-click remedy. There is exactly one
+# built-in today (see test_builtin_profiles.py's
+# test_imports_cleanly_with_exactly_one_builtin) and it is the base
+# station reference profile.
+_BASE_INVARIANTS_PROFILE_NAME = "ublox-f9p-base-standard"
 
 
 def _throughput_warnings(
@@ -411,6 +420,70 @@ class DeviceService:
                     )
             raise
 
+    async def check_base_invariants(self) -> BaseInvariantsCheck:
+        """Non-blocking pre-flight check for the base invariants (issue #63).
+
+        Compares the live receiver against the two invariants that used
+        to be force-applied on every base-mode transition (issues #38
+        and #40, retired in #63): stationary dynamics, and at least one
+        RTCM row enabled on every data-link port of the built-in base
+        profile (:data:`_BASE_INVARIANTS_PROFILE_NAME`). Never raises
+        for a mismatch — callers (the Survey-In confirmation dialog)
+        show the warnings but let Start proceed regardless; use
+        :meth:`apply_base_invariants` for the one-click remedy.
+
+        Raises:
+            RuntimeError: If not connected or relay is running.
+        """
+        driver = self._require_connected()
+        profile = BUILTIN_PROFILES[_BASE_INVARIANTS_PROFILE_NAME]
+
+        live_dyn_model = await asyncio.to_thread(driver.get_dyn_model)
+        live_rtcm = await asyncio.to_thread(driver.get_rtcm_port_config)
+
+        warnings: list[str] = []
+        if profile.dyn_model is not None and live_dyn_model != profile.dyn_model:
+            warnings.append(
+                f"Dynamics model is {live_dyn_model.value}, not "
+                f"{profile.dyn_model.value} — a base station should run "
+                "stationary dynamics."
+            )
+
+        for port in profile.data_link_port:
+            has_rtcm = any(
+                rates.get(port.value, 0) > 0 for rates in live_rtcm.messages.values()
+            )
+            if not has_rtcm:
+                warnings.append(
+                    f"No RTCM messages are enabled on {port.value} — this "
+                    "data-link port would broadcast no corrections."
+                )
+
+        return BaseInvariantsCheck(warnings=warnings)
+
+    async def apply_base_invariants(self) -> ApplyConfigResult:
+        """Apply the built-in base profile as the one-click remedy for issue #63.
+
+        Reuses :meth:`apply_receiver_config` — the built-in profile
+        (:data:`_BASE_INVARIANTS_PROFILE_NAME`) already specifies the
+        port protocols, dynamics model and RTCM matrix that satisfy
+        :meth:`check_base_invariants`. ``baud`` is stripped from the
+        profile before applying: the two invariants this remedy exists
+        for (dynamics model, RTCM-on-data-link-port) never touch baud,
+        so a one-click warning fix should not risk stranding the
+        console's own link on a UART1 baud change the operator didn't
+        ask for.
+
+        Raises:
+            RuntimeError: If not connected or relay is running.
+            ApplyConfigRefusedError: If a device-state guard rejects the
+                profile before any write.
+        """
+        profile = BUILTIN_PROFILES[_BASE_INVARIANTS_PROFILE_NAME]
+        return await self.apply_receiver_config(
+            profile.model_copy(update={"baud": None})
+        )
+
     async def send_cfg_rst_diagnostic(
         self,
         reset_mode: int,
@@ -538,42 +611,6 @@ class DeviceService:
             self._state = DeviceConnectionState.CONNECTED
             self._last_error = str(exc)
             raise
-
-    async def configure_rtcm_messages(self, config: RtcmMessageConfig) -> None:
-        """Enable/disable RTCM message outputs.
-
-        Args:
-            config: RTCM message selection.
-
-        Raises:
-            RuntimeError: If not connected or relay is running.
-        """
-        driver = self._require_connected()
-        self._state = DeviceConnectionState.CONFIGURING
-        try:
-            await asyncio.to_thread(driver.configure_rtcm_messages, config)
-            self._state = DeviceConnectionState.CONNECTED
-            logger.info(
-                "RTCM messages configured: %s @ %dHz",
-                config.message_id_values,
-                config.rate_hz,
-            )
-        except Exception as exc:
-            self._state = DeviceConnectionState.CONNECTED
-            self._last_error = str(exc)
-            raise
-
-    async def get_rtcm_config(self) -> RtcmMessageConfig:
-        """Read the current RTCM message output configuration.
-
-        Returns:
-            Current RTCM message selection and rate.
-
-        Raises:
-            RuntimeError: If not connected.
-        """
-        driver = self._require_connected()
-        return await asyncio.to_thread(driver.get_rtcm_config)
 
     async def get_rtcm_port_config(self) -> RtcmPortConfig:
         """Read RTCM output config for all ports (USB, UART1, etc.).

--- a/src/sp_rtk_base/services/drivers/base.py
+++ b/src/sp_rtk_base/services/drivers/base.py
@@ -20,7 +20,6 @@ from sp_rtk_base.models.device_models import (
     GpsPosition,
     PortId,
     PortProtocolConfig,
-    RtcmMessageConfig,
     RtcmPortConfig,
     RtcmRowId,
     SerialPortInfo,
@@ -133,30 +132,6 @@ class GpsReceiverDriver(abc.ABC):
         """
 
     @abc.abstractmethod
-    def configure_rtcm_messages(self, config: RtcmMessageConfig) -> None:
-        """Enable/disable RTCM message outputs on the receiver.
-
-        Args:
-            config: RTCM message selection and rate.
-
-        Raises:
-            ConnectionError: If not connected.
-            RuntimeError: If configuration fails.
-        """
-
-    @abc.abstractmethod
-    def get_rtcm_config(self) -> RtcmMessageConfig:
-        """Read the current RTCM message output configuration.
-
-        Returns:
-            Current RTCM message selection and rate.
-
-        Raises:
-            ConnectionError: If not connected.
-            RuntimeError: If the read fails.
-        """
-
-    @abc.abstractmethod
     def get_rtcm_port_config(self) -> RtcmPortConfig:
         """Read RTCM output config for all ports (USB, UART1, etc.).
 
@@ -255,6 +230,18 @@ class GpsReceiverDriver(abc.ABC):
         Raises:
             ConnectionError: If not connected.
             RuntimeError: If the write fails.
+        """
+
+    @abc.abstractmethod
+    def get_dyn_model(self) -> DynModel:
+        """Read the receiver's current dynamics platform model.
+
+        Used by the survey-in pre-flight check (issue #63) to detect
+        a receiver that hasn't had the base invariants applied.
+
+        Raises:
+            ConnectionError: If not connected.
+            RuntimeError: If the read fails.
         """
 
     @abc.abstractmethod

--- a/src/sp_rtk_base/services/drivers/fake.py
+++ b/src/sp_rtk_base/services/drivers/fake.py
@@ -64,7 +64,6 @@ from sp_rtk_base.models.device_models import (
     GpsPosition,
     PortId,
     PortProtocolConfig,
-    RtcmMessageConfig,
     RtcmPortConfig,
     RtcmRowId,
     SerialPortInfo,
@@ -144,7 +143,6 @@ class FakeGpsDriver(GpsReceiverDriver):
         self._survey_min_duration_s: int = 60
 
         # RTCM configuration — initialised with sensible defaults.
-        self._rtcm_msgs: RtcmMessageConfig = RtcmMessageConfig()
         self._rtcm_ports: RtcmPortConfig = RtcmPortConfig(
             messages={
                 msg_id: {"USB": 1, "UART1": 1, "UART2": 0, "I2C": 0, "SPI": 0}
@@ -353,16 +351,6 @@ class FakeGpsDriver(GpsReceiverDriver):
             accuracy_mm=0,
         )
 
-    def configure_rtcm_messages(self, config: RtcmMessageConfig) -> None:
-        """Store the simple RTCM message config in memory."""
-        self._ensure_connected()
-        self._rtcm_msgs = config
-
-    def get_rtcm_config(self) -> RtcmMessageConfig:
-        """Return the most recently stored simple RTCM config."""
-        self._ensure_connected()
-        return self._rtcm_msgs
-
     def get_rtcm_port_config(self) -> RtcmPortConfig:
         """Return the most recently stored per-port RTCM config."""
         self._ensure_connected()
@@ -420,6 +408,11 @@ class FakeGpsDriver(GpsReceiverDriver):
         """Store the dynamics model in memory."""
         self._ensure_connected()
         self._dyn_model = model
+
+    def get_dyn_model(self) -> DynModel:
+        """Return the most recently stored dynamics model."""
+        self._ensure_connected()
+        return self._dyn_model
 
     def configure_tmode_mode(self, mode: BaseMode) -> None:
         """Store the TMODE mode, leaving any existing position untouched."""

--- a/src/sp_rtk_base/services/drivers/ublox.py
+++ b/src/sp_rtk_base/services/drivers/ublox.py
@@ -40,7 +40,6 @@ from sp_rtk_base.models.device_models import (
     GpsPosition,
     PortId,
     PortProtocolConfig,
-    RtcmMessageConfig,
     RtcmOutputPort,
     RtcmPortConfig,
     RtcmRowId,
@@ -88,35 +87,6 @@ def _rtcm_key(msg_id: RtcmRowId, port: str) -> str:
     return f"{_RTCM_KEY_BASES[msg_id]}_{port}"
 
 
-# Legacy USB-only mapping (backward compat)
-_RTCM_USB_KEYS: dict[RtcmRowId, str] = {
-    msg_id: _rtcm_key(msg_id, "USB") for msg_id in _RTCM_KEY_BASES
-}
-
-# RTCM-only output profile applied to UART1/UART2 on every base-mode
-# transition (survey-in or fixed).  Silences NMEA/UBX output so a base
-# station doesn't flood rover data links with traffic they don't need —
-# see issue #40.  UBX *input* protocols and USB output are deliberately
-# left untouched: input must stay enabled for the app to manage the
-# receiver, and USB is used for local diagnostics.
-_BASE_OUTPUT_PROFILE: dict[str, int] = {
-    "CFG_UART1OUTPROT_NMEA": 0,
-    "CFG_UART1OUTPROT_UBX": 0,
-    "CFG_UART1OUTPROT_RTCM3X": 1,
-    "CFG_UART2OUTPROT_NMEA": 0,
-    "CFG_UART2OUTPROT_UBX": 0,
-    "CFG_UART2OUTPROT_RTCM3X": 1,
-}
-
-# u-blox dynamics-model class for a fixed-mount base station (issue #38).
-# 2 = stationary — tightens the position filter and suppresses
-# velocity/heading estimation, which is the correct nav class for a
-# receiver that never moves.  The receiver defaults to 0 (portable),
-# which is wrong for every base in this fleet, so it's applied
-# unconditionally on every base-mode transition rather than left as an
-# operator-configurable setting.
-_STATIONARY_DYN_MODEL: int = 2
-
 # CFG key prefix for each port covered by the live port-protocol read
 # (issue #57) — UART1/UART2 use a numbered prefix, USB does not.
 _PROTOCOL_PORT_PREFIXES: dict[PortId, str] = {
@@ -160,6 +130,9 @@ _DYN_MODEL_VALUES: dict[DynModel, int] = {
     DynModel.AIRBORNE_2G: 7,
     DynModel.AIRBORNE_4G: 8,
 }
+
+# Reverse of ``_DYN_MODEL_VALUES`` — for ``get_dyn_model``'s read-back.
+_DYN_MODEL_NAMES: dict[int, DynModel] = {v: k for k, v in _DYN_MODEL_VALUES.items()}
 
 # u-blox CFG_TMODE_MODE values — same mapping ``_parse_cfg_tmode`` reads back.
 _TMODE_MODE_VALUES: dict[BaseMode, int] = {
@@ -583,15 +556,15 @@ class UbloxDriver(GpsReceiverDriver):
                     "reset to 0."
                 )
 
-            # Apply the RTCM-only output profile as a separate layer=5
-            # (RAM+Flash) VALSET — independent of the survey write
-            # above (also layer=5 as of issue #42).  Silences NMEA
-            # for the whole survey, not just once a fixed base is
-            # later saved.
-            self._apply_base_output_profile_locked()
-            # Force stationary dynamics for the whole survey (issue
-            # #38) — see ``_apply_stationary_dyn_model_locked``.
-            self._apply_stationary_dyn_model_locked()
+            # Issue #63: this used to force-apply an RTCM-only UART1/
+            # UART2 output profile and stationary dynamics here on
+            # every transition (issues #40/#38). That made this method
+            # a competing writer that would silently overwrite an
+            # operator-applied ``ReceiverConfig`` profile the next time
+            # a survey-in started. Those invariants now live only in
+            # the built-in profile and are surfaced as a non-blocking
+            # pre-flight warning (``DeviceService.check_base_invariants``)
+            # instead of being force-written here.
         logger.info(
             "Survey-in configured: %ds min, %dmm accuracy",
             config.min_duration_seconds,
@@ -734,13 +707,9 @@ class UbloxDriver(GpsReceiverDriver):
                         "or power-cycle the receiver."
                     )
 
-            # Apply the RTCM-only output profile as a separate layer=5
-            # VALSET, same as configure_survey_in — see that method's
-            # comment for why this isn't merged into the write above.
-            self._apply_base_output_profile_locked()
-            # Force stationary dynamics (issue #38) — see
-            # ``_apply_stationary_dyn_model_locked``.
-            self._apply_stationary_dyn_model_locked()
+            # Issue #63: no longer force-applies the RTCM-only output
+            # profile / stationary dynamics here — see the matching
+            # comment in ``configure_survey_in``.
         logger.info(
             "Fixed base configured: %.7f, %.7f, %.2fm (ECEF cm: %d, %d, %d)",
             config.latitude,
@@ -751,104 +720,11 @@ class UbloxDriver(GpsReceiverDriver):
             ecef_z,
         )
 
-    # ------------------------------------------------------------------
-    # Base station output profile (issue #40)
-    # ------------------------------------------------------------------
-
-    def _apply_stationary_dyn_model_locked(self) -> None:
-        """Write and verify ``CFG_NAVSPG_DYNMODEL=2`` (stationary).
-
-        Must hold ``self._lock``.  Called from both ``configure_survey_in``
-        and ``configure_fixed_base`` after their mode-specific VALSET (and
-        the base output profile) has already succeeded — issue #38.
-
-        Written to layer=5 (RAM+Flash) rather than the RAM-only layer the
-        issue's original write-up suggested, matching the layer
-        ``configure_survey_in``'s own SVIN params already use since issue
-        #42: a RAM-only write reverts to the last-flashed value on reboot
-        or port reopen, which would fail this issue's own "after a reboot,
-        the value is still 2" acceptance criterion for the survey-in path.
-
-        Reuses ``_write_and_verify_locked``, so a read-back mismatch
-        retries once before raising — same pattern as every other durable
-        CFG-VALSET write in this driver.
-        """
-        self._write_and_verify_locked(
-            [("CFG_NAVSPG_DYNMODEL", _STATIONARY_DYN_MODEL)],
-            layer=5,
-            label="Dynamics model",
-        )
-        logger.info(
-            "Dynamics model set to stationary (CFG_NAVSPG_DYNMODEL=%d)",
-            _STATIONARY_DYN_MODEL,
-        )
-
-    def _apply_base_output_profile_locked(self) -> None:
-        """Write and verify the RTCM-only UART1/UART2 output profile.
-
-        Must hold ``self._lock``. Called from both ``configure_survey_in``
-        and ``configure_fixed_base`` after their mode-specific VALSET has
-        already succeeded. Always writes unconditionally — no pre-read
-        to skip an already-correct profile — since that keeps this
-        simple and guarantees convergence even after a prior partial
-        failure.
-
-        Verify-and-retry: matches ``disable_base_mode``'s pattern, since
-        the ACK can lie when the receiver is under load. A read-back
-        mismatch that survives one retry is a hard failure — the
-        RTCM-only profile is a required end-state per issue #40's
-        acceptance criteria, not best-effort, so a soft failure here
-        would silently reintroduce the exact NMEA-flooding bug this
-        exists to fix.
-        """
-        cfg_data = list(_BASE_OUTPUT_PROFILE.items())
-
-        self._send_cfg_valset_locked(cfg_data, layer=5)
-        if self._read_base_output_profile_locked() == _BASE_OUTPUT_PROFILE:
-            return
-
-        logger.warning("Base output profile mismatch after first write — retrying")
-        self._send_cfg_valset_locked(cfg_data, layer=5)
-        actual = self._read_base_output_profile_locked()
-        if actual != _BASE_OUTPUT_PROFILE:
-            raise RuntimeError(
-                "Base output profile did not take effect: receiver "
-                f"reports {actual}, expected {_BASE_OUTPUT_PROFILE} "
-                "after two write attempts. Try disconnecting and "
-                "reconnecting, or power-cycle the receiver."
-            )
-
-    def _read_base_output_profile_locked(self) -> dict[str, int]:
-        """Poll the six UART1/UART2 OUTPROT keys (must hold ``self._lock``)."""
-        ser, reader = self._require_connection()
-
-        keys: list[str | int] = list(_BASE_OUTPUT_PROFILE.keys())
-        msg = UBXMessage.config_poll(0, 0, keys)
-        ser.reset_input_buffer()
-        ser.write(msg.serialize())  # type: ignore[union-attr]
-
-        for _ in range(_MAX_READ_ATTEMPTS):
-            try:
-                raw, parsed = reader.read()  # type: ignore[misc]
-                if parsed is None:
-                    continue
-                identity = getattr(parsed, "identity", "")
-                if identity == "CFG-VALGET":
-                    return {
-                        key: int(getattr(parsed, key, -1))
-                        for key in _BASE_OUTPUT_PROFILE
-                    }
-            except Exception:
-                continue
-
-        raise RuntimeError("No CFG-VALGET response for base output profile")
-
     def _read_cfg_keys_locked(self, keys: list[str]) -> dict[str, int]:
         """Poll arbitrary CFG keys and return them as a dict (must hold ``self._lock``).
 
         Used to verify a CFG-VALSET write actually took effect — same
-        read-back pattern as ``_read_ecef_locked`` /
-        ``_read_base_output_profile_locked``, generalised to an
+        read-back pattern as ``_read_ecef_locked``, generalised to an
         arbitrary key list (issue #42).
         """
         ser, reader = self._require_connection()
@@ -902,84 +778,6 @@ class UbloxDriver(GpsReceiverDriver):
                 "disconnecting and reconnecting, or power-cycle the "
                 "receiver."
             )
-
-    def configure_rtcm_messages(self, config: RtcmMessageConfig) -> None:
-        cfg_data: list[tuple[str, int]] = []
-
-        # First disable all known RTCM messages
-        for key_name in _RTCM_USB_KEYS.values():
-            cfg_data.append((key_name, 0))
-
-        # Then enable requested messages at the specified rate
-        for msg_id in config.message_ids:
-            cfg_data.append((_RTCM_USB_KEYS[msg_id], config.rate_hz))
-
-        with self._lock:
-            # Issue #42: this used to write RAM only (layer=1), so the
-            # message selection reverted to whatever was last flashed
-            # as soon as the receiver rebooted or the port was
-            # reopened. Write RAM+Flash (layer=5) and verify the
-            # read-back, mirroring the ECEF verify-and-retry pattern
-            # added for issue #39.
-            self._write_and_verify_locked(
-                cfg_data, layer=5, label="RTCM message config"
-            )
-        logger.info(
-            "RTCM messages configured: %s @ %dHz",
-            config.message_id_values,
-            config.rate_hz,
-        )
-
-    def get_rtcm_config(self) -> RtcmMessageConfig:
-        """Read the current RTCM USB output configuration from the receiver.
-
-        Polls ``CFG_MSGOUT_RTCM_3X_TYPE*_USB`` keys and returns which
-        messages are enabled (rate > 0) and the most common rate.
-        """
-        with self._lock:
-            return self._get_rtcm_config_locked()
-
-    def _get_rtcm_config_locked(self) -> RtcmMessageConfig:
-        """Read RTCM config (must hold self._lock)."""
-        ser, reader = self._require_connection()
-
-        keys: list[str | int] = list(_RTCM_USB_KEYS.values())
-        msg = UBXMessage.config_poll(0, 0, keys)
-        ser.reset_input_buffer()
-        ser.write(msg.serialize())  # type: ignore[union-attr]
-
-        for _ in range(_MAX_READ_ATTEMPTS):
-            try:
-                raw, parsed = reader.read()  # type: ignore[misc]
-                if parsed is None:
-                    continue
-                identity = getattr(parsed, "identity", "")
-                if identity == "CFG-VALGET":
-                    return self._parse_rtcm_valget(parsed)
-            except Exception:
-                continue
-
-        raise RuntimeError("No CFG-VALGET response for RTCM config")
-
-    @staticmethod
-    def _parse_rtcm_valget(parsed: object) -> RtcmMessageConfig:
-        """Parse a CFG-VALGET response containing RTCM message rates."""
-        enabled_ids: list[RtcmRowId] = []
-        rates: list[int] = []
-
-        for msg_id, key_name in _RTCM_USB_KEYS.items():
-            rate = int(getattr(parsed, key_name, 0))
-            if rate > 0:
-                enabled_ids.append(msg_id)
-                rates.append(rate)
-
-        # Use the most common rate, defaulting to 1
-        common_rate = max(set(rates), key=rates.count) if rates else 1
-
-        return RtcmMessageConfig(
-            message_ids=enabled_ids,
-            rate_hz=common_rate,
-        )
 
     # ------------------------------------------------------------------
     # Multi-port RTCM configuration
@@ -1040,8 +838,9 @@ class UbloxDriver(GpsReceiverDriver):
         """Apply multi-port RTCM output configuration to the receiver.
 
         Sends a CFG-VALSET with rates for each message on each port,
-        writes to RAM+Flash (layer=5), and verifies the read-back —
-        see ``configure_rtcm_messages`` for why (issue #42).
+        writes to RAM+Flash (layer=5), and verifies the read-back — a
+        RAM-only write reverted to the last-flashed message selection
+        on reboot / reconnect (issue #42).
         """
         cfg_data: list[tuple[str, int]] = []
 
@@ -1066,9 +865,8 @@ class UbloxDriver(GpsReceiverDriver):
         """Read live in/out protocol state for UART1, UART2 and USB.
 
         Polls all ``CFG_{PORT}{IN,OUT}PROT_{UBX,NMEA,RTCM3X}`` keys —
-        the driver previously only polled the six UART OUTPROT keys
-        (``_read_base_output_profile_locked``); this covers INPROT and
-        USB too (issue #57).
+        the driver previously only polled the six UART OUTPROT keys;
+        this covers INPROT and USB too (issue #57).
         """
         with self._lock:
             return self._get_port_protocols_locked()
@@ -1292,18 +1090,19 @@ class UbloxDriver(GpsReceiverDriver):
             self._write_and_verify_locked(cfg_data, layer=5, label="Measurement rate")
 
     def configure_dyn_model(self, model: DynModel) -> None:
-        """Write ``CFG_NAVSPG_DYNMODEL`` for an arbitrary dynamics class.
-
-        General-purpose sibling of ``_apply_stationary_dyn_model_locked``,
-        which stays as-is (hard-coded stationary) since it's called from
-        the survey-in/fixed-base transition paths that issue #38 covers.
-        """
+        """Write ``CFG_NAVSPG_DYNMODEL`` for an arbitrary dynamics class."""
         with self._lock:
             self._write_and_verify_locked(
                 [("CFG_NAVSPG_DYNMODEL", _DYN_MODEL_VALUES[model])],
                 layer=5,
                 label="Dynamics model",
             )
+
+    def get_dyn_model(self) -> DynModel:
+        """Read the receiver's current ``CFG_NAVSPG_DYNMODEL``."""
+        with self._lock:
+            actual = self._read_cfg_keys_locked(["CFG_NAVSPG_DYNMODEL"])
+        return _DYN_MODEL_NAMES[actual["CFG_NAVSPG_DYNMODEL"]]
 
     def configure_tmode_mode(self, mode: BaseMode) -> None:
         """Write ``CFG_TMODE_MODE`` directly, without touching position keys.

--- a/src/sp_rtk_base/ui/pages/survey.py
+++ b/src/sp_rtk_base/ui/pages/survey.py
@@ -1045,6 +1045,54 @@ def survey_page() -> None:
                     "your accuracy target."
                 ).classes("text-grey-4 q-mt-sm")
 
+                # Non-blocking pre-flight check (issue #63): a receiver
+                # missing the base invariants (stationary dynamics, RTCM
+                # on its data-link ports) still gets a warning here, but
+                # Start Survey below is never disabled — the operator's
+                # decision to proceed anyway is the whole point.
+                invariants_warning = ui.column().classes("w-full")
+
+                async def _refresh_invariants_warning() -> None:
+                    invariants_warning.clear()
+                    try:
+                        check = await svc.check_base_invariants()
+                    except Exception:
+                        # Best-effort only — a failed pre-flight check
+                        # must never block Start.
+                        return
+                    if not check.warnings:
+                        return
+                    with invariants_warning:
+                        with (
+                            ui.card()
+                            .classes("w-full q-pa-sm q-mt-sm")
+                            .style("background-color: #3a2a10")
+                        ):
+                            for warning in check.warnings:
+                                ui.label(f"⚠ {warning}").classes(
+                                    "text-warning text-caption"
+                                )
+
+                            async def _apply_invariants_now() -> None:
+                                try:
+                                    await svc.apply_base_invariants()
+                                    ui.notify(
+                                        "Base invariants applied", type="positive"
+                                    )
+                                except Exception as exc:
+                                    ui.notify(
+                                        f"Failed to apply base invariants: {exc}",
+                                        type="negative",
+                                    )
+                                await _refresh_invariants_warning()
+
+                            ui.button(
+                                "Apply Base Invariants Now",
+                                on_click=_apply_invariants_now,
+                            ).props("flat dense color=warning")
+
+                await _refresh_invariants_warning()
+
                 with ui.row().classes("gap-2 q-mt-md justify-end"):
                     ui.button("Cancel", on_click=dlg.close).props("flat")
 

--- a/tests/e2e/test_survey_base_invariants.py
+++ b/tests/e2e/test_survey_base_invariants.py
@@ -1,0 +1,105 @@
+"""End-to-end tests for the survey-in base-invariants pre-flight check (issue #63).
+
+Covers the Start Survey-In confirmation dialog's non-blocking warning
+banner: a receiver missing the base invariants (stationary dynamics,
+RTCM on every data-link port) shows a warning with a one-click "Apply
+Base Invariants Now" remedy, but Start Survey remains clickable
+regardless — and a correctly configured receiver shows no warning.
+
+The :class:`~sp_rtk_base.services.drivers.fake.FakeGpsDriver` defaults
+to ``DynModel.PORTABLE`` and leaves UART2 with zero RTCM rows enabled
+(only UART1 defaults to on), so a fresh ``connected_gps`` connection
+is exactly the "under-configured" case this check exists for.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from playwright.sync_api import Page, expect
+
+
+@pytest.mark.e2e
+def test_warning_shown_and_start_still_works(
+    page: Page,
+    base_url: str,
+    connected_gps: None,
+) -> None:
+    """A freshly connected (under-configured) receiver warns but still starts."""
+    page.goto(f"{base_url}/survey")
+    expect(page.locator("text=Survey-In").first).to_be_visible(timeout=15_000)
+
+    page.get_by_role("button", name="Start Survey-In").click()
+    expect(page.locator("text=Start Survey-In?").first).to_be_visible(timeout=5_000)
+
+    # FakeGpsDriver defaults to portable dynamics and no RTCM on UART2.
+    expect(page.locator("text=Dynamics model is portable").first).to_be_visible(
+        timeout=5_000
+    )
+    expect(
+        page.locator("text=No RTCM messages are enabled on UART2").first
+    ).to_be_visible()
+    apply_now = page.get_by_role("button", name="Apply Base Invariants Now")
+    expect(apply_now).to_be_visible()
+
+    # Non-blocking: Start Survey is still clickable despite the warning.
+    page.get_by_role("button", name="Start Survey", exact=True).click()
+    expect(page.locator("text=Survey-in started").first).to_be_visible(timeout=10_000)
+
+
+@pytest.mark.e2e
+def test_apply_base_invariants_now_clears_the_warning(
+    page: Page,
+    base_url: str,
+    api_base_url: str,
+    connected_gps: None,
+) -> None:
+    """Clicking the one-click remedy applies the built-in profile and clears the banner."""
+    page.goto(f"{base_url}/survey")
+    expect(page.locator("text=Survey-In").first).to_be_visible(timeout=15_000)
+
+    page.get_by_role("button", name="Start Survey-In").click()
+    expect(page.locator("text=Start Survey-In?").first).to_be_visible(timeout=5_000)
+    expect(page.locator("text=Dynamics model is portable").first).to_be_visible(
+        timeout=5_000
+    )
+
+    page.get_by_role("button", name="Apply Base Invariants Now").click()
+    expect(page.locator("text=Base invariants applied").first).to_be_visible(
+        timeout=10_000
+    )
+
+    # The banner re-checks and clears once the remedy lands.
+    expect(page.locator("text=Dynamics model is portable")).not_to_be_visible(
+        timeout=5_000
+    )
+    expect(page.locator("text=No RTCM messages are enabled")).not_to_be_visible()
+
+    # REST mirror: the built-in profile's dyn_model is now live.
+    status = page.request.get(f"{api_base_url}/api/device/base-invariants")
+    assert status.ok, status.text()
+    payload: dict[str, Any] = status.json()
+    assert payload.get("warnings") == [], f"expected no warnings, got {payload!r}"
+
+
+@pytest.mark.e2e
+def test_no_warning_when_already_correctly_configured(
+    page: Page,
+    base_url: str,
+    api_base_url: str,
+    connected_gps: None,
+) -> None:
+    """A receiver already matching the built-in profile shows no warning."""
+    remedy = page.request.post(f"{api_base_url}/api/device/apply-base-invariants")
+    assert remedy.ok, remedy.text()
+
+    page.goto(f"{base_url}/survey")
+    expect(page.locator("text=Survey-In").first).to_be_visible(timeout=15_000)
+
+    page.get_by_role("button", name="Start Survey-In").click()
+    expect(page.locator("text=Start Survey-In?").first).to_be_visible(timeout=5_000)
+
+    expect(
+        page.get_by_role("button", name="Apply Base Invariants Now")
+    ).not_to_be_visible(timeout=5_000)

--- a/tests/unit/test_api_device.py
+++ b/tests/unit/test_api_device.py
@@ -409,26 +409,6 @@ class TestConfigureFixedBase:
         assert resp.status_code == 422  # Pydantic validation
 
 
-class TestConfigureRtcm:
-    """Tests for POST /api/device/configure/rtcm."""
-
-    def test_rtcm_success(
-        self,
-        client: TestClient,
-        mock_device_service: MagicMock,
-    ) -> None:
-        mock_device_service.configure_rtcm_messages = AsyncMock()
-        resp = client.post(
-            "/api/device/configure/rtcm",
-            json={
-                "message_ids": ["1005", "1077", "1087"],
-                "rate_hz": 1,
-            },
-        )
-        assert resp.status_code == 200
-        assert "RTCM messages configured" in resp.json()["message"]
-
-
 class TestSaveToFlash:
     """Tests for POST /api/device/save."""
 
@@ -687,6 +667,101 @@ class TestApplyConfig:
         detail = resp.json()["detail"]
         assert "57600" in detail
         assert "115200" in detail
+
+
+# ---------------------------------------------------------------------------
+# Base invariants pre-flight check + one-click remedy (issue #63)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckBaseInvariants:
+    """Tests for GET /api/device/base-invariants."""
+
+    def test_no_warnings(
+        self,
+        client: TestClient,
+        mock_device_service: MagicMock,
+    ) -> None:
+        from sp_rtk_base.models.device_models import BaseInvariantsCheck
+
+        mock_device_service.check_base_invariants = AsyncMock(
+            return_value=BaseInvariantsCheck(warnings=[])
+        )
+        resp = client.get("/api/device/base-invariants")
+        assert resp.status_code == 200
+        assert resp.json()["warnings"] == []
+
+    def test_returns_warnings(
+        self,
+        client: TestClient,
+        mock_device_service: MagicMock,
+    ) -> None:
+        from sp_rtk_base.models.device_models import BaseInvariantsCheck
+
+        mock_device_service.check_base_invariants = AsyncMock(
+            return_value=BaseInvariantsCheck(
+                warnings=["Dynamics model is portable, not stationary"]
+            )
+        )
+        resp = client.get("/api/device/base-invariants")
+        assert resp.status_code == 200
+        assert resp.json()["warnings"] == ["Dynamics model is portable, not stationary"]
+
+    def test_not_connected(
+        self,
+        client: TestClient,
+        mock_device_service: MagicMock,
+    ) -> None:
+        mock_device_service.check_base_invariants = AsyncMock(
+            side_effect=RuntimeError("Device not connected"),
+        )
+        resp = client.get("/api/device/base-invariants")
+        assert resp.status_code == 409
+
+
+class TestApplyBaseInvariants:
+    """Tests for POST /api/device/apply-base-invariants."""
+
+    def test_ok(
+        self,
+        client: TestClient,
+        mock_device_service: MagicMock,
+    ) -> None:
+        from sp_rtk_base.models.device_models import ApplyConfigResult
+
+        mock_device_service.apply_base_invariants = AsyncMock(
+            return_value=ApplyConfigResult(status="ok")
+        )
+        resp = client.post("/api/device/apply-base-invariants")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+
+    def test_not_connected(
+        self,
+        client: TestClient,
+        mock_device_service: MagicMock,
+    ) -> None:
+        mock_device_service.apply_base_invariants = AsyncMock(
+            side_effect=RuntimeError("Device not connected"),
+        )
+        resp = client.post("/api/device/apply-base-invariants")
+        assert resp.status_code == 409
+
+    def test_business_rule_refusal(
+        self,
+        client: TestClient,
+        mock_device_service: MagicMock,
+    ) -> None:
+        from sp_rtk_base.services.device_service import ApplyConfigRefusedError
+
+        mock_device_service.apply_base_invariants = AsyncMock(
+            side_effect=ApplyConfigRefusedError(
+                "ubx_in_liveness", "ports.USB.in must keep UBX enabled"
+            ),
+        )
+        resp = client.post("/api/device/apply-base-invariants")
+        assert resp.status_code == 400
+        assert "ubx_in_liveness" in resp.json()["detail"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_cancel_survey_in.py
+++ b/tests/unit/test_cancel_survey_in.py
@@ -58,27 +58,6 @@ def _make_ack() -> SimpleNamespace:
     return SimpleNamespace(identity="ACK-ACK")
 
 
-def _make_profile_valget() -> SimpleNamespace:
-    """CFG-VALGET response matching the RTCM-only base output profile."""
-    return SimpleNamespace(
-        identity="CFG-VALGET",
-        CFG_UART1OUTPROT_NMEA=0,
-        CFG_UART1OUTPROT_UBX=0,
-        CFG_UART1OUTPROT_RTCM3X=1,
-        CFG_UART2OUTPROT_NMEA=0,
-        CFG_UART2OUTPROT_UBX=0,
-        CFG_UART2OUTPROT_RTCM3X=1,
-    )
-
-
-def _make_dyn_model_valget(value: int = 2) -> SimpleNamespace:
-    """CFG-VALGET response for CFG_NAVSPG_DYNMODEL (issue #38).
-
-    Defaults to 2 (stationary).
-    """
-    return SimpleNamespace(identity="CFG-VALGET", CFG_NAVSPG_DYNMODEL=value)
-
-
 # ---------------------------------------------------------------------------
 # FakeGpsDriver.disable_base_mode
 # ---------------------------------------------------------------------------
@@ -229,13 +208,6 @@ class TestUbloxDisableBaseMode:
                     obs=1,
                 ),
             ),
-            (b"", _make_ack()),  # base output profile write (issue #40)
-            (b"", _make_profile_valget()),  # read-back matches
-            (b"", _make_ack()),  # dyn model write (issue #38)
-            (
-                b"",
-                _make_dyn_model_valget(),
-            ),  # dyn model read-back matches
         ]
         mock_reader_cls.return_value = reader
 
@@ -250,10 +222,10 @@ class TestUbloxDisableBaseMode:
                 SurveyInConfig(min_duration_seconds=120, accuracy_limit_mm=50000)
             )
 
-        # Four config_sets: full-layer disable, RAM+Flash enable, the
-        # layer=5 base output profile (issue #40), and the layer=5
-        # dyn model write (issue #38).
-        assert mock_ubx_msg.config_set.call_count == 4
+        # Issue #63: only two config_sets now — full-layer disable and
+        # the RAM+Flash enable. The base output profile / dyn model
+        # force-applies (issues #40/#38) were retired.
+        assert mock_ubx_msg.config_set.call_count == 2
         disable = mock_ubx_msg.config_set.call_args_list[0]
         enable = mock_ubx_msg.config_set.call_args_list[1]
         assert disable[0][2] == [("CFG_TMODE_MODE", 0)]
@@ -413,13 +385,6 @@ class TestUbloxDisableBaseMode:
             ),  # enable read-back — matches (issue #42)
             (b"", nav_svin_fresh_before),  # before-snapshot
             (b"", nav_svin_fresh_after),  # after-snapshot
-            (b"", _make_ack()),  # base output profile write (issue #40)
-            (b"", _make_profile_valget()),  # read-back matches
-            (b"", _make_ack()),  # dyn model write (issue #38)
-            (
-                b"",
-                _make_dyn_model_valget(),
-            ),  # dyn model read-back matches
         ]
         mock_reader_cls.return_value = reader
 
@@ -441,12 +406,11 @@ class TestUbloxDisableBaseMode:
 
         # No rollback path triggered — the pre-reset cleared the
         # stale state, and the post-write verify saw a fresh
-        # (dur=0 -> dur=3) progression.  4 CFG-VALSETs fire:
-        # layer=7 disable, layer=5 enable, layer=5 output profile,
-        # layer=5 dyn model (issue #38).
-        assert mock_ubx_msg.config_set.call_count == 4
+        # (dur=0 -> dur=3) progression. Issue #63: only two
+        # CFG-VALSETs fire now — layer=7 disable, layer=5 enable.
+        assert mock_ubx_msg.config_set.call_count == 2
         layers = [c[0][0] for c in mock_ubx_msg.config_set.call_args_list]
-        assert layers == [7, 5, 5, 5]
+        assert layers == [7, 5]
 
     @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
     @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
@@ -490,13 +454,6 @@ class TestUbloxDisableBaseMode:
             ),  # read-back — matches on retry
             (b"", nav_svin_idle),  # before-snapshot
             (b"", nav_svin_progressed),  # after-snapshot
-            (b"", _make_ack()),  # base output profile write
-            (b"", _make_profile_valget()),  # read-back matches
-            (b"", _make_ack()),  # dyn model write (issue #38)
-            (
-                b"",
-                _make_dyn_model_valget(),
-            ),  # dyn model read-back matches
         ]
         mock_reader_cls.return_value = reader
 
@@ -511,11 +468,12 @@ class TestUbloxDisableBaseMode:
                 SurveyInConfig(min_duration_seconds=60, accuracy_limit_mm=50000)
             )  # must not raise
 
-        # disable(7) + enable(5) + retried enable(5) + profile(5) +
-        # dyn model(5) = 5 VALSETs.
-        assert mock_ubx_msg.config_set.call_count == 5
+        # Issue #63: disable(7) + enable(5) + retried enable(5) = 3
+        # VALSETs — the base output profile / dyn model force-applies
+        # (issues #40/#38) were retired.
+        assert mock_ubx_msg.config_set.call_count == 3
         layers = [c[0][0] for c in mock_ubx_msg.config_set.call_args_list]
-        assert layers == [7, 5, 5, 5, 5]
+        assert layers == [7, 5, 5]
 
     @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
     @patch("sp_rtk_base.services.drivers.ublox.UBXReader")

--- a/tests/unit/test_device_models.py
+++ b/tests/unit/test_device_models.py
@@ -6,12 +6,12 @@ import pytest
 from pydantic import ValidationError
 
 from sp_rtk_base.models.device_models import (
+    BaseInvariantsCheck,
     DeviceCapability,
     DeviceConnectionState,
     DeviceInfo,
     DeviceStatus,
     FixedBaseConfig,
-    RtcmMessageConfig,
     RtcmRowId,
     SurveyInConfig,
     SurveyInProgress,
@@ -124,38 +124,15 @@ class TestFixedBaseConfig:
             FixedBaseConfig(latitude=0.0, longitude=181.0, altitude_m=0.0)
 
 
-class TestRtcmMessageConfig:
-    """Tests for RtcmMessageConfig model."""
+class TestBaseInvariantsCheck:
+    """Tests for BaseInvariantsCheck model (issue #63)."""
 
-    def test_defaults(self) -> None:
-        cfg = RtcmMessageConfig()
-        assert cfg.message_ids == [
-            RtcmRowId.RTCM_1005,
-            RtcmRowId.RTCM_1077,
-            RtcmRowId.RTCM_1087,
-            RtcmRowId.RTCM_1097,
-            RtcmRowId.RTCM_1127,
-            RtcmRowId.RTCM_1230,
-        ]
-        assert cfg.rate_hz == 1
+    def test_defaults_to_no_warnings(self) -> None:
+        assert BaseInvariantsCheck().warnings == []
 
-    def test_custom_messages(self) -> None:
-        cfg = RtcmMessageConfig(
-            message_ids=[RtcmRowId.RTCM_1005, RtcmRowId.RTCM_1077], rate_hz=5
-        )
-        assert len(cfg.message_ids) == 2
-        assert cfg.rate_hz == 5
-
-    def test_rate_out_of_range(self) -> None:
-        with pytest.raises(ValidationError):
-            RtcmMessageConfig(rate_hz=0)
-        with pytest.raises(ValidationError):
-            RtcmMessageConfig(rate_hz=11)
-
-    def test_rejects_unknown_row_id(self) -> None:
-        """message_ids only accepts the 12 known RtcmRowId values."""
-        with pytest.raises(ValidationError):
-            RtcmMessageConfig(message_ids=["9999"])  # type: ignore[list-item]
+    def test_carries_warnings(self) -> None:
+        check = BaseInvariantsCheck(warnings=["a", "b"])
+        assert check.warnings == ["a", "b"]
 
 
 class TestRtcmRowId:

--- a/tests/unit/test_device_service.py
+++ b/tests/unit/test_device_service.py
@@ -19,7 +19,6 @@ from sp_rtk_base.models.device_models import (
     GnssConstellation,
     GnssSystemConfig,
     PortId,
-    RtcmMessageConfig,
     RtcmPortConfig,
     RtcmRowId,
     SurveyInConfig,
@@ -276,22 +275,31 @@ class TestConfiguration:
         connected_svc.driver.configure_survey_in.assert_called_once_with(config)  # type: ignore[union-attr]
 
     @pytest.mark.asyncio()
+    async def test_configure_survey_in_does_not_touch_applied_profile(
+        self, connected_svc: DeviceService
+    ) -> None:
+        """Regression test for issue #63.
+
+        Starting a survey-in must not re-write the port protocols or
+        dynamics model an operator-applied ``ReceiverConfig`` profile
+        set — that's exactly the competing-writer bug #40/#38's
+        force-applies caused before they were retired.
+        """
+        config = SurveyInConfig(min_duration_seconds=300, accuracy_limit_mm=20000)
+        await connected_svc.configure_survey_in(config)
+
+        driver = connected_svc.driver
+        assert driver is not None
+        driver.configure_port_protocols.assert_not_called()  # type: ignore[union-attr]
+        driver.configure_dyn_model.assert_not_called()  # type: ignore[union-attr]
+
+    @pytest.mark.asyncio()
     async def test_configure_fixed_base(self, connected_svc: DeviceService) -> None:
         config = FixedBaseConfig(latitude=47.0, longitude=-122.0, altitude_m=100.0)
         await connected_svc.configure_fixed_base(config)
 
         assert connected_svc.state == DeviceConnectionState.CONNECTED
         connected_svc.driver.configure_fixed_base.assert_called_once_with(config)  # type: ignore[union-attr]
-
-    @pytest.mark.asyncio()
-    async def test_configure_rtcm_messages(self, connected_svc: DeviceService) -> None:
-        config = RtcmMessageConfig(
-            message_ids=[RtcmRowId.RTCM_1005, RtcmRowId.RTCM_1077], rate_hz=2
-        )
-        await connected_svc.configure_rtcm_messages(config)
-
-        assert connected_svc.state == DeviceConnectionState.CONNECTED
-        connected_svc.driver.configure_rtcm_messages.assert_called_once_with(config)  # type: ignore[union-attr]
 
     @pytest.mark.asyncio()
     async def test_save_to_flash(self, connected_svc: DeviceService) -> None:
@@ -822,6 +830,148 @@ class TestApplyReceiverConfig:
         }
         result = await connected_svc.apply_receiver_config(_minimal_config())
         assert result.warnings == []
+
+
+class TestSurveyInPreservesAppliedProfile:
+    """Regression test for issue #63's acceptance criterion:
+
+    "apply a profile, then start a survey-in, and the applied
+    port/dyn-model config is unchanged."
+
+    Uses the real ``FakeGpsDriver`` rather than a mock so this proves
+    the actual outcome (read-back after survey-in still matches what
+    was applied), not just which driver methods got called.
+    """
+
+    @pytest.mark.asyncio()
+    async def test_survey_in_does_not_revert_an_applied_profile(self) -> None:
+        from sp_rtk_base.services.drivers.fake import FakeGpsDriver
+
+        driver = FakeGpsDriver()
+        driver.connect("FAKE", 115200)
+        svc = DeviceService()
+        svc.set_driver(driver)
+        svc._state = DeviceConnectionState.CONNECTED
+        svc._info = DeviceInfo(vendor="Fake", model="FAKE-F9P")
+
+        # Deliberately not the built-in profile's values, so a
+        # regression that force-re-applies the built-in's stationary
+        # dyn model / RTCM-only ports would be caught.
+        applied = _minimal_config(
+            data_link_port=[PortId.UART1, PortId.UART2],
+            ports={
+                PortId.UART1: PortProtocolSet(
+                    in_=[UbxProtocol.UBX], out=[UbxProtocol.RTCM3X, UbxProtocol.NMEA]
+                ),
+                PortId.UART2: PortProtocolSet(
+                    in_=[UbxProtocol.UBX], out=[UbxProtocol.RTCM3X]
+                ),
+            },
+            dyn_model=DynModel.PORTABLE,
+            rtcm_stream=RtcmStreamConfig(
+                matrix={
+                    RtcmRowId.RTCM_1005: {PortId.UART1: True, PortId.UART2: True},
+                }
+            ),
+        )
+        apply_result = await svc.apply_receiver_config(applied)
+        assert apply_result.status == "ok"
+
+        await svc.configure_survey_in(
+            SurveyInConfig(min_duration_seconds=120, accuracy_limit_mm=50000)
+        )
+
+        assert driver.get_dyn_model() is DynModel.PORTABLE
+        protocols = driver.get_port_protocols()
+        assert protocols.enabled_out(PortId.UART1) == [
+            UbxProtocol.RTCM3X,
+            UbxProtocol.NMEA,
+        ]
+        assert protocols.enabled_out(PortId.UART2) == [UbxProtocol.RTCM3X]
+
+
+# ---------------------------------------------------------------------------
+# Tests: Base invariants pre-flight check + one-click remedy (issue #63)
+# ---------------------------------------------------------------------------
+
+
+class TestBaseInvariants:
+    """Tests for ``check_base_invariants`` / ``apply_base_invariants``."""
+
+    @pytest.fixture()
+    def connected_svc(self) -> DeviceService:
+        svc = DeviceService()
+        driver = _make_mock_driver()
+        driver.get_dyn_model.return_value = DynModel.STATIONARY
+        driver.get_rtcm_port_config.return_value = RtcmPortConfig(
+            messages={RtcmRowId.RTCM_1005: {"UART1": 1, "UART2": 1}}
+        )
+        svc.set_driver(driver)
+        svc._state = DeviceConnectionState.CONNECTED
+        svc._info = DeviceInfo(vendor="MockVendor", model="MockModel")
+        return svc
+
+    @pytest.mark.asyncio()
+    async def test_not_connected_raises(self) -> None:
+        svc = DeviceService()
+        svc.set_driver(_make_mock_driver())
+        with pytest.raises(RuntimeError, match="Device not connected"):
+            await svc.check_base_invariants()
+
+    @pytest.mark.asyncio()
+    async def test_no_warnings_when_matching_builtin(
+        self, connected_svc: DeviceService
+    ) -> None:
+        result = await connected_svc.check_base_invariants()
+        assert result.warnings == []
+
+    @pytest.mark.asyncio()
+    async def test_warns_on_wrong_dyn_model(self, connected_svc: DeviceService) -> None:
+        assert connected_svc.driver is not None
+        connected_svc.driver.get_dyn_model.return_value = DynModel.PORTABLE  # type: ignore[union-attr]
+
+        result = await connected_svc.check_base_invariants()
+
+        assert len(result.warnings) == 1
+        assert "portable" in result.warnings[0]
+
+    @pytest.mark.asyncio()
+    async def test_warns_on_no_rtcm_on_data_link_ports(
+        self, connected_svc: DeviceService
+    ) -> None:
+        assert connected_svc.driver is not None
+        connected_svc.driver.get_rtcm_port_config.return_value = RtcmPortConfig()  # type: ignore[union-attr]
+
+        result = await connected_svc.check_base_invariants()
+
+        # The built-in profile's data_link_port is [UART1, UART2] — both
+        # lack any enabled row, so both are called out by name.
+        assert len(result.warnings) == 2
+        assert any("UART1" in w for w in result.warnings)
+        assert any("UART2" in w for w in result.warnings)
+
+    @pytest.mark.asyncio()
+    async def test_apply_delegates_to_apply_receiver_config_with_builtin_profile(
+        self, connected_svc: DeviceService, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from unittest.mock import AsyncMock
+
+        from sp_rtk_base.models.device_models import ApplyConfigResult
+        from sp_rtk_base.profiles import BUILTIN_PROFILES
+
+        mock_apply = AsyncMock(return_value=ApplyConfigResult(status="ok"))
+        monkeypatch.setattr(connected_svc, "apply_receiver_config", mock_apply)
+
+        result = await connected_svc.apply_base_invariants()
+
+        applied_config = mock_apply.call_args[0][0]
+        builtin = BUILTIN_PROFILES["ublox-f9p-base-standard"]
+        # Everything except baud must match the built-in profile
+        # verbatim — baud is deliberately stripped so this one-click
+        # remedy can never strand the console's own link.
+        assert applied_config == builtin.model_copy(update={"baud": None})
+        assert applied_config.baud is None
+        assert result.status == "ok"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_driver_registry.py
+++ b/tests/unit/test_driver_registry.py
@@ -15,7 +15,6 @@ from sp_rtk_base.models.device_models import (
     GpsPosition,
     PortId,
     PortProtocolConfig,
-    RtcmMessageConfig,
     RtcmPortConfig,
     RtcmRowId,
     SurveyInConfig,
@@ -63,12 +62,6 @@ class StubDriver(GpsReceiverDriver):
     def configure_fixed_base(self, config: FixedBaseConfig) -> None:
         pass
 
-    def configure_rtcm_messages(self, config: RtcmMessageConfig) -> None:
-        pass
-
-    def get_rtcm_config(self) -> RtcmMessageConfig:
-        return RtcmMessageConfig(message_ids=[], rate_hz=1)
-
     def get_rtcm_port_config(self) -> RtcmPortConfig:
         return RtcmPortConfig()
 
@@ -114,6 +107,9 @@ class StubDriver(GpsReceiverDriver):
 
     def configure_dyn_model(self, model: DynModel) -> None:
         pass
+
+    def get_dyn_model(self) -> DynModel:
+        return DynModel.PORTABLE
 
     def configure_tmode_mode(self, mode: BaseMode) -> None:
         pass

--- a/tests/unit/test_fake_driver.py
+++ b/tests/unit/test_fake_driver.py
@@ -47,7 +47,6 @@ from sp_rtk_base.models.device_models import (
     GnssSystemConfig,
     GpsFixType,
     PortId,
-    RtcmMessageConfig,
     RtcmPortConfig,
     RtcmRowId,
     SurveyInConfig,
@@ -189,16 +188,6 @@ class TestDisconnectedGuards:
                 FixedBaseConfig(latitude=32.0, longitude=-117.0, altitude_m=10.0)
             )
 
-    def test_configure_rtcm_messages_requires_connection(
-        self, driver: FakeGpsDriver
-    ) -> None:
-        with pytest.raises(ConnectionError):
-            driver.configure_rtcm_messages(RtcmMessageConfig())
-
-    def test_get_rtcm_config_requires_connection(self, driver: FakeGpsDriver) -> None:
-        with pytest.raises(ConnectionError):
-            driver.get_rtcm_config()
-
     def test_get_rtcm_port_config_requires_connection(
         self, driver: FakeGpsDriver
     ) -> None:
@@ -265,6 +254,10 @@ class TestDisconnectedGuards:
         with pytest.raises(ConnectionError):
             driver.configure_dyn_model(DynModel.STATIONARY)
 
+    def test_get_dyn_model_requires_connection(self, driver: FakeGpsDriver) -> None:
+        with pytest.raises(ConnectionError):
+            driver.get_dyn_model()
+
     def test_configure_tmode_mode_requires_connection(
         self, driver: FakeGpsDriver
     ) -> None:
@@ -311,17 +304,6 @@ class TestConfigurationRoundTrips:
         assert current.longitude == pytest.approx(-117.2362788)
         assert current.altitude_m == pytest.approx(27.940)
         assert current.accuracy_mm == 47308
-
-    def test_rtcm_messages_round_trip(self, connected_driver: FakeGpsDriver) -> None:
-        cfg = RtcmMessageConfig(
-            message_ids=[RtcmRowId.RTCM_1005, RtcmRowId.RTCM_1077], rate_hz=2
-        )
-        connected_driver.configure_rtcm_messages(cfg)
-        assert connected_driver.get_rtcm_config().message_ids == [
-            RtcmRowId.RTCM_1005,
-            RtcmRowId.RTCM_1077,
-        ]
-        assert connected_driver.get_rtcm_config().rate_hz == 2
 
     def test_rtcm_ports_round_trip(self, connected_driver: FakeGpsDriver) -> None:
         cfg = RtcmPortConfig(
@@ -420,6 +402,10 @@ class TestConfigurationRoundTrips:
     ) -> None:
         connected_driver.configure_dyn_model(DynModel.STATIONARY)
         assert connected_driver._dyn_model is DynModel.STATIONARY
+
+    def test_get_dyn_model_round_trip(self, connected_driver: FakeGpsDriver) -> None:
+        connected_driver.configure_dyn_model(DynModel.STATIONARY)
+        assert connected_driver.get_dyn_model() is DynModel.STATIONARY
 
     def test_configure_tmode_mode_preserves_existing_position(
         self, connected_driver: FakeGpsDriver

--- a/tests/unit/test_rtcm_port_config.py
+++ b/tests/unit/test_rtcm_port_config.py
@@ -184,13 +184,6 @@ class TestRtcmKeyMapping:
             == "CFG_MSGOUT_RTCM_3X_TYPE4072_1_UART2"
         )
 
-    def test_legacy_usb_keys_match(self) -> None:
-        from sp_rtk_base.services.drivers.ublox import _RTCM_KEY_BASES, _RTCM_USB_KEYS
-
-        for msg_id, expected in _RTCM_USB_KEYS.items():
-            base = _RTCM_KEY_BASES[msg_id]
-            assert expected == f"{base}_USB"
-
 
 # ---------------------------------------------------------------------------
 # Driver parse tests

--- a/tests/unit/test_ublox_driver.py
+++ b/tests/unit/test_ublox_driver.py
@@ -24,7 +24,6 @@ from sp_rtk_base.models.device_models import (
     DynModel,
     FixedBaseConfig,
     PortId,
-    RtcmMessageConfig,
     RtcmRowId,
     SurveyInConfig,
     UbxProtocol,
@@ -88,42 +87,6 @@ def _make_nav_svin_response(
         meanAcc=mean_acc,
         obs=obs,
     )
-
-
-def _make_rtcm_valget(overrides: dict[str, int] | None = None) -> object:
-    """Fake CFG-VALGET response for RTCM message keys.
-
-    Any key not present in ``overrides`` reads back as 0 (disabled) —
-    the ``_read_cfg_keys_locked`` verify step polls a specific key
-    list, so this only needs to answer for the keys it's asked about.
-    """
-    values = dict(overrides or {})
-
-    class _FakeRtcmValGet:
-        identity = "CFG-VALGET"
-
-        def __getattr__(self, name: str) -> int:
-            return values.get(name, 0)
-
-    return _FakeRtcmValGet()
-
-
-def _make_base_output_profile_valget(**overrides: int) -> SimpleNamespace:
-    """Create a mock CFG-VALGET response for the six OUTPROT keys.
-
-    Defaults to the RTCM-only profile issue #40 applies; pass overrides
-    to simulate a mismatch (e.g. ``CFG_UART1OUTPROT_NMEA=1``).
-    """
-    values = {
-        "CFG_UART1OUTPROT_NMEA": 0,
-        "CFG_UART1OUTPROT_UBX": 0,
-        "CFG_UART1OUTPROT_RTCM3X": 1,
-        "CFG_UART2OUTPROT_NMEA": 0,
-        "CFG_UART2OUTPROT_UBX": 0,
-        "CFG_UART2OUTPROT_RTCM3X": 1,
-    }
-    values.update(overrides)
-    return SimpleNamespace(identity="CFG-VALGET", **values)
 
 
 def _make_dyn_model_valget(value: int = 2) -> SimpleNamespace:
@@ -363,7 +326,8 @@ class TestUbloxDriverConfiguration:
         mock_serial_cls.return_value = ser
 
         reader = MagicMock()
-        # configure_survey_in now performs:
+        # configure_survey_in now performs (issue #63 retired the
+        # trailing base-output-profile / dyn-model force-applies):
         #   0. NAV-SVIN baseline poll                       -> dur=0 (no pre-reset)
         #   1. CFG-VALSET TMODE=0 (layer=7: RAM+BBR+Flash)  -> ACK
         #   2. CFG-VALSET TMODE=1 + SVIN params (layer=5)   -> ACK
@@ -371,10 +335,6 @@ class TestUbloxDriverConfiguration:
         #   4. NAV-SVIN poll                                -> dur=0
         #   5. (~2 s gap)
         #   6. NAV-SVIN poll                                -> dur=3 (incremented)
-        #   7. CFG-VALSET base output profile (layer=5)     -> ACK
-        #   8. CFG-VALGET read-back                         -> matches (issue #40)
-        #   9. CFG-VALSET dyn model (layer=5)                -> ACK
-        #  10. CFG-VALGET read-back                         -> matches (issue #38)
         reader.read.side_effect = [
             (b"", _make_mon_ver_response()),
             (b"", _make_nav_svin_response(active=0, valid=0, dur=0, obs=0)),  # baseline
@@ -391,13 +351,6 @@ class TestUbloxDriverConfiguration:
             ),  # enable read-back — matches
             (b"", _make_nav_svin_response(active=0, valid=0, dur=0, obs=0)),
             (b"", _make_nav_svin_response(active=0, valid=0, dur=3, obs=1)),
-            (b"", _make_ack_response()),  # base output profile write
-            (b"", _make_base_output_profile_valget()),  # read-back matches
-            (b"", _make_ack_response()),  # dyn model write
-            (
-                b"",
-                _make_dyn_model_valget(),
-            ),  # dyn model read-back matches
         ]
         mock_reader_cls.return_value = reader
 
@@ -412,18 +365,15 @@ class TestUbloxDriverConfiguration:
         with patch("sp_rtk_base.services.drivers.ublox.time.sleep"):
             driver.configure_survey_in(config)
 
-        # Four CFG-VALSET calls: layer=7 disable, layer=5 enable
-        # (issue #42), layer=5 base output profile (issue #40), and
-        # layer=5 dyn model (issue #38).
-        assert mock_ubx_msg.config_set.call_count == 4
+        # Issue #63: only two CFG-VALSET calls now — layer=7 disable and
+        # layer=5 enable (issue #42). The base output profile and dyn
+        # model force-applies (issues #40/#38) were retired: they used
+        # to overwrite an operator-applied profile on every transition.
+        assert mock_ubx_msg.config_set.call_count == 2
         disable_layer = mock_ubx_msg.config_set.call_args_list[0][0][0]
         disable_cfg = mock_ubx_msg.config_set.call_args_list[0][0][2]
         enable_layer = mock_ubx_msg.config_set.call_args_list[1][0][0]
         enable_cfg = mock_ubx_msg.config_set.call_args_list[1][0][2]
-        profile_layer = mock_ubx_msg.config_set.call_args_list[2][0][0]
-        profile_cfg = mock_ubx_msg.config_set.call_args_list[2][0][2]
-        dyn_model_layer = mock_ubx_msg.config_set.call_args_list[3][0][0]
-        dyn_model_cfg = mock_ubx_msg.config_set.call_args_list[3][0][2]
 
         # Disable must hit RAM|BBR|Flash (7), per u-blox C099 reference
         # script — RAM-only leaves BBR pinned and the ``dur`` counter
@@ -448,24 +398,20 @@ class TestUbloxDriverConfiguration:
         dur_vals = [v for k, v in enable_cfg if k == "CFG_TMODE_SVIN_MIN_DUR"]
         assert dur_vals == [300]
 
-        # Base output profile: separate layer=5 VALSET, RTCM-only.
-        assert profile_layer == 5
-        assert profile_cfg == [
-            ("CFG_UART1OUTPROT_NMEA", 0),
-            ("CFG_UART1OUTPROT_UBX", 0),
-            ("CFG_UART1OUTPROT_RTCM3X", 1),
-            ("CFG_UART2OUTPROT_NMEA", 0),
-            ("CFG_UART2OUTPROT_UBX", 0),
-            ("CFG_UART2OUTPROT_RTCM3X", 1),
-        ]
-        # Dynamics model: separate layer=5 VALSET, stationary (issue #38).
-        assert dyn_model_layer == 5
-        assert dyn_model_cfg == [("CFG_NAVSPG_DYNMODEL", 2)]
-        # UBX input protocols must never be touched — the app manages
-        # the receiver over the same link.
+        # Issue #63: a survey-in start must not write the base output
+        # profile or dynamics model keys at all — those are exactly the
+        # keys an operator-applied ``ReceiverConfig`` profile owns, and
+        # this used to silently overwrite it on every transition.
         all_keys = {
             k for call in mock_ubx_msg.config_set.call_args_list for k, _ in call[0][2]
         }
+        assert "CFG_UART1OUTPROT_NMEA" not in all_keys
+        assert "CFG_UART1OUTPROT_RTCM3X" not in all_keys
+        assert "CFG_UART2OUTPROT_NMEA" not in all_keys
+        assert "CFG_UART2OUTPROT_RTCM3X" not in all_keys
+        assert "CFG_NAVSPG_DYNMODEL" not in all_keys
+        # UBX input protocols must never be touched — the app manages
+        # the receiver over the same link.
         assert "CFG_UART1INPROT_UBX" not in all_keys
         assert "CFG_UART2INPROT_UBX" not in all_keys
 
@@ -484,7 +430,9 @@ class TestUbloxDriverConfiguration:
 
         reader = MagicMock()
         # configure_fixed_base now performs (mirroring
-        # configure_survey_in's edge-triggered TMODE pattern):
+        # configure_survey_in's edge-triggered TMODE pattern; issue #63
+        # retired the trailing base-output-profile / dyn-model
+        # force-applies):
         #   1. UBX-CFG-RST (no ACK read needed)
         #   2. CFG-VALSET TMODE=0 (layer=7)  -> ACK
         #   3. CFG-VALSET TMODE=2 + coords + ECEF (layer=5) -> ACK
@@ -505,13 +453,6 @@ class TestUbloxDriverConfiguration:
                     CFG_TMODE_ECEF_Z=467210663,
                 ),
             ),
-            (b"", _make_ack_response()),  # ACK for base output profile write
-            (b"", _make_base_output_profile_valget()),  # read-back matches
-            (b"", _make_ack_response()),  # ACK for dyn model write
-            (
-                b"",
-                _make_dyn_model_valget(),
-            ),  # dyn model read-back matches
         ]
         mock_reader_cls.return_value = reader
 
@@ -531,22 +472,19 @@ class TestUbloxDriverConfiguration:
         with patch("sp_rtk_base.services.drivers.ublox.time.sleep"):
             driver.configure_fixed_base(config)
 
-        # Four CFG-VALSETs: layer=7 disable, layer=5 fixed-base, layer=5
-        # base output profile (issue #40), and layer=5 dyn model
-        # (issue #38).
+        # Issue #63: only two CFG-VALSETs now — layer=7 disable and
+        # layer=5 fixed-base. The base output profile and dyn model
+        # force-applies (issues #40/#38) were retired: they used to
+        # overwrite an operator-applied profile on every transition.
         # Pre-disable mirrors configure_survey_in — without it, a
         # receiver currently in TMODE=1 silently coalesces the
         # TMODE=2 write and stays in survey-in (the Path 2 bug
         # diagnosed on larson-base before v0.3.5).
-        assert mock_ubx_msg.config_set.call_count == 4
+        assert mock_ubx_msg.config_set.call_count == 2
         disable_layer = mock_ubx_msg.config_set.call_args_list[0][0][0]
         disable_cfg = mock_ubx_msg.config_set.call_args_list[0][0][2]
         fixed_layer = mock_ubx_msg.config_set.call_args_list[1][0][0]
         fixed_cfg = mock_ubx_msg.config_set.call_args_list[1][0][2]
-        profile_layer = mock_ubx_msg.config_set.call_args_list[2][0][0]
-        profile_cfg = mock_ubx_msg.config_set.call_args_list[2][0][2]
-        dyn_model_layer = mock_ubx_msg.config_set.call_args_list[3][0][0]
-        dyn_model_cfg = mock_ubx_msg.config_set.call_args_list[3][0][2]
 
         assert disable_layer == 7
         assert disable_cfg == [("CFG_TMODE_MODE", 0)]
@@ -578,24 +516,20 @@ class TestUbloxDriverConfiguration:
         acc_vals = [v for k, v in fixed_cfg if k == "CFG_TMODE_FIXED_POS_ACC"]
         assert acc_vals == [5000]
 
-        # Base output profile: separate layer=5 VALSET, RTCM-only.
-        assert profile_layer == 5
-        assert profile_cfg == [
-            ("CFG_UART1OUTPROT_NMEA", 0),
-            ("CFG_UART1OUTPROT_UBX", 0),
-            ("CFG_UART1OUTPROT_RTCM3X", 1),
-            ("CFG_UART2OUTPROT_NMEA", 0),
-            ("CFG_UART2OUTPROT_UBX", 0),
-            ("CFG_UART2OUTPROT_RTCM3X", 1),
-        ]
-        # Dynamics model: separate layer=5 VALSET, stationary (issue #38).
-        assert dyn_model_layer == 5
-        assert dyn_model_cfg == [("CFG_NAVSPG_DYNMODEL", 2)]
-        # UBX input protocols must never be touched — the app manages
-        # the receiver over the same link.
+        # Issue #63: a fixed-base transition must not write the base
+        # output profile or dynamics model keys at all — those are
+        # exactly the keys an operator-applied ``ReceiverConfig``
+        # profile owns.
         all_keys = {
             k for call in mock_ubx_msg.config_set.call_args_list for k, _ in call[0][2]
         }
+        assert "CFG_UART1OUTPROT_NMEA" not in all_keys
+        assert "CFG_UART1OUTPROT_RTCM3X" not in all_keys
+        assert "CFG_UART2OUTPROT_NMEA" not in all_keys
+        assert "CFG_UART2OUTPROT_RTCM3X" not in all_keys
+        assert "CFG_NAVSPG_DYNMODEL" not in all_keys
+        # UBX input protocols must never be touched — the app manages
+        # the receiver over the same link.
         assert "CFG_UART1INPROT_UBX" not in all_keys
         assert "CFG_UART2INPROT_UBX" not in all_keys
 
@@ -702,366 +636,6 @@ class TestUbloxDriverConfiguration:
 
         # Retried once: layer=7 disable + two layer=5 writes.
         assert mock_ubx_msg.config_set.call_count == 3
-
-    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
-    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
-    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
-    def test_base_output_profile_retries_once_on_mismatch(
-        self,
-        mock_serial_cls: MagicMock,
-        mock_reader_cls: MagicMock,
-        mock_ubx_msg: MagicMock,
-    ) -> None:
-        """Issue #40: a read-back mismatch after the first write is
-        retried once (mirroring disable_base_mode's verify-and-retry
-        pattern) rather than failing immediately."""
-        ser = MagicMock()
-        ser.is_open = True
-        mock_serial_cls.return_value = ser
-
-        reader = MagicMock()
-        reader.read.side_effect = [
-            (b"", _make_mon_ver_response()),
-            (b"", _make_ack_response()),  # ACK for layer=7 disable
-            (b"", _make_ack_response()),  # ACK for layer=5 fixed-base write
-            (
-                b"",
-                SimpleNamespace(
-                    identity="CFG-VALGET",
-                    CFG_TMODE_ECEF_X=427750094,
-                    CFG_TMODE_ECEF_Y=64275758,
-                    CFG_TMODE_ECEF_Z=467210663,
-                ),
-            ),
-            (b"", _make_ack_response()),  # first profile write
-            # First read-back — NMEA still enabled, write hasn't taken.
-            (b"", _make_base_output_profile_valget(CFG_UART1OUTPROT_NMEA=1)),
-            (b"", _make_ack_response()),  # retried profile write
-            (b"", _make_base_output_profile_valget()),  # second read-back matches
-            (b"", _make_ack_response()),  # dyn model write
-            (
-                b"",
-                _make_dyn_model_valget(),
-            ),  # dyn model read-back matches
-        ]
-        mock_reader_cls.return_value = reader
-
-        mock_msg = MagicMock()
-        mock_msg.serialize.return_value = b"\x00"
-        mock_ubx_msg.config_set.return_value = mock_msg
-
-        driver = UbloxDriver()
-        driver.connect("/dev/ttyUSB0")
-
-        config = FixedBaseConfig(
-            latitude=47.3977, longitude=8.5456, altitude_m=408.0, accuracy_mm=500
-        )
-        with patch("sp_rtk_base.services.drivers.ublox.time.sleep"):
-            driver.configure_fixed_base(config)  # must not raise
-
-        # disable(7) + fixed(5) + profile write + profile retry + dyn
-        # model = 5 VALSETs.
-        assert mock_ubx_msg.config_set.call_count == 5
-
-    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
-    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
-    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
-    def test_base_output_profile_raises_after_second_mismatch(
-        self,
-        mock_serial_cls: MagicMock,
-        mock_reader_cls: MagicMock,
-        mock_ubx_msg: MagicMock,
-    ) -> None:
-        """Issue #40: if the profile still doesn't match after the retry,
-        the whole configure_fixed_base call must fail hard — even though
-        TMODE/position config already succeeded — because a silently
-        mis-configured port is exactly the bug this exists to fix."""
-        ser = MagicMock()
-        ser.is_open = True
-        mock_serial_cls.return_value = ser
-
-        mismatched = _make_base_output_profile_valget(CFG_UART1OUTPROT_NMEA=1)
-        reader = MagicMock()
-        reader.read.side_effect = [
-            (b"", _make_mon_ver_response()),
-            (b"", _make_ack_response()),  # ACK for layer=7 disable
-            (b"", _make_ack_response()),  # ACK for layer=5 fixed-base write
-            (
-                b"",
-                SimpleNamespace(
-                    identity="CFG-VALGET",
-                    CFG_TMODE_ECEF_X=427750094,
-                    CFG_TMODE_ECEF_Y=64275758,
-                    CFG_TMODE_ECEF_Z=467210663,
-                ),
-            ),
-            (b"", _make_ack_response()),  # first profile write
-            (b"", mismatched),  # first read-back — mismatch
-            (b"", _make_ack_response()),  # retried profile write
-            (b"", mismatched),  # second read-back — still mismatched
-        ]
-        mock_reader_cls.return_value = reader
-
-        mock_msg = MagicMock()
-        mock_msg.serialize.return_value = b"\x00"
-        mock_ubx_msg.config_set.return_value = mock_msg
-
-        driver = UbloxDriver()
-        driver.connect("/dev/ttyUSB0")
-
-        config = FixedBaseConfig(
-            latitude=47.3977, longitude=8.5456, altitude_m=408.0, accuracy_mm=500
-        )
-        with patch("sp_rtk_base.services.drivers.ublox.time.sleep"):
-            with pytest.raises(RuntimeError, match="[Bb]ase output profile"):
-                driver.configure_fixed_base(config)
-
-        # disable(7) + fixed(5) + profile write + profile retry = 4 VALSETs.
-        assert mock_ubx_msg.config_set.call_count == 4
-
-    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
-    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
-    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
-    def test_dyn_model_retries_once_on_mismatch(
-        self,
-        mock_serial_cls: MagicMock,
-        mock_reader_cls: MagicMock,
-        mock_ubx_msg: MagicMock,
-    ) -> None:
-        """Issue #38: a read-back mismatch on CFG_NAVSPG_DYNMODEL is
-        retried once, mirroring the base output profile's verify-and-retry
-        pattern, rather than failing immediately."""
-        ser = MagicMock()
-        ser.is_open = True
-        mock_serial_cls.return_value = ser
-
-        reader = MagicMock()
-        reader.read.side_effect = [
-            (b"", _make_mon_ver_response()),
-            (b"", _make_ack_response()),  # ACK for layer=7 disable
-            (b"", _make_ack_response()),  # ACK for layer=5 fixed-base write
-            (
-                b"",
-                SimpleNamespace(
-                    identity="CFG-VALGET",
-                    CFG_TMODE_ECEF_X=427750094,
-                    CFG_TMODE_ECEF_Y=64275758,
-                    CFG_TMODE_ECEF_Z=467210663,
-                ),
-            ),
-            (b"", _make_ack_response()),  # base output profile write
-            (b"", _make_base_output_profile_valget()),  # read-back matches
-            (b"", _make_ack_response()),  # first dyn model write
-            # First read-back — still portable (0), write hasn't taken.
-            (b"", _make_dyn_model_valget(0)),
-            (b"", _make_ack_response()),  # retried dyn model write
-            (
-                b"",
-                _make_dyn_model_valget(),
-            ),  # second read-back matches
-        ]
-        mock_reader_cls.return_value = reader
-
-        mock_msg = MagicMock()
-        mock_msg.serialize.return_value = b"\x00"
-        mock_ubx_msg.config_set.return_value = mock_msg
-
-        driver = UbloxDriver()
-        driver.connect("/dev/ttyUSB0")
-
-        config = FixedBaseConfig(
-            latitude=47.3977, longitude=8.5456, altitude_m=408.0, accuracy_mm=500
-        )
-        with patch("sp_rtk_base.services.drivers.ublox.time.sleep"):
-            driver.configure_fixed_base(config)  # must not raise
-
-        # disable(7) + fixed(5) + profile + dyn write + dyn retry = 5.
-        assert mock_ubx_msg.config_set.call_count == 5
-
-    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
-    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
-    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
-    def test_dyn_model_raises_after_second_mismatch(
-        self,
-        mock_serial_cls: MagicMock,
-        mock_reader_cls: MagicMock,
-        mock_ubx_msg: MagicMock,
-    ) -> None:
-        """Issue #38: if CFG_NAVSPG_DYNMODEL still doesn't read back as 2
-        after the retry, configure_fixed_base must fail hard — even though
-        TMODE/position and the output profile already succeeded."""
-        ser = MagicMock()
-        ser.is_open = True
-        mock_serial_cls.return_value = ser
-
-        stale = _make_dyn_model_valget(0)
-        reader = MagicMock()
-        reader.read.side_effect = [
-            (b"", _make_mon_ver_response()),
-            (b"", _make_ack_response()),  # ACK for layer=7 disable
-            (b"", _make_ack_response()),  # ACK for layer=5 fixed-base write
-            (
-                b"",
-                SimpleNamespace(
-                    identity="CFG-VALGET",
-                    CFG_TMODE_ECEF_X=427750094,
-                    CFG_TMODE_ECEF_Y=64275758,
-                    CFG_TMODE_ECEF_Z=467210663,
-                ),
-            ),
-            (b"", _make_ack_response()),  # base output profile write
-            (b"", _make_base_output_profile_valget()),  # read-back matches
-            (b"", _make_ack_response()),  # first dyn model write
-            (b"", stale),  # first read-back — mismatch
-            (b"", _make_ack_response()),  # retried dyn model write
-            (b"", stale),  # second read-back — still mismatched
-        ]
-        mock_reader_cls.return_value = reader
-
-        mock_msg = MagicMock()
-        mock_msg.serialize.return_value = b"\x00"
-        mock_ubx_msg.config_set.return_value = mock_msg
-
-        driver = UbloxDriver()
-        driver.connect("/dev/ttyUSB0")
-
-        config = FixedBaseConfig(
-            latitude=47.3977, longitude=8.5456, altitude_m=408.0, accuracy_mm=500
-        )
-        with patch("sp_rtk_base.services.drivers.ublox.time.sleep"):
-            with pytest.raises(RuntimeError, match="[Dd]ynamics model"):
-                driver.configure_fixed_base(config)
-
-        # disable(7) + fixed(5) + profile + dyn write + dyn retry = 5.
-        assert mock_ubx_msg.config_set.call_count == 5
-
-    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
-    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
-    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
-    def test_configure_rtcm_messages(
-        self,
-        mock_serial_cls: MagicMock,
-        mock_reader_cls: MagicMock,
-        mock_ubx_msg: MagicMock,
-    ) -> None:
-        ser = MagicMock()
-        ser.is_open = True
-        mock_serial_cls.return_value = ser
-
-        reader = MagicMock()
-        reader.read.side_effect = [
-            (b"", _make_mon_ver_response()),
-            (b"", _make_ack_response()),
-            (
-                b"",
-                _make_rtcm_valget(
-                    {
-                        "CFG_MSGOUT_RTCM_3X_TYPE1005_USB": 1,
-                        "CFG_MSGOUT_RTCM_3X_TYPE1077_USB": 1,
-                        "CFG_MSGOUT_RTCM_3X_TYPE1087_USB": 1,
-                    }
-                ),
-            ),  # read-back verify (issue #42) — matches
-        ]
-        mock_reader_cls.return_value = reader
-
-        mock_msg = MagicMock()
-        mock_msg.serialize.return_value = b"\x00"
-        mock_ubx_msg.config_set.return_value = mock_msg
-
-        driver = UbloxDriver()
-        driver.connect("/dev/ttyUSB0")
-
-        config = RtcmMessageConfig(
-            message_ids=[RtcmRowId.RTCM_1005, RtcmRowId.RTCM_1077, RtcmRowId.RTCM_1087],
-            rate_hz=1,
-        )
-        driver.configure_rtcm_messages(config)
-
-        mock_ubx_msg.config_set.assert_called_once()
-        # Issue #42: RAM+Flash, not RAM-only — a layer=1 write reverted
-        # to the last-flashed message selection on reboot / reconnect.
-        assert mock_ubx_msg.config_set.call_args[0][0] == 5
-
-    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
-    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
-    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
-    def test_configure_rtcm_messages_retries_once_on_mismatch(
-        self,
-        mock_serial_cls: MagicMock,
-        mock_reader_cls: MagicMock,
-        mock_ubx_msg: MagicMock,
-    ) -> None:
-        """Issue #42: a read-back mismatch after the first write is
-        retried once rather than failing immediately."""
-        ser = MagicMock()
-        ser.is_open = True
-        mock_serial_cls.return_value = ser
-
-        reader = MagicMock()
-        reader.read.side_effect = [
-            (b"", _make_mon_ver_response()),
-            (b"", _make_ack_response()),  # first write
-            (b"", _make_rtcm_valget()),  # first read-back — still all zero
-            (b"", _make_ack_response()),  # retried write
-            (
-                b"",
-                _make_rtcm_valget({"CFG_MSGOUT_RTCM_3X_TYPE1005_USB": 1}),
-            ),  # second read-back — matches
-        ]
-        mock_reader_cls.return_value = reader
-
-        mock_msg = MagicMock()
-        mock_msg.serialize.return_value = b"\x00"
-        mock_ubx_msg.config_set.return_value = mock_msg
-
-        driver = UbloxDriver()
-        driver.connect("/dev/ttyUSB0")
-
-        config = RtcmMessageConfig(message_ids=[RtcmRowId.RTCM_1005], rate_hz=1)
-        driver.configure_rtcm_messages(config)  # must not raise
-
-        assert mock_ubx_msg.config_set.call_count == 2
-
-    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
-    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
-    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
-    def test_configure_rtcm_messages_raises_after_second_mismatch(
-        self,
-        mock_serial_cls: MagicMock,
-        mock_reader_cls: MagicMock,
-        mock_ubx_msg: MagicMock,
-    ) -> None:
-        """Issue #42: if the message selection still doesn't match after
-        the retry, the call must fail hard instead of silently reporting
-        success — this is the exact bug that let RTCM output go silent
-        after a reboot while the UI claimed success."""
-        ser = MagicMock()
-        ser.is_open = True
-        mock_serial_cls.return_value = ser
-
-        reader = MagicMock()
-        reader.read.side_effect = [
-            (b"", _make_mon_ver_response()),
-            (b"", _make_ack_response()),  # first write
-            (b"", _make_rtcm_valget()),  # first read-back — still all zero
-            (b"", _make_ack_response()),  # retried write
-            (b"", _make_rtcm_valget()),  # second read-back — still all zero
-        ]
-        mock_reader_cls.return_value = reader
-
-        mock_msg = MagicMock()
-        mock_msg.serialize.return_value = b"\x00"
-        mock_ubx_msg.config_set.return_value = mock_msg
-
-        driver = UbloxDriver()
-        driver.connect("/dev/ttyUSB0")
-
-        config = RtcmMessageConfig(message_ids=[RtcmRowId.RTCM_1005], rate_hz=1)
-        with pytest.raises(RuntimeError, match="did not take effect"):
-            driver.configure_rtcm_messages(config)
-
-        assert mock_ubx_msg.config_set.call_count == 2
 
     @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
     @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
@@ -1885,97 +1459,6 @@ class TestConnectTimeoutAndCancel:
                 assert not driver._cancel_event.is_set()  # pyright: ignore[reportPrivateUsage]
 
 
-class TestGetRtcmConfig:
-    """Tests for get_rtcm_config() and _parse_rtcm_valget()."""
-
-    def test_parse_rtcm_valget_some_enabled(self) -> None:  # pyright: ignore[reportPrivateUsage]
-        """Parse a CFG-VALGET with some RTCM messages enabled."""
-        parsed = SimpleNamespace(
-            identity="CFG-VALGET",
-            CFG_MSGOUT_RTCM_3X_TYPE1005_USB=1,
-            CFG_MSGOUT_RTCM_3X_TYPE1074_USB=0,
-            CFG_MSGOUT_RTCM_3X_TYPE1077_USB=1,
-            CFG_MSGOUT_RTCM_3X_TYPE1084_USB=0,
-            CFG_MSGOUT_RTCM_3X_TYPE1087_USB=1,
-            CFG_MSGOUT_RTCM_3X_TYPE1094_USB=0,
-            CFG_MSGOUT_RTCM_3X_TYPE1097_USB=1,
-            CFG_MSGOUT_RTCM_3X_TYPE1124_USB=0,
-            CFG_MSGOUT_RTCM_3X_TYPE1127_USB=1,
-            CFG_MSGOUT_RTCM_3X_TYPE1230_USB=1,
-            CFG_MSGOUT_RTCM_3X_TYPE4072_0_USB=0,
-        )
-        result = UbloxDriver._parse_rtcm_valget(parsed)  # pyright: ignore[reportPrivateUsage]
-        assert set(result.message_ids) == {
-            RtcmRowId.RTCM_1005,
-            RtcmRowId.RTCM_1077,
-            RtcmRowId.RTCM_1087,
-            RtcmRowId.RTCM_1097,
-            RtcmRowId.RTCM_1127,
-            RtcmRowId.RTCM_1230,
-        }
-        assert result.rate_hz == 1
-
-    def test_parse_rtcm_valget_all_disabled(self) -> None:  # pyright: ignore[reportPrivateUsage]
-        """All messages disabled returns empty list and default rate."""
-        parsed = SimpleNamespace(identity="CFG-VALGET")
-        result = UbloxDriver._parse_rtcm_valget(parsed)  # pyright: ignore[reportPrivateUsage]
-        assert result.message_ids == []
-        assert result.rate_hz == 1  # default
-
-    def test_parse_rtcm_valget_mixed_rates(self) -> None:  # pyright: ignore[reportPrivateUsage]
-        """Most common rate is returned when messages have different rates."""
-        parsed = SimpleNamespace(
-            identity="CFG-VALGET",
-            CFG_MSGOUT_RTCM_3X_TYPE1005_USB=2,
-            CFG_MSGOUT_RTCM_3X_TYPE1077_USB=1,
-            CFG_MSGOUT_RTCM_3X_TYPE1087_USB=1,
-            CFG_MSGOUT_RTCM_3X_TYPE1097_USB=1,
-        )
-        result = UbloxDriver._parse_rtcm_valget(parsed)  # pyright: ignore[reportPrivateUsage]
-        assert RtcmRowId.RTCM_1005 in result.message_ids
-        assert RtcmRowId.RTCM_1077 in result.message_ids
-        assert result.rate_hz == 1  # most common
-
-    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
-    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
-    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
-    def test_get_rtcm_config_success(
-        self,
-        mock_serial_cls: MagicMock,
-        mock_reader_cls: MagicMock,
-        mock_ubx_msg: MagicMock,
-    ) -> None:
-        """Full get_rtcm_config() flow with mocked serial."""
-        ser = MagicMock()
-        ser.is_open = True
-        mock_serial_cls.return_value = ser
-
-        valget_response = SimpleNamespace(
-            identity="CFG-VALGET",
-            CFG_MSGOUT_RTCM_3X_TYPE1005_USB=1,
-            CFG_MSGOUT_RTCM_3X_TYPE1077_USB=1,
-        )
-
-        reader = MagicMock()
-        reader.read.side_effect = [
-            (b"", _make_mon_ver_response()),
-            (b"", valget_response),
-        ]
-        mock_reader_cls.return_value = reader
-
-        mock_msg = MagicMock()
-        mock_msg.serialize.return_value = b"\x00"
-        mock_ubx_msg.config_poll.return_value = mock_msg
-
-        driver = UbloxDriver()
-        driver.connect("/dev/ttyUSB0")
-        result = driver.get_rtcm_config()
-
-        assert RtcmRowId.RTCM_1005 in result.message_ids
-        assert RtcmRowId.RTCM_1077 in result.message_ids
-        assert result.rate_hz == 1
-
-
 class TestDeviceServiceCancelConnect:
     """Tests for DeviceService.cancel_connect() and set_connecting()."""
 
@@ -2185,6 +1668,40 @@ class TestConfigureDynModel:
 
         _, _, cfg_data = mock_ubx_msg.config_set.call_args[0]
         assert dict(cfg_data) == {"CFG_NAVSPG_DYNMODEL": expected_value}
+
+
+class TestGetDynModel:
+    """Tests for ``UbloxDriver.get_dyn_model`` (issue #63)."""
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_reads_stationary(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        driver, _reader = _connect_driver(
+            mock_serial_cls, mock_reader_cls, mock_ubx_msg, [_make_dyn_model_valget(2)]
+        )
+
+        assert driver.get_dyn_model() == DynModel.STATIONARY
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_reads_portable(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        driver, _reader = _connect_driver(
+            mock_serial_cls, mock_reader_cls, mock_ubx_msg, [_make_dyn_model_valget(0)]
+        )
+
+        assert driver.get_dyn_model() == DynModel.PORTABLE
 
 
 class TestConfigureTmodeMode:


### PR DESCRIPTION
## Summary
- Retires the `_USB`-only RTCM write path (`configure_rtcm_messages`, `get_rtcm_config`, `RtcmMessageConfig`, `POST /configure/rtcm`) — no code path writes only `_USB` RTCM keys for a base data link anymore.
- Removes `_apply_base_output_profile_locked()` and `_apply_stationary_dyn_model_locked()` from `configure_survey_in`/`configure_fixed_base` — these force-applies used to silently overwrite an operator-applied `ReceiverConfig` profile on every base-mode transition (issues #40/#38's original fixes are now expressed only in the built-in profile's `ports`/`dyn_model` values).
- Adds a non-blocking survey-in pre-flight check: `DeviceService.check_base_invariants()` / `apply_base_invariants()`, `GET /api/device/base-invariants`, `POST /api/device/apply-base-invariants`, and a warning banner + "Apply Base Invariants Now" button in the Start Survey-In confirmation dialog. Start Survey always remains clickable regardless of warnings.
- The one-click remedy applies the built-in base profile with `baud` stripped, so it can never strand the console's own management link.

Closes #63.

## Test plan
- [x] `uv run pytest` — 1302 unit tests pass, 93.27% coverage
- [x] `uv run pytest tests/e2e --no-cov` — 46 e2e tests pass (incl. 3 new tests for the base-invariants banner/remedy/no-warning cases)
- [x] `uv run pyright src/` — 0 errors
- [x] `uv run mypy src/` — 0 errors
- [x] `uv run ruff check`/`ruff format` — clean
- [x] `uv run pre-commit run --all-files` — clean
- [x] Code review (Standards + Spec axes) run and findings addressed (stale CLAUDE.md doc reference fixed; baud stripped from the one-click remedy to remove link-loss risk; added a literal end-to-end regression test for "apply a profile, then start a survey-in, config unchanged" using the real `FakeGpsDriver`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)