### PR TITLE
Apply from the GPS page, with the receiver-out-of-sync indicator

### DIFF
--- a/src/sp_rtk_base/services/drivers/fake.py
+++ b/src/sp_rtk_base/services/drivers/fake.py
@@ -104,6 +104,13 @@ FAKE_PORT_LABEL: str = "FAKE"
 # "unconfirmed hardware" picker banner without real hardware.
 FAKE_UNKNOWN_HW_PORT: str = "FAKE-UNKNOWN-HW"
 
+# Sentinel ``port`` value the e2e suite can pass to ``connect()`` to make
+# the fake driver report a factory-fresh RTCM state (no message enabled
+# on any port) instead of its normal pre-configured base profile — the
+# only way to reach the GPS page's "data-link port cannot be inferred"
+# prompt without real hardware.
+FAKE_FACTORY_PORT: str = "FAKE-FACTORY"
+
 
 class FakeGpsDriver(GpsReceiverDriver):
     """In-memory GPS receiver driver for E2E + dev-mode testing.
@@ -305,6 +312,8 @@ class FakeGpsDriver(GpsReceiverDriver):
                     "hardware_confidence": HardwareConfidence.UNKNOWN,
                 }
             )
+        elif port == FAKE_FACTORY_PORT:
+            self._rtcm_ports = RtcmPortConfig()
         return self._device_info
 
     def disconnect(self) -> None:

--- a/src/sp_rtk_base/ui/pages/gps_config.py
+++ b/src/sp_rtk_base/ui/pages/gps_config.py
@@ -1,16 +1,17 @@
-"""Advanced GPS Configuration page — profile picker, live-seeded form, handoff.
+"""Advanced GPS Configuration page — profile picker, live-seeded form, Apply, handoff.
 
 Provides the profile-based GPS receiver setup flow (issue #54): a
-profile picker tagged with hardware compatibility, a read-only
-receiver-configuration view seeded from the live device (RTCM matrix,
-port protocols, GNSS constellations), save-to-flash, and relay
-handoff.
+profile picker tagged with hardware compatibility, a receiver-
+configuration view seeded from the live device (RTCM matrix, port
+protocols, GNSS constellations), save-to-flash, and relay handoff.
 
-This is the read-only shell (issue #64) — no Apply, no Save-as yet.
-Selecting a profile is rendering-only: it does not write into the
-form. That wiring, plus the shave-by-shave RTCM/GNSS editing this page
-used to have, lands in a later ticket via the profile Apply pipeline
-(``POST /api/device/apply-config``).
+Issue #64 shipped the read-only shell; issue #65 (this revision) makes
+the RTCM matrix and data-link port(s) editable and wires them to
+``POST /api/device/apply-config`` via ``DeviceService.apply_receiver_config``,
+plus the "receiver out of sync" indicator (form vs. live receiver,
+cleared only by a successful apply). Selecting a profile is still
+rendering-only — it does not write into the form; that wiring, plus
+editing ports/GNSS/role fields, lands in a later ticket (#66).
 """
 
 # pyright: reportUnknownMemberType=false
@@ -25,11 +26,13 @@ import logging
 from dataclasses import dataclass
 
 from nicegui import ui
+from pydantic import ValidationError
 
 from sp_rtk_base.models.config_models import DeviceProfile
 from sp_rtk_base.models.device_models import (
     ALL_RTCM_MESSAGE_IDS,
     RTCM_MESSAGE_GROUPS,
+    ApplyConfigCellDiff,
     DeviceCapability,
     DeviceConnectionState,
     GnssConfig,
@@ -48,11 +51,15 @@ from sp_rtk_base.models.hardware_identity import (
     incompatible_reason,
     is_compatible,
 )
-from sp_rtk_base.models.profile_models import Profile
+from sp_rtk_base.models.profile_models import Profile, ReceiverConfig, RtcmStreamConfig
 from sp_rtk_base.services import (
     get_config_service,
     get_device_service,
     get_profile_store,
+)
+from sp_rtk_base.services.device_service import (
+    ApplyConfigLinkLostError,
+    ApplyConfigRefusedError,
 )
 from sp_rtk_base.services.drivers import create_driver, list_drivers
 from sp_rtk_base.services.drivers.base import GpsReceiverDriver
@@ -159,6 +166,94 @@ def i2c_spi_advisory_rows(rtcm: RtcmPortConfig) -> list[RtcmRowId]:
     ]
 
 
