### PR TITLE
GPS page: profile picker and live-seeded form (read-only)

### DIFF
--- a/src/sp_rtk_base/services/drivers/fake.py
+++ b/src/sp_rtk_base/services/drivers/fake.py
@@ -71,6 +71,7 @@ from sp_rtk_base.models.device_models import (
     SurveyInProgress,
     UbxProtocol,
 )
+from sp_rtk_base.models.hardware_identity import HARDWARE_UNKNOWN, HardwareConfidence
 from sp_rtk_base.services.drivers.base import GpsReceiverDriver
 
 # ---------------------------------------------------------------------------
@@ -97,6 +98,12 @@ _SURVEY_FAST_COMPLETE_SECONDS: float = 3.0
 # Identifier the UI uses to find the fake "serial port".
 FAKE_PORT_LABEL: str = "FAKE"
 
+# Sentinel ``port`` value the e2e suite can pass to ``connect()`` to make
+# the fake driver report an unresolved hardware identity instead of its
+# normal confirmed ZED-F9P — the only way to reach the GPS page's
+# "unconfirmed hardware" picker banner without real hardware.
+FAKE_UNKNOWN_HW_PORT: str = "FAKE-UNKNOWN-HW"
+
 
 class FakeGpsDriver(GpsReceiverDriver):
     """In-memory GPS receiver driver for E2E + dev-mode testing.
@@ -117,6 +124,12 @@ class FakeGpsDriver(GpsReceiverDriver):
         self._baud_rate: int | None = None
 
         # Identity returned by ``connect()`` / ``get_device_info()``.
+        # hardware_target/confidence default to a *confirmed* ZED-F9P —
+        # this driver already mirrors that receiver's reference RTCM/port
+        # profile (see class docstring), and the GPS page's profile
+        # picker needs a confirmed identity to exercise its "suggested
+        # default" path. ``connect(FAKE_UNKNOWN_HW_PORT, ...)`` overrides
+        # this to unknown/unknown for the picker's other e2e path.
         self._device_info: DeviceInfo = DeviceInfo(
             vendor="Fake",
             model="FAKE-F9P",
@@ -124,6 +137,8 @@ class FakeGpsDriver(GpsReceiverDriver):
             protocol_version="27.99",
             hardware_version="FAKE-HW",
             serial_number="FAKE-0001",
+            hardware_target="ZED-F9P",
+            hardware_confidence=HardwareConfidence.CONFIRMED,
         )
 
         # Base config — starts disabled.  Switches to SURVEY_IN /
@@ -283,6 +298,13 @@ class FakeGpsDriver(GpsReceiverDriver):
         self._connected = True
         self._port = port
         self._baud_rate = baud_rate
+        if port == FAKE_UNKNOWN_HW_PORT:
+            self._device_info = self._device_info.model_copy(
+                update={
+                    "hardware_target": HARDWARE_UNKNOWN,
+                    "hardware_confidence": HardwareConfidence.UNKNOWN,
+                }
+            )
         return self._device_info
 
     def disconnect(self) -> None:

--- a/src/sp_rtk_base/ui/pages/gps_config.py
+++ b/src/sp_rtk_base/ui/pages/gps_config.py
@@ -1,8 +1,16 @@
-"""Advanced GPS Configuration page — RTCM, GNSS, save-to-flash, handoff.
+"""Advanced GPS Configuration page — profile picker, live-seeded form, handoff.
 
-Provides advanced GPS receiver configuration including RTCM message
-output ports, GNSS constellation selection, save to flash, and
-relay handoff.
+Provides the profile-based GPS receiver setup flow (issue #54): a
+profile picker tagged with hardware compatibility, a read-only
+receiver-configuration view seeded from the live device (RTCM matrix,
+port protocols, GNSS constellations), save-to-flash, and relay
+handoff.
+
+This is the read-only shell (issue #64) — no Apply, no Save-as yet.
+Selecting a profile is rendering-only: it does not write into the
+form. That wiring, plus the shave-by-shave RTCM/GNSS editing this page
+used to have, lands in a later ticket via the profile Apply pipeline
+(``POST /api/device/apply-config``).
 """
 
 # pyright: reportUnknownMemberType=false
@@ -14,21 +22,41 @@ relay handoff.
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 
 from nicegui import ui
 
 from sp_rtk_base.models.config_models import DeviceProfile
 from sp_rtk_base.models.device_models import (
+    ALL_RTCM_MESSAGE_IDS,
     RTCM_MESSAGE_GROUPS,
     DeviceCapability,
     DeviceConnectionState,
+    GnssConfig,
+    PortId,
+    PortProtocolConfig,
     RtcmOutputPort,
     RtcmPortConfig,
     RtcmRowId,
 )
-from sp_rtk_base.services import get_config_service, get_device_service
+from sp_rtk_base.models.hardware_identity import (
+    HARDWARE_UNKNOWN,
+    HardwareConfidence,
+    HardwareIdentity,
+    default_selection,
+    identity_from_target,
+    incompatible_reason,
+    is_compatible,
+)
+from sp_rtk_base.models.profile_models import Profile
+from sp_rtk_base.services import (
+    get_config_service,
+    get_device_service,
+    get_profile_store,
+)
 from sp_rtk_base.services.drivers import create_driver, list_drivers
 from sp_rtk_base.services.drivers.base import GpsReceiverDriver
+from sp_rtk_base.services.profile_store import ProfileStore
 from sp_rtk_base.ui.layout import page_layout
 
 logger = logging.getLogger(__name__)
@@ -36,13 +64,105 @@ logger = logging.getLogger(__name__)
 BAUD_RATES = [9600, 19200, 38400, 57600, 115200, 230400, 460800, 921600]
 DEFAULT_BAUD = 115200
 