+def rtcm_config_to_matrix(
+    rtcm: RtcmPortConfig,
+) -> dict[RtcmRowId, dict[PortId, bool]]:
+    """Seed the editable boolean matrix from a live ``RtcmPortConfig`` read-back.
+
+    Every catalog row x :data:`MATRIX_PORTS` cell is present (default
+    off) so the result compares by plain equality against another
+    matrix built the same way — that equality is how the "receiver out
+    of sync" indicator works.
+    """
+    return {
+        row_id: {port: matrix_cell_on(rtcm, row_id, port) for port in MATRIX_PORTS}
+        for row_id in ALL_RTCM_MESSAGE_IDS
+    }
+
+
+def infer_data_link_ports(matrix: dict[RtcmRowId, dict[PortId, bool]]) -> list[PortId]:
+    """UART ports already carrying at least one enabled RTCM row.
+
+    ``data_link_port`` has no CFG key of its own — it can't be read
+    back from the receiver — so it's inferred from which UART already
+    emits RTCM rather than guessed (issue #54's usage-driven
+    revision). USB is never a candidate. An empty result means the
+    inference is empty (a factory receiver with no RTCM anywhere) and
+    the operator must pick explicitly.
+    """
+    return [
+        port
+        for port in (PortId.UART1, PortId.UART2)
+        if any(row.get(port, False) for row in matrix.values())
+    ]
+
+
+def apply_blocked_reason(data_link_port: list[PortId]) -> str | None:
+    """Why Apply is disabled right now, or ``None`` if it isn't."""
+    if not data_link_port:
+        return (
+            "No data-link port could be inferred — select at least one "
+            "UART port below before applying."
+        )
+    return None
+
+
+def build_apply_config(
+    matrix: dict[RtcmRowId, dict[PortId, bool]],
+    data_link_port: list[PortId],
+) -> ReceiverConfig:
+    """Build the ``ReceiverConfig`` Apply pushes from the editable form state.
+
+    Only the RTCM matrix and the data-link ports are editable on this
+    page (issue #65) — every other field is left at its schema default
+    / ``None`` so Apply never touches ports, GNSS, role fields or baud
+    that this page doesn't yet expose for editing.
+
+    Raises:
+        pydantic.ValidationError: If the resulting config fails a
+            context-free rule (e.g. 1005 missing from every chosen
+            data-link port) — a client-side pre-write refusal, nothing
+            is sent to the receiver.
+    """
+    return ReceiverConfig(
+        data_link_port=data_link_port,
+        rtcm_stream=RtcmStreamConfig(matrix=matrix),
+    )
+
+
+def copy_matrix(
+    matrix: dict[RtcmRowId, dict[PortId, bool]],
+) -> dict[RtcmRowId, dict[PortId, bool]]:
+    """Deep-copy a row x port matrix so the copy can diverge independently.
+
+    A shallow ``dict(matrix)`` shares the per-row inner dicts with the
+    original — mutating one cell would silently mutate both the form
+    and the "last known live" snapshot, breaking the out-of-sync
+    comparison.
+    """
+    return {row: dict(ports) for row, ports in matrix.items()}
+
+
+def format_cell_diff(diff: ApplyConfigCellDiff) -> str:
+    """Render one post-apply read-back mismatch as a human-readable line."""
+    expected = "on" if diff.expected else "off"
+    actual = "on" if diff.actual else "off"
+    return (
+        f"{diff.row_id.value} on {diff.port.value}: expected {expected}, got {actual}"
+    )
+
+
 def row_slug(row_id: RtcmRowId) -> str:
     """A CSS-class-safe token for *row_id* (``"4072.0"`` -> ``"4072_0"``) — a
     stable hook the e2e suite uses to target a specific matrix row/cell."""
@@ -262,8 +357,9 @@ def gps_config_page() -> None:
         with config_card:
             ui.label("Receiver Configuration").classes("text-h6 text-white")
             ui.label(
-                "Read-only — reflects what is actually on the receiver right "
-                "now, not a saved profile."
+                "Port protocols and GNSS reflect the receiver and aren't "
+                "editable here yet. The RTCM matrix and data-link port(s) "
+                "below are — edit, then Apply."
             ).classes("text-grey-4 q-mt-xs text-caption")
             ui.separator()
 
@@ -275,9 +371,9 @@ def gps_config_page() -> None:
 
             ui.label("RTCM Stream").classes("text-subtitle2 text-white q-mt-md")
             ui.label(
-                "Boolean matrix — on/off per message x port. "
-                "Highlighted columns are data-link ports (where rovers read "
-                "corrections); USB is local diagnostics only."
+                "Boolean matrix — on/off per message x port. Click a cell to "
+                "toggle it. Highlighted columns are data-link ports (where "
+                "rovers read corrections); USB is local diagnostics only."
             ).classes("text-grey-4 q-mt-xs text-caption")
             matrix_view = ui.column().classes("q-mt-sm gap-0 w-full")
 
@@ -287,6 +383,30 @@ def gps_config_page() -> None:
                 .style("border: 1px solid #5a4520; border-radius: 4px")
             )
             advisory_label.set_visibility(False)
+
+            ui.label("Data-Link Port(s)").classes("text-subtitle2 text-white q-mt-md")
+            data_link_hint = ui.label("").classes(
+                "data-link-hint text-grey-4 q-mt-xs text-caption"
+            )
+            data_link_blocked_label = (
+                ui.label("")
+                .classes("data-link-blocked text-warning text-caption q-mt-xs q-pa-sm")
+                .style("border: 1px solid #5a4520; border-radius: 4px")
+            )
+            data_link_blocked_label.set_visibility(False)
+            data_link_picker = ui.row().classes("data-link-picker q-mt-xs gap-4")
+
+            with ui.row().classes("items-center gap-3 q-mt-md"):
+                apply_btn = ui.button("Apply", icon="bolt").props("color=primary")
+                sync_badge = ui.badge("").classes("sync-badge").props("color=positive")
+
+            apply_result_label = (
+                ui.label("")
+                .classes("apply-result text-caption q-mt-sm q-pa-sm")
+                .style("border: 1px solid #333; border-radius: 4px")
+            )
+            apply_result_label.set_visibility(False)
+            apply_diff_list = ui.column().classes("apply-diff-list q-mt-xs gap-0")
 
         # ================================================================
         # Section D: Save to Flash (hidden until connected + capable)
@@ -473,6 +593,18 @@ def gps_config_page() -> None:
             else:
                 error_label.set_visibility(False)
 
+        # Editable form state (issue #65) — seeded from the live receiver on
+        # every load/reload/reconnect, then mutated by matrix clicks and the
+        # data-link checkboxes until the next Apply or reseed.
+        form_matrix: dict[RtcmRowId, dict[PortId, bool]] = rtcm_config_to_matrix(
+            RtcmPortConfig()
+        )
+        live_matrix: dict[RtcmRowId, dict[PortId, bool]] = copy_matrix(form_matrix)
+        form_data_link_ports: list[PortId] = []
+
+        def _out_of_sync() -> bool:
+            return form_matrix != live_matrix
+
         def _render_ports_table(ports: PortProtocolConfig) -> None:
             ports_view.clear()
             with ports_view:
@@ -500,7 +632,12 @@ def gps_config_page() -> None:
                         "color=positive" if enabled else "outline color=grey"
                     )
 
-        def _render_matrix(rtcm: RtcmPortConfig) -> None:
+        def _toggle_matrix_cell(msg_id: RtcmRowId, port: PortId) -> None:
+            form_matrix[msg_id][port] = not form_matrix[msg_id][port]
+            _render_matrix()
+            _on_form_changed()
+
+        def _render_matrix() -> None:
             matrix_view.clear()
             with matrix_view:
                 # Header row
@@ -548,15 +685,144 @@ def gps_config_page() -> None:
                                     ui.badge("Required").props("outline color=warning")
 
                             for port in MATRIX_PORTS:
-                                on = matrix_cell_on(rtcm, msg_id, port)
+                                on = form_matrix[msg_id][port]
                                 cell_classes = (
                                     f"rtcm-cell rtcm-cell-{slug}-{port.value} "
-                                    "text-center"
+                                    "text-center cursor-pointer"
                                     + (" text-positive" if on else " text-grey-7")
                                 )
                                 ui.label("✓" if on else "-").classes(
                                     cell_classes
-                                ).style("width: 70px; flex-shrink: 0")
+                                ).style("width: 70px; flex-shrink: 0").on(
+                                    "click",
+                                    lambda _, m=msg_id, p=port: _toggle_matrix_cell(
+                                        m, p
+                                    ),
+                                )
+
+        def _render_data_link_picker() -> None:
+            inferred = infer_data_link_ports(form_matrix)
+            data_link_hint.text = (
+                f"Inferred from current RTCM state: "
+                f"{', '.join(p.value for p in inferred)}"
+                if inferred
+                else "Nothing inferred yet — pick below."
+            )
+
+            data_link_picker.clear()
+            with data_link_picker:
+                for port in (PortId.UART1, PortId.UART2):
+                    ui.checkbox(
+                        port.value,
+                        value=port in form_data_link_ports,
+                        on_change=lambda e, p=port: _toggle_data_link_port(
+                            p, bool(e.value)
+                        ),
+                    ).classes(f"data-link-checkbox-{port.value}")
+
+        def _toggle_data_link_port(port: PortId, checked: bool) -> None:
+            if checked and port not in form_data_link_ports:
+                form_data_link_ports.append(port)
+            elif not checked and port in form_data_link_ports:
+                form_data_link_ports.remove(port)
+            _on_form_changed()
+
+        def _render_sync_indicator() -> None:
+            if _out_of_sync():
+                sync_badge.text = "Receiver out of sync"
+                sync_badge.props("color=warning")
+            else:
+                sync_badge.text = "In sync"
+                sync_badge.props("color=positive")
+
+        def _render_apply_gate() -> None:
+            reason = apply_blocked_reason(form_data_link_ports)
+            apply_btn.set_enabled(reason is None)
+            data_link_blocked_label.text = reason or ""
+            data_link_blocked_label.set_visibility(reason is not None)
+
+        def _on_form_changed() -> None:
+            """Recompute every reactive bit of the form after an edit.
+
+            Includes the data-link picker so its "inferred from current
+            RTCM state" hint stays current after a matrix toggle, not
+            just after a reseed.
+            """
+            _render_data_link_picker()
+            _render_sync_indicator()
+            _render_apply_gate()
+
+        def _set_apply_result(text: str, *, ok: bool) -> None:
+            apply_diff_list.clear()
+            apply_result_label.text = text
+            apply_result_label.classes(
+                remove="text-negative" if ok else "text-positive",
+                add="text-positive" if ok else "text-negative",
+            )
+            apply_result_label.set_visibility(True)
+
+        def _clear_apply_result() -> None:
+            apply_result_label.set_visibility(False)
+            apply_diff_list.clear()
+
+        def _show_apply_diff(diff: list[ApplyConfigCellDiff]) -> None:
+            apply_diff_list.clear()
+            with apply_diff_list:
+                for cell in diff:
+                    ui.label(format_cell_diff(cell)).classes(
+                        "text-caption text-warning"
+                    )
+
+        async def _apply() -> None:
+            """Push the current form (matrix + data-link ports) to the receiver."""
+            nonlocal live_matrix
+            try:
+                config = build_apply_config(form_matrix, form_data_link_ports)
+            except ValidationError as exc:
+                _set_apply_result(
+                    f"Apply refused: {exc.errors()[0]['msg']} — nothing was written.",
+                    ok=False,
+                )
+                return
+
+            try:
+                result = await svc.apply_receiver_config(config)
+            except ApplyConfigRefusedError as exc:
+                _set_apply_result(
+                    f"Apply refused ({exc.rule}): {exc} — nothing was written.",
+                    ok=False,
+                )
+                return
+            except ApplyConfigLinkLostError as exc:
+                _set_apply_result(str(exc), ok=False)
+                return
+            except Exception as exc:
+                ui.notify(f"Apply failed: {exc}", type="negative")
+                logger.exception("apply-config failed")
+                return
+
+            if result.status == "ok":
+                live_matrix = copy_matrix(form_matrix)
+                _set_apply_result("Applied and verified ✓", ok=True)
+                ui.notify("Applied and verified ✓", type="positive")
+            else:
+                # The writes landed but the read-back disagrees — reflect
+                # the receiver's *actual* state so "out of sync" stays
+                # honest even though only a successful apply clears it.
+                for cell in result.diff:
+                    live_matrix[cell.row_id][cell.port] = cell.actual
+                _set_apply_result(
+                    "Applied, but verification found mismatches — nothing "
+                    "was rolled back.",
+                    ok=False,
+                )
+                _show_apply_diff(result.diff)
+                ui.notify("Verification found mismatches", type="warning")
+
+            if result.warnings:
+                ui.notify(" ".join(result.warnings), type="warning")
+
+            _on_form_changed()
 
         def _render_advisory(rtcm: RtcmPortConfig) -> None:
             rows = i2c_spi_advisory_rows(rtcm)