-# Ports to show in the RTCM table (SPI is excluded — rarely used)
-VISIBLE_PORTS: list[RtcmOutputPort] = [
-    RtcmOutputPort.USB,
-    RtcmOutputPort.UART1,
-    RtcmOutputPort.UART2,
-    RtcmOutputPort.I2C,
+# GNSS constellations shown in the read-only form, in display order.
+_GNSS_DISPLAY: list[tuple[str, str]] = [
+    ("gps", "GPS"),
+    ("glonass", "GLONASS"),
+    ("galileo", "Galileo"),
+    ("beidou", "BeiDou"),
+    ("sbas", "SBAS"),
+    ("qzss", "QZSS"),
 ]
+
+#: Ports the boolean RTCM matrix covers — matches
+#: ``RtcmStreamConfig.matrix``'s column set (``PortId``), not the full
+#: 5-port live read-back.
+MATRIX_PORTS: list[PortId] = [PortId.UART1, PortId.UART2, PortId.USB]
+
+#: Data-link-capable ports — highlighted matrix columns. Mirrors
+#: ``profile_models._DATA_LINK_CANDIDATE_PORTS`` (USB excluded).
+DATA_LINK_PORTS: frozenset[PortId] = frozenset({PortId.UART1, PortId.UART2})
+
+#: Ports the matrix doesn't manage. A nonzero cell here in the live
+#: read-back means the receiver has RTCM enabled somewhere the
+#: profile form can't see or control.
+_ADVISORY_PORTS: tuple[RtcmOutputPort, ...] = (RtcmOutputPort.I2C, RtcmOutputPort.SPI)
+
+#: The one row every base profile must carry on a data-link port.
+REQUIRED_RTCM_ROW: RtcmRowId = RtcmRowId.RTCM_1005
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers — extracted for unit testing (see test_gps_config_helpers.py).
+# The page-rendering closure itself drives NiceGUI elements and can't be
+# meaningfully unit-tested without a full browser harness (tests/e2e).
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ProfilePickerEntry:
+    """One row in the profile picker, tagged with everything it needs to render."""
+
+    profile: Profile
+    is_builtin: bool
+    compatible: bool
+    incompatible_reason: str | None
+    is_default: bool
+
+
+def resolve_identity(
+    hardware_target: str | None, hardware_confidence: HardwareConfidence | None
+) -> HardwareIdentity:
+    """Build a :class:`HardwareIdentity` from device info, or the unknown sentinel."""
+    if hardware_target is None or hardware_confidence is None:
+        return identity_from_target(HARDWARE_UNKNOWN, HardwareConfidence.UNKNOWN)
+    return identity_from_target(hardware_target, hardware_confidence)
+
+
+def build_picker_entries(
+    profiles: list[Profile],
+    store: ProfileStore,
+    identity: HardwareIdentity,
+) -> list[ProfilePickerEntry]:
+    """Tag every profile with builtin/compatibility/default state for the picker.
+
+    Mirrors ``api/profiles.py:list_profiles`` — the UI reads the same
+    ``ProfileStore`` + ``hardware_identity`` primitives directly rather
+    than round-tripping through its own REST API. *profiles* is assumed
+    already ordered (built-ins before customs, alphabetical within
+    each group — ``ProfileStore.list_profiles`` guarantees this).
+    """
+    default_name = default_selection(identity, [(p.name, p.hardware) for p in profiles])
+    return [
+        ProfilePickerEntry(
+            profile=p,
+            is_builtin=store.is_builtin(p.name),
+            compatible=is_compatible(identity, p.hardware),
+            incompatible_reason=incompatible_reason(identity, p.hardware),
+            is_default=p.name == default_name,
+        )
+        for p in profiles
+    ]
+
+
+def matrix_cell_on(rtcm: RtcmPortConfig, row: RtcmRowId, port: PortId) -> bool:
+    """Whether *row* is enabled on *port* in the live read-back."""
+    return rtcm.is_enabled(row, RtcmOutputPort(port.value))
+
+
+def i2c_spi_advisory_rows(rtcm: RtcmPortConfig) -> list[RtcmRowId]:
+    """Row IDs with nonzero RTCM output on a port the matrix doesn't manage."""
+    return [
+        row_id
+        for row_id in ALL_RTCM_MESSAGE_IDS
+        if any(rtcm.is_enabled(row_id, p) for p in _ADVISORY_PORTS)
+    ]
+
+
+def row_slug(row_id: RtcmRowId) -> str:
+    """A CSS-class-safe token for *row_id* (``"4072.0"`` -> ``"4072_0"``) — a
+    stable hook the e2e suite uses to target a specific matrix row/cell."""
+    return row_id.value.replace(".", "_")
 
 
 @ui.page("/gps-config")
@@ -50,6 +170,7 @@ def gps_config_page() -> None:
     """Render the advanced GPS configuration page."""
     svc = get_device_service()
     config_svc = get_config_service()
+    profile_store = get_profile_store()
 
     with page_layout("Advanced GPS"):
         ui.label("Advanced GPS Configuration").classes("text-h4 text-white q-mb-md")
@@ -111,176 +232,61 @@ def gps_config_page() -> None:
             info_card.set_visibility(False)
 
         # ================================================================
-        # Section B: RTCM Message Output (hidden until connected)
+        # Section B: Profile picker (hidden until connected)
         # ================================================================
-        rtcm_section = ui.column().classes("w-full gap-4 q-mt-md")
-        rtcm_section.set_visibility(False)
+        profile_card = ui.card().classes("w-full q-pa-md q-mt-md")
+        profile_card.set_visibility(False)
 
-        with rtcm_section:
-            with ui.card().classes("w-full q-pa-md"):
-                ui.label("RTCM Message Output").classes("text-h6 text-white")
-                ui.separator()
-                ui.label(
-                    "Enable RTCM messages per output port. "
-                    "Rate is messages per navigation epoch (1 = every epoch)."
-                ).classes("text-grey-4 q-mt-xs text-caption")
-
-                # Build checkbox grid: rtcm_port_checks[msg_id][port] = checkbox
-                rtcm_port_checks: dict[RtcmRowId, dict[str, ui.checkbox]] = {}
-
-                with ui.column().classes("q-mt-sm gap-0 w-full"):
-                    # Header row
-                    with (
-                        ui.row()
-                        .classes("items-center w-full gap-0")
-                        .style("border-bottom: 1px solid #333; padding-bottom: 4px")
-                    ):
-                        ui.label("Group").classes("text-caption text-grey-5").style(
-                            "width: 100px; flex-shrink: 0"
-                        )
-                        ui.label("Message").classes("text-caption text-grey-5").style(
-                            "width: 180px; flex-shrink: 0"
-                        )
-                        for port in VISIBLE_PORTS:
-                            ui.label(port.value).classes(
-                                "text-caption text-grey-5 text-center"
-                            ).style("width: 65px; flex-shrink: 0")
-
-                    # Message rows grouped
-                    for group_name, messages in RTCM_MESSAGE_GROUPS:
-                        for idx, (msg_id, msg_desc) in enumerate(messages):
-                            with (
-                                ui.row()
-                                .classes("items-center w-full gap-0")
-                                .style("border-bottom: 1px solid #222; padding: 2px 0")
-                            ):
-                                # Group label (only on first row)
-                                if idx == 0:
-                                    ui.label(group_name).classes(
-                                        "text-white text-caption"
-                                    ).style("width: 100px; flex-shrink: 0")
-                                else:
-                                    ui.label("").style("width: 100px; flex-shrink: 0")
-
-                                # Message ID + description
-                                ui.label(f"{msg_id} {msg_desc}").classes(
-                                    "text-grey-3 text-caption"
-                                ).style("width: 180px; flex-shrink: 0")
-
-                                # Per-port checkboxes
-                                rtcm_port_checks[msg_id] = {}
-                                for port in VISIBLE_PORTS:
-                                    cb = ui.checkbox(
-                                        "",
-                                        value=False,
-                                    ).style("width: 65px; flex-shrink: 0")
-                                    rtcm_port_checks[msg_id][port.value] = cb
-
-                # Rate selector + quick actions + buttons
-                with ui.row().classes("gap-4 q-mt-md items-center flex-wrap"):
-                    rtcm_rate = (
-                        ui.number(
-                            "Rate",
-                            value=1,
-                            min=1,
-                            max=10,
-                            step=1,
-                        )
-                        .classes("w-24")
-                        .props("dense")
-                    )
-
-                    ui.label("|").classes("text-grey-6")
-
-                    # Quick-select per-port buttons
-                    for qp in VISIBLE_PORTS:
-                        _qp_val = qp.value
-
-                        def _toggle_port(
-                            p: str = _qp_val,
-                        ) -> None:
-                            """Toggle all msgs for a port."""
-                            any_on = any(
-                                cb.value
-                                for cbs in rtcm_port_checks.values()
-                                for k, cb in cbs.items()
-                                if k == p
-                            )
-                            for cbs in rtcm_port_checks.values():
-                                if p in cbs:
-                                    cbs[p].value = not any_on
-
-                        ui.button(
-                            qp.value,
-                            on_click=_toggle_port,
-                        ).props("dense flat size=sm color=grey-5")
-
-                    def _clear_all() -> None:
-                        for cbs in rtcm_port_checks.values():
-                            for cb in cbs.values():
-                                cb.value = False
-
-                    ui.button(
-                        "Clear All",
-                        icon="clear",
-                        on_click=_clear_all,
-                    ).props("dense flat size=sm color=grey-5")
-
-                with ui.row().classes("gap-4 q-mt-sm items-center"):
-                    rtcm_load_btn = ui.button(
-                        "Load from Device", icon="download"
-                    ).props("color=info outlined")
-                    rtcm_apply_btn = ui.button("Apply RTCM Config", icon="send").props(
-                        "color=primary"
-                    )
-                # Persistent status label beside the buttons.  The
-                # ``ui.notify`` toast fires on apply but fades in
-                # ~5s; operators in the e2e tour reported "no
-                # feedback" because they checked the page after the
-                # toast had vanished.  This label keeps the last
-                # apply result visible until the next attempt.
-                rtcm_apply_status = ui.label("").classes("text-caption q-mt-xs")
-                rtcm_apply_status.set_visibility(False)
-
-        # ================================================================
-        # Section C: GNSS Constellations (hidden until connected + capable)
-        # ================================================================
-        gnss_card = ui.card().classes("w-full q-pa-md q-mt-md")
-        gnss_card.set_visibility(False)
-
-        with gnss_card:
-            ui.label("GNSS Constellations").classes("text-h6 text-white")
+        with profile_card:
+            ui.label("Profile").classes("text-h6 text-white")
             ui.separator()
-            ui.label(
-                "Enable/disable satellite systems. At least one must remain enabled."
-            ).classes("text-grey-4 q-mt-xs text-caption")
-
-            _GNSS_DISPLAY: list[tuple[str, str, str]] = [
-                ("gps", "GPS", "🇺🇸 USA"),
-                ("glonass", "GLONASS", "🇷🇺 Russia"),
-                ("galileo", "Galileo", "🇪🇺 Europe"),
-                ("beidou", "BeiDou", "🇨🇳 China"),
-                ("sbas", "SBAS", "Augmentation"),
-                ("qzss", "QZSS", "🇯🇵 Japan"),
-            ]
-
-            gnss_toggles: dict[str, ui.switch] = {}
-            with ui.column().classes("q-mt-sm gap-2"):
-                for c_val, c_name, c_region in _GNSS_DISPLAY:
-                    with ui.row().classes("items-center gap-2"):
-                        sw = ui.switch(c_name, value=True)
-                        ui.label(c_region).classes("text-caption text-grey-5")
-                        gnss_toggles[c_val] = sw
-
-            with ui.row().classes("gap-4 q-mt-sm items-center"):
-                gnss_load_btn = ui.button("Load from Device", icon="download").props(
-                    "color=info outlined"
+            identity_label = ui.label("").classes("text-caption text-grey-4 q-mt-xs")
+            unconfirmed_banner = (
+                ui.label(
+                    "Unconfirmed hardware — only family- or any-tagged profiles are "
+                    "enabled, and no profile is suggested."
                 )
-                gnss_apply_btn = ui.button(
-                    "Apply GNSS Config", icon="satellite_alt"
-                ).props("color=primary")
-            gnss_apply_status = ui.label("").classes("text-caption q-mt-xs")
-            gnss_apply_status.set_visibility(False)
+                .classes("text-warning text-caption q-mt-xs q-pa-sm")
+                .style("border: 1px solid #5a4520; border-radius: 4px")
+            )
+            unconfirmed_banner.set_visibility(False)
+            picker_list = ui.column().classes("q-mt-sm gap-1 w-full")
+
+        # ================================================================
+        # Section C: Receiver configuration — read-only, seeded from the
+        # live receiver (hidden until connected)
+        # ================================================================
+        config_card = ui.card().classes("w-full q-pa-md q-mt-md")
+        config_card.set_visibility(False)
+
+        with config_card:
+            ui.label("Receiver Configuration").classes("text-h6 text-white")
+            ui.label(
+                "Read-only — reflects what is actually on the receiver right "
+                "now, not a saved profile."
+            ).classes("text-grey-4 q-mt-xs text-caption")
+            ui.separator()
+
+            ui.label("Port Protocols").classes("text-subtitle2 text-white q-mt-sm")
+            ports_view = ui.column().classes("q-mt-xs gap-1 w-full")
+
+            ui.label("GNSS Constellations").classes("text-subtitle2 text-white q-mt-md")
+            gnss_view = ui.row().classes("q-mt-xs gap-2 flex-wrap")
+
+            ui.label("RTCM Stream").classes("text-subtitle2 text-white q-mt-md")
+            ui.label(
+                "Boolean matrix — on/off per message x port. "
+                "Highlighted columns are data-link ports (where rovers read "
+                "corrections); USB is local diagnostics only."
+            ).classes("text-grey-4 q-mt-xs text-caption")
+            matrix_view = ui.column().classes("q-mt-sm gap-0 w-full")
+
+            advisory_label = (
+                ui.label("")
+                .classes("text-warning text-caption q-mt-sm q-pa-sm")
+                .style("border: 1px solid #5a4520; border-radius: 4px")
+            )
+            advisory_label.set_visibility(False)
 
         # ================================================================
         # Section D: Save to Flash (hidden until connected + capable)
@@ -358,6 +364,49 @@ def gps_config_page() -> None:
             except Exception:
                 pass  # Non-critical
 
+        def _render_picker() -> None:
+            """Render the profile picker from the current device identity."""
+            info = svc.device_info
+            identity = resolve_identity(
+                info.hardware_target if info else None,
+                info.hardware_confidence if info else None,
+            )
+            identity_label.text = (
+                f"Connected receiver hardware: {identity.target} "
+                f"({identity.confidence.value})"
+            )
+            unconfirmed_banner.set_visibility(
+                identity.confidence != HardwareConfidence.CONFIRMED
+            )
+
+            entries = build_picker_entries(
+                profile_store.list_profiles(), profile_store, identity
+            )
+
+            picker_list.clear()
+            with picker_list:
+                for entry in entries:
+                    row_classes = f"profile-row profile-row-{entry.profile.name} items-center gap-2 q-py-xs"
+                    with ui.row().classes(row_classes) as row:
+                        name_classes = (
+                            "text-white" if entry.compatible else "text-grey-6"
+                        )
+                        ui.label(entry.profile.name).classes(
+                            f"profile-name {name_classes}"
+                        )
+                        ui.badge("built-in" if entry.is_builtin else "custom").props(
+                            "outline color=grey"
+                        )
+                        if entry.is_default:
+                            ui.badge("Suggested").classes(
+                                "profile-suggested-badge"
+                            ).props("color=primary")
+                        if not entry.compatible and entry.incompatible_reason:
+                            row.classes("opacity-60")
+                            ui.icon("info").classes(
+                                "profile-incompatible-icon text-grey-5"
+                            ).tooltip(entry.incompatible_reason)
+
         def _update_ui_state() -> None:
             """Update UI visibility and button states based on device state."""
             state = svc.state
@@ -405,15 +454,16 @@ def gps_config_page() -> None:
                                 ui.badge(c.value).props("color=primary outline")
 
             # Section visibility
-            rtcm_section.set_visibility(
-                connected and DeviceCapability.RTCM_MESSAGE_SELECT in caps
-            )
-            gnss_card.set_visibility(connected and DeviceCapability.GNSS_SELECT in caps)
+            profile_card.set_visibility(connected)
+            config_card.set_visibility(connected)
             flash_card.set_visibility(
                 connected and DeviceCapability.SAVE_TO_FLASH in caps
             )
             handoff_card.set_visibility(connected)
             reload_device_btn.set_visibility(connected)
+
+            if connected:
+                _render_picker()
 
             # Error display
             status = svc.get_status()
@@ -422,6 +472,113 @@ def gps_config_page() -> None:
                 error_label.set_visibility(True)
             else:
                 error_label.set_visibility(False)
+
+        def _render_ports_table(ports: PortProtocolConfig) -> None:
+            ports_view.clear()
+            with ports_view:
+                for port_id in (PortId.UART1, PortId.UART2, PortId.USB):
+                    with ui.row().classes("items-center gap-2"):
+                        ui.label(port_id.value).classes("text-white").style(
+                            "width: 60px; flex-shrink: 0"
+                        )
+                        ui.label("IN").classes("text-caption text-grey-5")
+                        for proto in ports.enabled_in(port_id):
+                            ui.badge(proto.value).props("outline color=grey")
+                        ui.label("OUT").classes("text-caption text-grey-5 q-ml-md")
+                        for proto in ports.enabled_out(port_id):
+                            ui.badge(proto.value).props("outline color=primary")
+
+        def _render_gnss(gnss: GnssConfig) -> None:
+            enabled_map: dict[str, bool] = {
+                sys_cfg.constellation.value: sys_cfg.enabled for sys_cfg in gnss.systems
+            }
+            gnss_view.clear()
+            with gnss_view:
+                for c_val, c_name in _GNSS_DISPLAY:
+                    enabled = enabled_map.get(c_val, False)
+                    ui.badge(c_name).props(
+                        "color=positive" if enabled else "outline color=grey"
+                    )
+
+        def _render_matrix(rtcm: RtcmPortConfig) -> None:
+            matrix_view.clear()
+            with matrix_view:
+                # Header row
+                with (
+                    ui.row()
+                    .classes("items-center w-full gap-0")
+                    .style("border-bottom: 1px solid #333; padding-bottom: 4px")
+                ):
+                    ui.label("Message").classes("text-caption text-grey-5").style(
+                        "width: 220px; flex-shrink: 0"
+                    )
+                    for port in MATRIX_PORTS:
+                        header_classes = (
+                            f"rtcm-col-header rtcm-col-header-{port.value} "
+                            "text-caption text-center q-px-sm"
+                            + (
+                                " text-primary"
+                                if port in DATA_LINK_PORTS
+                                else " text-grey-5"
+                            )
+                        )
+                        ui.label(port.value).classes(header_classes).style(
+                            "width: 70px; flex-shrink: 0"
+                        )
+
+                for _group_name, messages in RTCM_MESSAGE_GROUPS:
+                    for msg_id, msg_desc in messages:
+                        slug = row_slug(msg_id)
+                        with (
+                            ui.row()
+                            .classes(
+                                f"rtcm-row rtcm-row-{slug} items-center w-full gap-0"
+                            )
+                            .style("border-bottom: 1px solid #222; padding: 2px 0")
+                        ):
+                            with (
+                                ui.row()
+                                .classes("items-center gap-1")
+                                .style("width: 220px; flex-shrink: 0")
+                            ):
+                                ui.label(f"{msg_id.value} {msg_desc}").classes(
+                                    "text-grey-3 text-caption"
+                                )
+                                if msg_id == REQUIRED_RTCM_ROW:
+                                    ui.badge("Required").props("outline color=warning")
+
+                            for port in MATRIX_PORTS:
+                                on = matrix_cell_on(rtcm, msg_id, port)
+                                cell_classes = (
+                                    f"rtcm-cell rtcm-cell-{slug}-{port.value} "
+                                    "text-center"
+                                    + (" text-positive" if on else " text-grey-7")
+                                )
+                                ui.label("✓" if on else "-").classes(
+                                    cell_classes
+                                ).style("width: 70px; flex-shrink: 0")
+
+        def _render_advisory(rtcm: RtcmPortConfig) -> None:
+            rows = i2c_spi_advisory_rows(rtcm)
+            if rows:
+                names = ", ".join(r.value for r in rows)
+                advisory_label.text = (
+                    f"RTCM enabled on I2C/SPI for {names} — this profile "
+                    "doesn't manage those ports."
+                )
+                advisory_label.set_visibility(True)
+            else:
+                advisory_label.set_visibility(False)
+
+        async def _load_receiver_config_form() -> None:
+            """Seed the read-only form from the live receiver."""
+            rtcm = await svc.get_rtcm_port_config()
+            ports = await svc.get_port_protocols()
+            gnss = await svc.get_gnss_config()
+            _render_ports_table(ports)
+            _render_gnss(gnss)
+            _render_matrix(rtcm)
+            _render_advisory(rtcm)
 
         async def _connect() -> None:
             """Connect to the selected device."""
@@ -455,16 +612,12 @@ def gps_config_page() -> None:
 
             _update_ui_state()
 
-            # Auto-load configs after connect
+            # Auto-load the receiver-config form after connect
             if svc.is_connected:
                 try:
-                    await _load_rtcm_config()
+                    await _load_receiver_config_form()
                 except Exception:
-                    logger.warning("Failed to read RTCM config on connect")
-                try:
-                    await _load_gnss_config()
-                except Exception:
-                    logger.warning("Failed to read GNSS config on connect")
+                    logger.warning("Failed to load receiver config on connect")
 
         def _cancel_connect() -> None:
             """Cancel an in-progress connect attempt."""
@@ -477,112 +630,6 @@ def gps_config_page() -> None:
             await svc.disconnect()
             ui.notify("Disconnected", type="info")
             _update_ui_state()
-
-        async def _apply_rtcm() -> None:
-            """Apply multi-port RTCM message configuration."""
-            rate = int(rtcm_rate.value or 1)
-            messages: dict[RtcmRowId, dict[str, int]] = {}
-
-            any_enabled = False
-            for msg_id, port_cbs in rtcm_port_checks.items():
-                port_rates: dict[str, int] = {}
-                for port_name, cb in port_cbs.items():
-                    val = rate if cb.value else 0
-                    port_rates[port_name] = val
-                    if val > 0:
-                        any_enabled = True
-                port_rates.setdefault("SPI", 0)
-                messages[msg_id] = port_rates
-
-            if not any_enabled:
-                ui.notify(
-                    "Enable at least one message on one port",
-                    type="warning",
-                )
-                return
-
-            try:
-                await svc.configure_rtcm_ports(RtcmPortConfig(messages=messages))
-                ui.notify("RTCM config applied ✓", type="positive")
-                rtcm_apply_status.text = "✓ RTCM config applied"
-                rtcm_apply_status.classes(replace="text-positive text-caption q-mt-xs")
-                rtcm_apply_status.set_visibility(True)
-            except Exception as exc:
-                ui.notify(f"RTCM config failed: {exc}", type="negative")
-                rtcm_apply_status.text = f"✗ RTCM config failed: {exc}"
-                rtcm_apply_status.classes(replace="text-negative text-caption q-mt-xs")
-                rtcm_apply_status.set_visibility(True)
-
-        async def _load_rtcm_config() -> None:
-            """Load current RTCM multi-port config from the device."""
-            try:
-                config = await svc.get_rtcm_port_config()
-
-                for msg_id, port_cbs in rtcm_port_checks.items():
-                    device_ports = config.messages.get(msg_id, {})
-                    for port_name, cb in port_cbs.items():
-                        cb.value = device_ports.get(port_name, 0) > 0
-
-                for port_rates in config.messages.values():
-                    for r in port_rates.values():
-                        if r > 0:
-                            rtcm_rate.value = r
-                            break
-                    else:
-                        continue
-                    break
-
-                ui.notify("RTCM config loaded from device", type="positive")
-            except Exception as exc:
-                ui.notify(f"Load RTCM failed: {exc}", type="negative")
-
-        async def _load_gnss_config() -> None:
-            """Load current GNSS constellation config from the device."""
-            try:
-                config = await svc.get_gnss_config()
-                enabled_map: dict[str, bool] = {}
-                for sys_cfg in config.systems:
-                    enabled_map[sys_cfg.constellation.value] = sys_cfg.enabled
-                for c_val, sw in gnss_toggles.items():
-                    sw.value = enabled_map.get(c_val, False)
-                ui.notify("GNSS config loaded from device", type="positive")
-            except Exception as exc:
-                ui.notify(f"Load GNSS failed: {exc}", type="negative")
-
-        async def _apply_gnss_config() -> None:
-            """Apply GNSS constellation configuration to the device."""
-            from sp_rtk_base.models.device_models import (
-                GnssConfig,
-                GnssConstellation,
-                GnssSystemConfig,
-            )
-
-            enabled_count = sum(1 for sw in gnss_toggles.values() if sw.value)
-            if enabled_count == 0:
-                ui.notify("At least one constellation must be enabled", type="warning")
-                return
-
-            systems: list[GnssSystemConfig] = []
-            for c_val, sw in gnss_toggles.items():
-                systems.append(
-                    GnssSystemConfig(
-                        constellation=GnssConstellation(c_val),
-                        enabled=bool(sw.value),
-                    )
-                )
-
-            try:
-                await svc.configure_gnss(GnssConfig(systems=systems))
-                enabled = [c_val for c_val, sw in gnss_toggles.items() if sw.value]
-                ui.notify(f"GNSS config applied: {enabled}", type="positive")
-                gnss_apply_status.text = f"✓ GNSS config applied: {enabled}"
-                gnss_apply_status.classes(replace="text-positive text-caption q-mt-xs")
-                gnss_apply_status.set_visibility(True)
-            except Exception as exc:
-                ui.notify(f"GNSS config failed: {exc}", type="negative")
-                gnss_apply_status.text = f"✗ GNSS config failed: {exc}"
-                gnss_apply_status.classes(replace="text-negative text-caption q-mt-xs")
-                gnss_apply_status.set_visibility(True)
 
         async def _save_flash() -> None:
             """Save configuration to device flash."""
@@ -612,20 +659,16 @@ def gps_config_page() -> None:
             _update_ui_state()
 
         async def _reload_device_config() -> None:
-            """Re-read all configs from the connected device."""
+            """Re-read the profile picker and receiver-config form."""
             if not svc.is_connected:
                 ui.notify("Not connected", type="warning")
                 return
             ui.notify("Reloading device config...", type="info")
             _update_ui_state()
             try:
-                await _load_rtcm_config()
+                await _load_receiver_config_form()
             except Exception:
-                logger.debug("Reload RTCM config failed")
-            try:
-                await _load_gnss_config()
-            except Exception:
-                logger.debug("Reload GNSS config failed")
+                logger.debug("Reload receiver config failed")
 
         # ---- Wire up event handlers ----
         connect_btn.on_click(_connect)
@@ -633,26 +676,18 @@ def gps_config_page() -> None:
         cancel_btn.on_click(lambda: _cancel_connect())
         refresh_btn.on_click(lambda: _refresh_ports())
         reload_device_btn.on_click(_reload_device_config)
-        rtcm_load_btn.on_click(_load_rtcm_config)
-        rtcm_apply_btn.on_click(_apply_rtcm)
-        gnss_load_btn.on_click(_load_gnss_config)
-        gnss_apply_btn.on_click(_apply_gnss_config)
         save_flash_btn.on_click(_save_flash)
         handoff_btn.on_click(_handoff_to_relay)
 
         # ---- Auto-load if already connected (navigated from another page) ----
         async def _on_page_load() -> None:
-            """If device is already connected, auto-load RTCM and GNSS configs."""
+            """If device is already connected, auto-load the receiver-config form."""
             if svc.is_connected:
                 _update_ui_state()
                 try:
-                    await _load_rtcm_config()
+                    await _load_receiver_config_form()
                 except Exception:
-                    logger.debug("Auto-load RTCM config failed on page load")
-                try:
-                    await _load_gnss_config()
-                except Exception:
-                    logger.debug("Auto-load GNSS config failed on page load")
+                    logger.debug("Auto-load receiver config failed on page load")
 
         # ---- Initial load ----
         _refresh_ports()

--- a/tests/e2e/test_gps_config_buttons.py
+++ b/tests/e2e/test_gps_config_buttons.py
@@ -13,9 +13,11 @@ Buttons covered here:
 2. **Save to Flash** → Quasar ``Saved to flash!`` toast → REST
    confirms (the fake driver's ``save_to_flash`` is a no-op that
    succeeds, so we only assert the toast appears).
-3. **Load from Device** (GNSS card) → ``GNSS config loaded`` toast.
-4. **Apply GNSS Config** → ``GNSS config applied`` toast → REST
-   read-back returns the expected enabled-systems list.
+
+The shave-by-shave RTCM/GNSS editing controls (checkboxes, switches,
+their own Load/Apply buttons) this page used to have were replaced by
+the read-only profile picker + live-seeded form (issue #64) — see
+``test_gps_profile_picker.py`` for that coverage.
 
 The **Connect** button is intentionally *not* tested through the UI
 here because the ``connected_gps`` fixture already calls
@@ -89,128 +91,3 @@ def test_save_to_flash_button_emits_success_toast(
     save_btn.click()
 
     expect(page.locator("text=Saved to flash!").first).to_be_visible(timeout=10_000)
-
-
-@pytest.mark.e2e
-def test_load_gnss_button_pulls_config_from_device(
-    page: Page,
-    base_url: str,
-    connected_gps: None,
-) -> None:
-    """**Load from Device** (GNSS card) → ``GNSS config loaded`` toast.
-
-    The button is rendered with a leading ``icon="download"`` and the
-    label "Load from Device".  There is only one such button on the
-    page (the RTCM card uses the same label, so we scope by parent
-    section to disambiguate).
-    """
-    page.goto(f"{base_url}/gps-config")
-    expect(page.locator("text=Advanced GPS Configuration").first).to_be_visible(
-        timeout=15_000
-    )
-
-    # Both the RTCM and GNSS cards have a "Load from Device" button.
-    # Scope to the GNSS card by looking inside the section that
-    # contains the "GNSS Constellations" heading.
-    gnss_card = page.locator(".q-card:has(:text('GNSS Constellations'))").first
-    expect(gnss_card).to_be_visible(timeout=10_000)
-
-    load_btn = gnss_card.get_by_role("button", name="Load from Device")
-    expect(load_btn).to_be_visible(timeout=10_000)
-    load_btn.click()
-
-    expect(page.locator("text=GNSS config loaded from device").first).to_be_visible(
-        timeout=10_000
-    )
-
-
-@pytest.mark.e2e
-def test_apply_gnss_button_writes_configuration(
-    page: Page,
-    base_url: str,
-    api_base_url: str,
-    connected_gps: None,
-) -> None:
-    """**Apply GNSS Config** click reaches the handler and writes to device.
-
-    The browser-level assertion is the success toast.  A REST-level
-    read-back proves the click triggered the underlying
-    :meth:`DeviceService.configure_gnss` call (the fake driver
-    overwrites its stored config wholesale on apply, so the
-    ``min_channels`` / ``max_channels`` values in the read-back will
-    drop to the form's defaults — that's a stable observable side-
-    effect that doesn't depend on the user's specific toggle
-    pattern, which Quasar switches don't always honour reliably from
-    Playwright clicks).
-    """
-    page.goto(f"{base_url}/gps-config")
-    expect(page.locator("text=Advanced GPS Configuration").first).to_be_visible(
-        timeout=15_000
-    )
-
-    # Seed a known channel count so the comparison after Apply is
-    # unambiguous.  The fake driver's default for GPS is
-    # ``min_channels=8, max_channels=16`` — picking different
-    # numbers gives us a clear delta.
-    seed_systems = [
-        {
-            "constellation": "gps",
-            "enabled": True,
-            "min_channels": 8,
-            "max_channels": 16,
-            "sig_cfg_mask": 1,
-        },
-        {
-            "constellation": "glonass",
-            "enabled": True,
-            "min_channels": 8,
-            "max_channels": 14,
-            "sig_cfg_mask": 1,
-        },
-        {
-            "constellation": "galileo",
-            "enabled": True,
-            "min_channels": 4,
-            "max_channels": 12,
-            "sig_cfg_mask": 33,
-        },
-        {
-            "constellation": "beidou",
-            "enabled": True,
-            "min_channels": 8,
-            "max_channels": 16,
-            "sig_cfg_mask": 17,
-        },
-    ]
-    seed = page.request.put(
-        f"{api_base_url}/api/device/gnss",
-        data={"systems": seed_systems},
-    )
-    assert seed.status < 500, seed.text()
-
-    # Click Apply.
-    gnss_card = page.locator(".q-card:has(:text('GNSS Constellations'))").first
-    expect(gnss_card).to_be_visible(timeout=10_000)
-    apply_btn = gnss_card.get_by_role("button", name="Apply GNSS Config")
-    expect(apply_btn).to_be_visible(timeout=10_000)
-    apply_btn.click()
-
-    # Toast — message is "GNSS config applied: ..." with the list of
-    # enabled systems appended; substring match is enough.
-    expect(page.locator("text=GNSS config applied").first).to_be_visible(timeout=10_000)
-
-    # REST read-back: at least one numeric field must have changed
-    # from the seeded values — proving the click *did* trigger a
-    # write rather than being a no-op.
-    after = page.request.get(f"{api_base_url}/api/device/gnss")
-    assert after.ok, after.text()
-    after_payload: dict[str, Any] = after.json()
-    systems_after = list(after_payload.get("systems", []))
-    seeded_max = sum(int(s["max_channels"]) for s in seed_systems)
-    actual_max = sum(
-        int(s.get("max_channels", 0)) for s in systems_after if isinstance(s, dict)
-    )
-    assert seeded_max != actual_max, (
-        "Apply GNSS Config click did not write to the device — "
-        f"channel totals unchanged at {actual_max} (seeded {seeded_max})"
-    )

--- a/tests/e2e/test_gps_profile_picker.py
+++ b/tests/e2e/test_gps_profile_picker.py
@@ -1,0 +1,228 @@
+"""E2E tests for the GPS page's profile picker + live-seeded form (issue #64).
+
+Extends the existing GPS page suite (``test_gps_config_buttons.py``,
+``test_gps_data_flow.py``). This ticket is rendering-only — no Apply,
+no Save-as — so these tests cover:
+
+- The form (ports, GNSS, RTCM matrix) seeds from the live receiver via
+  ``connected_gps``, not from any profile.
+- The picker lists built-ins before customs, tagging compatibility and
+  greying incompatible entries with a tooltip.
+- The deterministic default is visibly suggested but never written
+  into the form.
+- The unconfirmed-hardware banner appears (and no default is
+  suggested) when the receiver's identity can't be confirmed — driven
+  through ``FakeGpsDriver``'s ``FAKE_UNKNOWN_HW_PORT`` sentinel.
+- The matrix highlights the data-link columns and tags 1005 required.
+
+Locators target the stable ``profile-*`` / ``rtcm-*`` CSS class hooks
+the page renders (see ``ui/pages/gps_config.py``) rather than text
+substrings — several page strings (e.g. the unconfirmed-hardware
+banner's "...no profile is suggested") share words with the things
+under test, which makes plain ``get_by_text`` matches ambiguous.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+from sp_rtk_base.services.drivers.fake import FAKE_UNKNOWN_HW_PORT
+
+CUSTOM_INCOMPATIBLE_PROFILE = {
+    "name": "e2e-f9r-only",
+    "version": 1,
+    "hardware": "ZED-F9R",
+    "data_link_port": ["UART1"],
+    "rtcm_stream": {"matrix": {"1005": {"UART1": True}}},
+}
+
+BUILTIN_NAME = "ublox-f9p-base-standard"
+
+
+@pytest.fixture()
+def custom_incompatible_profile(api_base_url: str) -> Iterator[None]:
+    """Create a custom profile incompatible with the fake driver's ZED-F9P.
+
+    ``FakeGpsDriver`` reports a confirmed ``ZED-F9P`` target by
+    default. ``ZED-F9R`` is neither that specific model nor in a
+    family set matching a *different* model token, so it's reliably
+    incompatible (see ``models.hardware_identity.is_compatible``).
+    """
+    resp = httpx.post(
+        f"{api_base_url}/api/profiles",
+        json=CUSTOM_INCOMPATIBLE_PROFILE,
+        timeout=5.0,
+    )
+    assert resp.status_code in (201, 409), resp.text
+    try:
+        yield
+    finally:
+        httpx.delete(
+            f"{api_base_url}/api/profiles/{CUSTOM_INCOMPATIBLE_PROFILE['name']}",
+            timeout=5.0,
+        )
+
+
+@pytest.fixture()
+def connected_gps_unknown_hw(api_base_url: str) -> Iterator[None]:
+    """Connect the fake driver with an unresolved hardware identity.
+
+    Uses ``FakeGpsDriver.FAKE_UNKNOWN_HW_PORT`` — the sentinel that
+    makes the fake driver report ``hardware_confidence=unknown``
+    instead of its normal confirmed ``ZED-F9P`` — the only way to
+    reach the GPS page's "unconfirmed hardware" banner without real
+    hardware.
+    """
+    try:
+        httpx.post(f"{api_base_url}/api/device/disconnect", timeout=5.0)
+    except Exception:
+        pass
+
+    payload = {"vendor": "fake", "port": FAKE_UNKNOWN_HW_PORT, "baud_rate": 115200}
+    resp = httpx.post(f"{api_base_url}/api/device/connect", json=payload, timeout=10.0)
+    if resp.status_code not in (200, 409):
+        raise RuntimeError(
+            f"Could not connect FakeGpsDriver (unknown hw): "
+            f"HTTP {resp.status_code} — {resp.text}"
+        )
+    try:
+        yield
+    finally:
+        try:
+            httpx.post(f"{api_base_url}/api/device/disconnect", timeout=5.0)
+        except Exception:
+            pass
+
+
+def _goto_gps_config(page: Page, base_url: str) -> None:
+    page.goto(f"{base_url}/gps-config")
+    expect(page.locator("text=Advanced GPS Configuration").first).to_be_visible(
+        timeout=15_000
+    )
+
+
+@pytest.mark.e2e
+def test_form_seeds_matrix_and_gnss_from_live_receiver(
+    page: Page,
+    base_url: str,
+    connected_gps: None,
+) -> None:
+    """The RTCM matrix and GNSS badges reflect the fake driver's live state.
+
+    ``FakeGpsDriver`` enables RTCM 1005/1077/1087/1097/1127/1230 on
+    USB+UART1 (not UART2) and enables GPS/GLONASS/Galileo/BeiDou but
+    not SBAS/QZSS — none of which matches the built-in profile's
+    matrix, so a passing assertion here also proves the form isn't
+    seeded from a profile.
+    """
+    _goto_gps_config(page, base_url)
+
+    expect(page.locator(".rtcm-cell-1077-UART1")).to_have_text("✓", timeout=10_000)
+    expect(page.locator(".rtcm-cell-1077-UART2")).to_have_text("-")
+    expect(page.locator(".rtcm-cell-1077-USB")).to_have_text("✓")
+    # A row with no live data at all stays off everywhere.
+    expect(page.locator(".rtcm-cell-1074-UART1")).to_have_text("-")
+
+    config_card = page.locator(".q-card:has(:text('Receiver Configuration'))").first
+    expect(config_card.locator(".q-badge:text-is('GPS')")).to_be_visible()
+    expect(config_card.locator(".q-badge:text-is('SBAS')")).to_be_visible()
+
+
+@pytest.mark.e2e
+def test_matrix_tags_1005_required_and_highlights_data_link_columns(
+    page: Page,
+    base_url: str,
+    connected_gps: None,
+) -> None:
+    """1005 carries a "Required" tag; UART1/UART2 headers are highlighted."""
+    _goto_gps_config(page, base_url)
+
+    row_1005 = page.locator(".rtcm-row-1005")
+    expect(row_1005).to_be_visible(timeout=10_000)
+    expect(row_1005.locator(".q-badge:text-is('Required')")).to_be_visible()
+
+    expect(page.locator(".rtcm-col-header-UART1")).to_have_class(
+        re.compile("text-primary")
+    )
+    expect(page.locator(".rtcm-col-header-UART2")).to_have_class(
+        re.compile("text-primary")
+    )
+    expect(page.locator(".rtcm-col-header-USB")).not_to_have_class(
+        re.compile("text-primary")
+    )
+
+
+@pytest.mark.e2e
+def test_picker_lists_builtin_before_custom_and_greys_incompatible(
+    page: Page,
+    base_url: str,
+    connected_gps: None,
+    custom_incompatible_profile: None,
+) -> None:
+    """Built-in appears before the incompatible custom, which is greyed + tooltipped."""
+    _goto_gps_config(page, base_url)
+
+    builtin_row = page.locator(f".profile-row-{BUILTIN_NAME}")
+    custom_name = CUSTOM_INCOMPATIBLE_PROFILE["name"]
+    custom_row = page.locator(f".profile-row-{custom_name}")
+    expect(builtin_row).to_be_visible(timeout=10_000)
+    expect(custom_row).to_be_visible(timeout=10_000)
+
+    builtin_box = builtin_row.bounding_box()
+    custom_box = custom_row.bounding_box()
+    assert builtin_box is not None and custom_box is not None
+    assert builtin_box["y"] < custom_box["y"], (
+        "built-in profile should render above the custom profile"
+    )
+
+    # Greyed + tooltip: the incompatible custom's row carries an info
+    # icon whose hover tooltip names the mismatched hardware.
+    info_icon = custom_row.locator(".profile-incompatible-icon")
+    expect(info_icon).to_be_visible()
+    info_icon.hover()
+    expect(page.get_by_text("not for this hardware (ZED-F9P)")).to_be_visible(
+        timeout=5_000
+    )
+    expect(builtin_row.locator(".profile-incompatible-icon")).to_have_count(0)
+
+
+@pytest.mark.e2e
+def test_default_is_suggested_but_not_written_to_form(
+    page: Page,
+    base_url: str,
+    connected_gps: None,
+) -> None:
+    """The confirmed-compatible built-in is badged "Suggested"; the form stays live-seeded."""
+    _goto_gps_config(page, base_url)
+
+    builtin_row = page.locator(f".profile-row-{BUILTIN_NAME}")
+    expect(builtin_row).to_be_visible(timeout=10_000)
+    expect(builtin_row.locator(".profile-suggested-badge")).to_be_visible()
+
+    # The built-in profile's matrix has UART2 enabled for 1077; the
+    # fake driver's live read-back does not (UART1+USB only). If the
+    # form had been written from the "suggested" profile, this cell
+    # would show "on". It must instead reflect the live receiver.
+    expect(page.locator(".rtcm-cell-1077-UART2")).to_have_text("-", timeout=10_000)
+
+
+@pytest.mark.e2e
+def test_unconfirmed_hardware_banner_shown_with_no_default(
+    page: Page,
+    base_url: str,
+    connected_gps_unknown_hw: None,
+) -> None:
+    """Unresolved hardware identity shows the banner and suggests nothing."""
+    _goto_gps_config(page, base_url)
+
+    profile_card = page.locator(".q-card:has(.profile-row)").first
+    expect(profile_card).to_be_visible(timeout=10_000)
+    expect(profile_card.get_by_text("Unconfirmed hardware")).to_be_visible(
+        timeout=10_000
+    )
+    expect(profile_card.locator(".profile-suggested-badge")).to_have_count(0)

--- a/tests/unit/test_gps_config_helpers.py
+++ b/tests/unit/test_gps_config_helpers.py
@@ -1,0 +1,190 @@
+"""Tests for the pure helpers used by the Advanced GPS Config page (issue #64).
+
+The page-rendering closure itself drives NiceGUI elements and can't be
+meaningfully unit-tested without a full browser harness (that's what
+tests/e2e covers). These helpers are pure functions extracted from
+``ui/pages/gps_config.py`` to make the profile-picker tagging and
+RTCM-matrix/advisory logic verifiable in isolation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sp_rtk_base.models.device_models import (
+    PortId,
+    RtcmOutputPort,
+    RtcmPortConfig,
+    RtcmRowId,
+)
+from sp_rtk_base.models.hardware_identity import (
+    HARDWARE_ANY,
+    HARDWARE_UNKNOWN,
+    HardwareConfidence,
+    identity_from_target,
+)
+from sp_rtk_base.models.profile_models import Profile
+from sp_rtk_base.services.profile_store import ProfileStore
+from sp_rtk_base.ui.pages.gps_config import (
+    REQUIRED_RTCM_ROW,
+    build_picker_entries,
+    i2c_spi_advisory_rows,
+    matrix_cell_on,
+    resolve_identity,
+    row_slug,
+)
+
+
+def _matrix_ok() -> dict[RtcmRowId, dict[PortId, bool]]:
+    return {RtcmRowId.RTCM_1005: {PortId.UART1: True}}
+
+
+def _profile(name: str, hardware: str) -> Profile:
+    return Profile.model_validate(
+        {
+            "name": name,
+            "version": 1,
+            "hardware": hardware,
+            "data_link_port": [PortId.UART1],
+            "rtcm_stream": {"matrix": _matrix_ok()},
+        }
+    )
+
+
+class TestResolveIdentity:
+    def test_none_fields_resolve_to_unknown(self) -> None:
+        identity = resolve_identity(None, None)
+        assert identity.target == HARDWARE_UNKNOWN
+        assert identity.confidence == HardwareConfidence.UNKNOWN
+
+    def test_confirmed_target_passes_through(self) -> None:
+        identity = resolve_identity("ZED-F9P", HardwareConfidence.CONFIRMED)
+        assert identity.target == "ZED-F9P"
+        assert identity.confidence == HardwareConfidence.CONFIRMED
+        assert identity.is_specific_model
+
+
+class TestBuildPickerEntries:
+    """The one-time-required 1005 row is REQUIRED_RTCM_ROW — sanity check."""
+
+    def test_required_row_is_1005(self) -> None:
+        assert REQUIRED_RTCM_ROW == RtcmRowId.RTCM_1005
+
+    def test_builtin_before_custom(self, tmp_path: Path) -> None:
+        store = ProfileStore(profiles_dir=tmp_path)
+        custom = _profile("zzz-custom", HARDWARE_ANY)
+        store.create_profile(custom)
+        profiles = store.list_profiles()  # built-in first, alphabetical
+
+        identity = identity_from_target(HARDWARE_UNKNOWN, HardwareConfidence.UNKNOWN)
+        entries = build_picker_entries(profiles, store, identity)
+
+        assert [e.profile.name for e in entries] == [p.name for p in profiles]
+        assert entries[0].is_builtin
+        assert not entries[-1].is_builtin
+
+    def test_confirmed_matching_device_is_compatible_and_default(
+        self, tmp_path: Path
+    ) -> None:
+        store = ProfileStore(profiles_dir=tmp_path)
+        profiles = store.list_profiles()
+        identity = identity_from_target("ZED-F9P", HardwareConfidence.CONFIRMED)
+
+        entries = build_picker_entries(profiles, store, identity)
+        builtin_entry = next(
+            e for e in entries if e.profile.name == "ublox-f9p-base-standard"
+        )
+        assert builtin_entry.compatible
+        assert builtin_entry.incompatible_reason is None
+        assert builtin_entry.is_default
+
+    def test_mismatched_specific_model_is_incompatible_with_reason(
+        self, tmp_path: Path
+    ) -> None:
+        store = ProfileStore(profiles_dir=tmp_path)
+        custom = _profile("f9r-only", "ZED-F9R")
+        store.create_profile(custom)
+        profiles = store.list_profiles()
+        identity = identity_from_target("ZED-F9P", HardwareConfidence.CONFIRMED)
+
+        entries = build_picker_entries(profiles, store, identity)
+        f9r_entry = next(e for e in entries if e.profile.name == "f9r-only")
+
+        assert not f9r_entry.compatible
+        assert f9r_entry.incompatible_reason == "not for this hardware (ZED-F9P)"
+        assert not f9r_entry.is_default
+
+    def test_unconfirmed_identity_has_no_default(self, tmp_path: Path) -> None:
+        store = ProfileStore(profiles_dir=tmp_path)
+        profiles = store.list_profiles()
+        identity = identity_from_target("ZED-F9P", HardwareConfidence.INFERRED)
+
+        entries = build_picker_entries(profiles, store, identity)
+
+        assert not any(e.is_default for e in entries)
+        builtin_entry = next(
+            e for e in entries if e.profile.name == "ublox-f9p-base-standard"
+        )
+        assert not builtin_entry.compatible
+        assert builtin_entry.incompatible_reason == (
+            "receiver hardware is unconfirmed — only family- or any-tagged "
+            "profiles are enabled"
+        )
+
+
+class TestMatrixCellOn:
+    def test_on_when_rate_positive(self) -> None:
+        rtcm = RtcmPortConfig(
+            messages={RtcmRowId.RTCM_1005: {"UART1": 1, "UART2": 0, "USB": 0}}
+        )
+        assert matrix_cell_on(rtcm, RtcmRowId.RTCM_1005, PortId.UART1)
+        assert not matrix_cell_on(rtcm, RtcmRowId.RTCM_1005, PortId.UART2)
+
+    def test_missing_row_is_off(self) -> None:
+        rtcm = RtcmPortConfig(messages={})
+        assert not matrix_cell_on(rtcm, RtcmRowId.RTCM_1077, PortId.USB)
+
+
+class TestRowSlug:
+    def test_plain_row_id_is_unchanged(self) -> None:
+        assert row_slug(RtcmRowId.RTCM_1005) == "1005"
+
+    def test_dotted_row_id_becomes_css_safe(self) -> None:
+        assert row_slug(RtcmRowId.RTCM_4072_0) == "4072_0"
+        assert row_slug(RtcmRowId.RTCM_4072_1) == "4072_1"
+
+
+class TestI2cSpiAdvisoryRows:
+    def test_empty_when_only_matrix_ports_enabled(self) -> None:
+        rtcm = RtcmPortConfig(
+            messages={
+                RtcmRowId.RTCM_1005: {
+                    "UART1": 1,
+                    "UART2": 0,
+                    "USB": 0,
+                    "I2C": 0,
+                    "SPI": 0,
+                }
+            }
+        )
+        assert i2c_spi_advisory_rows(rtcm) == []
+
+    @pytest.mark.parametrize("advisory_port", [RtcmOutputPort.I2C, RtcmOutputPort.SPI])
+    def test_nonzero_cell_on_advisory_port_is_flagged(
+        self, advisory_port: RtcmOutputPort
+    ) -> None:
+        rtcm = RtcmPortConfig(
+            messages={RtcmRowId.RTCM_1077: {"UART1": 0, advisory_port.value: 1}}
+        )
+        assert i2c_spi_advisory_rows(rtcm) == [RtcmRowId.RTCM_1077]
+
+    def test_multiple_flagged_rows_preserve_catalog_order(self) -> None:
+        rtcm = RtcmPortConfig(
+            messages={
+                RtcmRowId.RTCM_1097: {"I2C": 1},
+                RtcmRowId.RTCM_1005: {"SPI": 1},
+            }
+        )
+        assert i2c_spi_advisory_rows(rtcm) == [RtcmRowId.RTCM_1005, RtcmRowId.RTCM_1097]


### PR DESCRIPTION
## Summary

Closes #64.

- Replaces the checkbox/switch RTCM and GNSS editing sections on `/gps-config` with the read-only profile-based shell approved in the T5 prototype (#49): a profile picker tagged with hardware compatibility, and a "Receiver Configuration" view seeded from the live device.
- Profile picker: built-ins before customs (alphabetical within each), incompatible profiles greyed with a "not for this hardware" tooltip, an "unconfirmed hardware" banner when identity confidence isn't `confirmed`, and the deterministic default visibly badged "Suggested" — without writing into the form. Selecting a profile still doesn't do anything yet; that wiring is a later ticket.
- Receiver Configuration: read-only port protocols, GNSS constellations, and a 12-row × 3-port (UART1/UART2/USB) boolean RTCM matrix seeded from `GET /api/device/rtcm-ports`, `GET /api/device/port-protocols`, and `GET /api/device/gnss`. UART1/UART2 columns are highlighted as data-link ports, row 1005 is tagged "Required", and a non-zero I2C/SPI cell in the read-back surfaces an advisory banner.
- No Apply, no Save-as yet — those land with the profile Apply pipeline in a later ticket.
- `FakeGpsDriver` now reports a confirmed `ZED-F9P` identity by default (it already mirrors that receiver's reference profile) and gained a `FAKE_UNKNOWN_HW_PORT` sentinel so e2e tests can exercise the unconfirmed-hardware banner without real hardware.

The old shave-by-shave RTCM/GNSS editable sections (and their e2e coverage) are removed as part of this migration, per the destination design in #54.

## Test plan

- [x] `uv run pytest` — full unit suite (1317 tests), coverage 93.24%
- [x] `uv run pytest tests/e2e --no-cov` — full e2e suite (49 tests), including the new `test_gps_profile_picker.py`
- [x] `uv run pyright src/` — clean
- [x] `uv run ruff check`/`format` — clean
- [x] `/code-review` (Standards + Spec axes) — Spec: 0 findings; Standards: 2 judgement calls found and fixed (untested `row_slug()` helper, duplicated sentinel string in an e2e fixture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)