@@ -571,14 +837,28 @@ def gps_config_page() -> None:
                 advisory_label.set_visibility(False)
 
         async def _load_receiver_config_form() -> None:
-            """Seed the read-only form from the live receiver."""
+            """Seed the form from the live receiver.
+
+            The RTCM matrix and data-link ports are freshly inferred here
+            every time — on connect, reload, and reconnect — so the form
+            starts in sync by construction (issue #65), matching the rest
+            of this page's existing live-seeding behaviour.
+            """
+            nonlocal form_matrix, live_matrix, form_data_link_ports
             rtcm = await svc.get_rtcm_port_config()
             ports = await svc.get_port_protocols()
             gnss = await svc.get_gnss_config()
+
+            form_matrix = rtcm_config_to_matrix(rtcm)
+            live_matrix = copy_matrix(form_matrix)
+            form_data_link_ports = infer_data_link_ports(form_matrix)
+
             _render_ports_table(ports)
             _render_gnss(gnss)
-            _render_matrix(rtcm)
+            _render_matrix()
             _render_advisory(rtcm)
+            _clear_apply_result()
+            _on_form_changed()
 
         async def _connect() -> None:
             """Connect to the selected device."""
@@ -676,6 +956,7 @@ def gps_config_page() -> None:
         cancel_btn.on_click(lambda: _cancel_connect())
         refresh_btn.on_click(lambda: _refresh_ports())
         reload_device_btn.on_click(_reload_device_config)
+        apply_btn.on_click(_apply)
         save_flash_btn.on_click(_save_flash)
         handoff_btn.on_click(_handoff_to_relay)
 

--- a/tests/e2e/test_gps_apply.py
+++ b/tests/e2e/test_gps_apply.py
@@ -1,0 +1,152 @@
+"""E2E tests for Apply + the receiver-out-of-sync indicator (issue #65).
+
+Extends the GPS page suite (``test_gps_profile_picker.py`` covers the
+read-only shell from #64). This ticket makes the RTCM matrix and
+data-link port(s) editable and wires them to
+``POST /api/device/apply-config``:
+
+- Toggling a matrix cell flips the "In sync" badge to "Receiver out of
+  sync"; a successful Apply clears it back to "In sync" (usage path 2
+  — tweak one cell, apply, iterate).
+- A factory-fresh receiver (no RTCM anywhere) can't infer a data-link
+  port — Apply is disabled with a clear prompt until the operator
+  checks at least one UART box.
+- Breaking a context-free rule (1005 must stay on the chosen data-link
+  port) surfaces a named pre-write refusal and writes nothing.
+
+Locators target the stable CSS class hooks the page renders (see
+``ui/pages/gps_config.py``), matching the existing suite's convention.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+from sp_rtk_base.services.drivers.fake import FAKE_FACTORY_PORT
+
+
+@pytest.fixture()
+def connected_gps_factory(api_base_url: str) -> Iterator[None]:
+    """Connect the fake driver in its factory-fresh state (no RTCM anywhere).
+
+    Uses ``FakeGpsDriver.FAKE_FACTORY_PORT`` — the sentinel that resets
+    the fake driver's RTCM read-back to empty, the only way to reach
+    the GPS page's "data-link port cannot be inferred" prompt without
+    real hardware.
+    """
+    try:
+        httpx.post(f"{api_base_url}/api/device/disconnect", timeout=5.0)
+    except Exception:
+        pass
+
+    payload = {"vendor": "fake", "port": FAKE_FACTORY_PORT, "baud_rate": 115200}
+    resp = httpx.post(f"{api_base_url}/api/device/connect", json=payload, timeout=10.0)
+    if resp.status_code not in (200, 409):
+        raise RuntimeError(
+            f"Could not connect FakeGpsDriver (factory): "
+            f"HTTP {resp.status_code} — {resp.text}"
+        )
+    try:
+        yield
+    finally:
+        try:
+            httpx.post(f"{api_base_url}/api/device/disconnect", timeout=5.0)
+        except Exception:
+            pass
+
+
+def _goto_gps_config(page: Page, base_url: str) -> None:
+    page.goto(f"{base_url}/gps-config")
+    expect(page.locator("text=Advanced GPS Configuration").first).to_be_visible(
+        timeout=15_000
+    )
+
+
+@pytest.mark.e2e
+def test_toggle_cell_then_apply_clears_out_of_sync(
+    page: Page,
+    base_url: str,
+    connected_gps: None,
+) -> None:
+    """Usage path 2: connect to a configured base, tweak one cell, Apply."""
+    _goto_gps_config(page, base_url)
+
+    sync_badge = page.locator(".sync-badge")
+    expect(sync_badge).to_have_text("In sync", timeout=10_000)
+
+    # 1077 is off on UART2 by default (see FakeGpsDriver) — toggle it on.
+    cell = page.locator(".rtcm-cell-1077-UART2")
+    expect(cell).to_have_text("-")
+    cell.click()
+    expect(cell).to_have_text("✓")
+    expect(sync_badge).to_have_text("Receiver out of sync")
+
+    apply_btn = page.get_by_role("button", name="Apply")
+    expect(apply_btn).to_be_enabled()
+    apply_btn.click()
+
+    expect(page.locator(".apply-result")).to_contain_text(
+        "Applied and verified", timeout=10_000
+    )
+    expect(sync_badge).to_have_text("In sync")
+    # The applied cell stays on after a successful, verified apply.
+    expect(cell).to_have_text("✓")
+
+
+@pytest.mark.e2e
+def test_factory_receiver_blocks_apply_until_data_link_port_chosen(
+    page: Page,
+    base_url: str,
+    connected_gps_factory: None,
+) -> None:
+    """No RTCM anywhere -> nothing inferred -> Apply is blocked with a prompt."""
+    _goto_gps_config(page, base_url)
+
+    expect(page.locator(".data-link-blocked")).to_be_visible(timeout=10_000)
+    apply_btn = page.get_by_role("button", name="Apply")
+    expect(apply_btn).to_be_disabled()
+
+    # Turn on 1005 for UART1 so the chosen data-link port has a row on,
+    # then explicitly pick UART1 as the data-link port.
+    page.locator(".rtcm-cell-1005-UART1").click()
+    page.locator(".data-link-checkbox-UART1").click()
+
+    expect(page.locator(".data-link-blocked")).not_to_be_visible()
+    expect(apply_btn).to_be_enabled()
+
+    apply_btn.click()
+    expect(page.locator(".apply-result")).to_contain_text(
+        "Applied and verified", timeout=10_000
+    )
+
+
+@pytest.mark.e2e
+def test_breaking_1005_rule_shows_named_refusal_and_writes_nothing(
+    page: Page,
+    base_url: str,
+    connected_gps: None,
+) -> None:
+    """Turning off 1005 on the only data-link port is refused pre-write."""
+    _goto_gps_config(page, base_url)
+
+    # FakeGpsDriver's default state has 1005 enabled on UART1, which is
+    # inferred as the sole data-link port. Turn it off.
+    cell = page.locator(".rtcm-cell-1005-UART1")
+    expect(cell).to_have_text("✓", timeout=10_000)
+    cell.click()
+    expect(cell).to_have_text("-")
+
+    page.get_by_role("button", name="Apply").click()
+
+    result = page.locator(".apply-result")
+    expect(result).to_contain_text("Apply refused", timeout=10_000)
+    expect(result).to_contain_text("1005")
+    expect(result).to_contain_text("nothing was written")
+
+    # Nothing was written — the receiver-out-of-sync badge is untouched
+    # by the refusal (still reflects the pending, unwritten edit).
+    expect(page.locator(".sync-badge")).to_have_text("Receiver out of sync")

--- a/tests/unit/test_gps_config_helpers.py
+++ b/tests/unit/test_gps_config_helpers.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import pytest
 
 from sp_rtk_base.models.device_models import (
+    ApplyConfigCellDiff,
     PortId,
     RtcmOutputPort,
     RtcmPortConfig,
@@ -28,12 +29,18 @@ from sp_rtk_base.models.hardware_identity import (
 from sp_rtk_base.models.profile_models import Profile
 from sp_rtk_base.services.profile_store import ProfileStore
 from sp_rtk_base.ui.pages.gps_config import (
+    MATRIX_PORTS,
     REQUIRED_RTCM_ROW,
+    apply_blocked_reason,
+    build_apply_config,
     build_picker_entries,
+    format_cell_diff,
     i2c_spi_advisory_rows,
+    infer_data_link_ports,
     matrix_cell_on,
     resolve_identity,
     row_slug,
+    rtcm_config_to_matrix,
 )
 
 
@@ -188,3 +195,109 @@ class TestI2cSpiAdvisoryRows:
             }
         )
         assert i2c_spi_advisory_rows(rtcm) == [RtcmRowId.RTCM_1005, RtcmRowId.RTCM_1097]
+
+
+class TestRtcmConfigToMatrix:
+    """Seeds the editable boolean matrix from a live ``RtcmPortConfig`` read-back."""
+
+    def test_covers_every_catalog_row_and_matrix_port(self) -> None:
+        matrix = rtcm_config_to_matrix(RtcmPortConfig(messages={}))
+        assert set(matrix.keys()) == {
+            RtcmRowId.RTCM_1005,
+            RtcmRowId.RTCM_1077,
+            RtcmRowId.RTCM_1087,
+            RtcmRowId.RTCM_1097,
+            RtcmRowId.RTCM_1127,
+            RtcmRowId.RTCM_1230,
+            RtcmRowId.RTCM_1074,
+            RtcmRowId.RTCM_1084,
+            RtcmRowId.RTCM_1094,
+            RtcmRowId.RTCM_1124,
+            RtcmRowId.RTCM_4072_0,
+            RtcmRowId.RTCM_4072_1,
+        }
+        for row in matrix.values():
+            assert set(row.keys()) == set(MATRIX_PORTS)
+
+    def test_reflects_live_enabled_cells(self) -> None:
+        rtcm = RtcmPortConfig(
+            messages={RtcmRowId.RTCM_1005: {"UART1": 1, "UART2": 0, "USB": 1}}
+        )
+        matrix = rtcm_config_to_matrix(rtcm)
+        assert matrix[RtcmRowId.RTCM_1005][PortId.UART1] is True
+        assert matrix[RtcmRowId.RTCM_1005][PortId.UART2] is False
+        assert matrix[RtcmRowId.RTCM_1005][PortId.USB] is True
+        assert matrix[RtcmRowId.RTCM_1077][PortId.UART1] is False
+
+
+class TestInferDataLinkPorts:
+    """The spec-mandated inference: a UART carrying any RTCM row qualifies."""
+
+    def test_empty_matrix_infers_nothing(self) -> None:
+        matrix = rtcm_config_to_matrix(RtcmPortConfig(messages={}))
+        assert infer_data_link_ports(matrix) == []
+
+    def test_uart_with_a_row_on_is_inferred(self) -> None:
+        matrix = rtcm_config_to_matrix(
+            RtcmPortConfig(messages={RtcmRowId.RTCM_1005: {"UART1": 1}})
+        )
+        assert infer_data_link_ports(matrix) == [PortId.UART1]
+
+    def test_usb_only_traffic_infers_nothing(self) -> None:
+        """USB can never be a data-link port — it's excluded even if it carries RTCM."""
+        matrix = rtcm_config_to_matrix(
+            RtcmPortConfig(messages={RtcmRowId.RTCM_1005: {"USB": 1}})
+        )
+        assert infer_data_link_ports(matrix) == []
+
+    def test_both_uarts_inferred_in_enum_order(self) -> None:
+        matrix = rtcm_config_to_matrix(
+            RtcmPortConfig(messages={RtcmRowId.RTCM_1005: {"UART1": 1, "UART2": 1}})
+        )
+        assert infer_data_link_ports(matrix) == [PortId.UART1, PortId.UART2]
+
+
+class TestApplyBlockedReason:
+    def test_no_data_link_port_blocks_with_a_reason(self) -> None:
+        reason = apply_blocked_reason([])
+        assert reason is not None
+        assert "data-link port" in reason
+
+    def test_a_chosen_data_link_port_unblocks(self) -> None:
+        assert apply_blocked_reason([PortId.UART1]) is None
+
+
+class TestBuildApplyConfig:
+    def test_builds_a_valid_receiver_config(self) -> None:
+        matrix = rtcm_config_to_matrix(
+            RtcmPortConfig(messages={RtcmRowId.RTCM_1005: {"UART1": 1}})
+        )
+        config = build_apply_config(matrix, [PortId.UART1])
+        assert config.data_link_port == [PortId.UART1]
+        assert config.rtcm_stream.matrix[RtcmRowId.RTCM_1005][PortId.UART1] is True
+        # Fields this page doesn't make editable are left untouched.
+        assert config.ports is None
+        assert config.constellations is None
+        assert config.dyn_model is None
+        assert config.tmode_mode is None
+        assert config.baud is None
+
+    def test_raises_when_1005_missing_from_every_data_link_port(self) -> None:
+        matrix = rtcm_config_to_matrix(RtcmPortConfig(messages={}))
+        with pytest.raises(ValueError, match="1005"):
+            build_apply_config(matrix, [PortId.UART1])
+
+
+class TestFormatCellDiff:
+    def test_names_row_port_and_the_mismatch(self) -> None:
+        diff = ApplyConfigCellDiff(
+            row_id=RtcmRowId.RTCM_1005,
+            port=PortId.UART1,
+            expected=True,
+            actual=False,
+        )
+        text = format_cell_diff(diff)
+        assert "1005" in text
+        assert "UART1" in text
+        assert "on" in text
+        assert "off" in text


### PR DESCRIPTION
## Summary
- Makes the Advanced GPS page's RTCM matrix and data-link port(s) editable and wires them to the existing `POST /api/device/apply-config` pipeline (#61) via an always-present **Apply** button.
- Adds a "receiver out of sync" indicator (form vs. live receiver), cleared only by a successful, verified apply; a failed verify updates it from the read-back's actual state so it stays honest.
- `data_link_port` is inferred from which UART already carries RTCM (it has no CFG key of its own, per spec) rather than guessed; when inference is empty, Apply is blocked with a clear prompt until the operator picks.
- A verify mismatch renders the per-cell diff; a pre-write refusal (client-side schema violation or a backend business-rule guard) names the failure and states nothing was written.
- Editing ports/GNSS/role fields and profile pre-fill/Save-as remain out of scope (#66).

Closes #65.

## Test plan
- [x] `uv run pytest` — 1328 unit tests pass, 93% coverage
- [x] `uv run pytest tests/e2e --no-cov` — 52 e2e tests pass, including 3 new tests covering: toggle-a-cell-then-apply clearing out-of-sync (usage path 2), the factory-receiver/no-inference block, and a named pre-write refusal
- [x] `uv run pyright src/` — 0 errors
- [x] `uv run mypy` on changed files — 0 issues
- [x] `uv run ruff check` / `ruff format --check` — clean
- [x] `/code-review` (standards + spec axes) run; findings addressed (extracted duplicated error-display code, renamed `form_data_link_port` → `form_data_link_ports`, fixed a stale data-link hint after matrix edits)