### PR TITLE
Profile pre-fill, Save-as, and the modified-from-profile indicator

### DIFF
--- a/src/sp_rtk_base/ui/pages/gps_config.py
+++ b/src/sp_rtk_base/ui/pages/gps_config.py
@@ -5,13 +5,25 @@ profile picker tagged with hardware compatibility, a receiver-
 configuration view seeded from the live device (RTCM matrix, port
 protocols, GNSS constellations), save-to-flash, and relay handoff.
 
-Issue #64 shipped the read-only shell; issue #65 (this revision) makes
-the RTCM matrix and data-link port(s) editable and wires them to
+Issue #64 shipped the read-only shell; issue #65 made the RTCM matrix
+and data-link port(s) editable, wired to
 ``POST /api/device/apply-config`` via ``DeviceService.apply_receiver_config``,
 plus the "receiver out of sync" indicator (form vs. live receiver,
-cleared only by a successful apply). Selecting a profile is still
-rendering-only — it does not write into the form; that wiring, plus
-editing ports/GNSS/role fields, lands in a later ticket (#66).
+cleared only by a successful apply).
+
+Issue #66 (this revision) makes picking a profile actually write into
+the form — the whole ``ReceiverConfig`` shape (ports, GNSS,
+baud/measurement-rate, role fields, optimisations, plus the matrix and
+data-link ports), not just the matrix — and adds the second,
+independent "modified from X" indicator (form vs. *selected profile*,
+gating Save-as) alongside the existing "out of sync" one (form vs.
+*live receiver*, gating Apply). Save-as, rename, delete and export
+round out the custom-profile lifecycle. The ports/GNSS/baud/role
+section remains a read-only *display* of form state rather than a
+click-to-edit grid — the driver has no read-back for most of those
+fields (baud excepted), so there's nothing yet to reconcile an edit
+against; turning that into an editable grid is future work, same as
+#65 deferred it.
 """
 
 # pyright: reportUnknownMemberType=false
@@ -22,6 +34,7 @@ editing ports/GNSS/role fields, lands in a later ticket (#66).
 
 from __future__ import annotations
 
+import json
 import logging
 from dataclasses import dataclass
 
@@ -35,15 +48,22 @@ from sp_rtk_base.models.device_models import (
     ApplyConfigCellDiff,
     DeviceCapability,
     DeviceConnectionState,
+    DynModel,
     GnssConfig,
+    GnssConstellation,
     PortId,
     PortProtocolConfig,
     RtcmOutputPort,
     RtcmPortConfig,
     RtcmRowId,
 )
+from sp_rtk_base.models.device_models import (
+    BaseMode as TmodeMode,
+)
 from sp_rtk_base.models.hardware_identity import (
+    HARDWARE_ANY,
     HARDWARE_UNKNOWN,
+    KNOWN_FAMILY_TOKENS,
     HardwareConfidence,
     HardwareIdentity,
     default_selection,
@@ -51,7 +71,13 @@ from sp_rtk_base.models.hardware_identity import (
     incompatible_reason,
     is_compatible,
 )
-from sp_rtk_base.models.profile_models import Profile, ReceiverConfig, RtcmStreamConfig
+from sp_rtk_base.models.profile_models import (
+    BaudConfig,
+    PortProtocolSet,
+    Profile,
+    ReceiverConfig,
+    RtcmStreamConfig,
+)
 from sp_rtk_base.services import (
     get_config_service,
     get_device_service,
@@ -63,7 +89,7 @@ from sp_rtk_base.services.device_service import (
 )
 from sp_rtk_base.services.drivers import create_driver, list_drivers
 from sp_rtk_base.services.drivers.base import GpsReceiverDriver
-from sp_rtk_base.services.profile_store import ProfileStore
+from sp_rtk_base.services.profile_store import ProfileStore, ProfileStoreError
 from sp_rtk_base.ui.layout import page_layout
 
 logger = logging.getLogger(__name__)
@@ -209,16 +235,43 @@ def apply_blocked_reason(data_link_port: list[PortId]) -> str | None:
     return None
 
 
+@dataclass
+class FormExtras:
+    """The hardware-section fields beyond the matrix and data-link ports.
+
+    Not editable via any widget on this page yet (see the module
+    docstring) — this only carries values a *profile pick* pre-fills,
+    so Apply can push them and Save-as / "modified from X" can compare
+    against them. ``None`` mirrors ``ReceiverConfig``'s own "leave
+    untouched" semantics for every field except ``meas_period_ms``,
+    which ``ReceiverConfig`` itself always defaults to ``1000``.
+    """
+
+    ports: dict[PortId, PortProtocolSet] | None = None
+    constellations: list[GnssConstellation] | None = None
+    baud: BaudConfig | None = None
+    meas_period_ms: int = 1000
+    dyn_model: DynModel | None = None
+    tmode_mode: TmodeMode | None = None
+    elevation_mask_deg: int | None = None
+    bds_b2_enabled: bool | None = None
+    spi_enabled: bool | None = None
+
+
 def build_apply_config(
     matrix: dict[RtcmRowId, dict[PortId, bool]],
     data_link_port: list[PortId],
+    extras: FormExtras | None = None,
 ) -> ReceiverConfig:
-    """Build the ``ReceiverConfig`` Apply pushes from the editable form state.
+    """Build a ``ReceiverConfig`` from the form state.
 
-    Only the RTCM matrix and the data-link ports are editable on this
-    page (issue #65) — every other field is left at its schema default
-    / ``None`` so Apply never touches ports, GNSS, role fields or baud
-    that this page doesn't yet expose for editing.
+    *extras* defaults to an all-``None`` :class:`FormExtras` — nothing
+    but the matrix and data-link ports set. ``_apply()`` always uses
+    that default (Apply stays scoped to the matrix + data-link ports,
+    per #65 — the other fields have no live read-back to verify a
+    write against). Save-as and the "modified from X" comparison pass
+    the real *extras* through, since those only compare in-form state
+    and never touch the receiver.
 
     Raises:
         pydantic.ValidationError: If the resulting config fails a
@@ -226,10 +279,232 @@ def build_apply_config(
             data-link port) — a client-side pre-write refusal, nothing
             is sent to the receiver.
     """
+    extras = extras or FormExtras()
     return ReceiverConfig(
+        ports=extras.ports,
+        constellations=extras.constellations,
+        baud=extras.baud,
+        meas_period_ms=extras.meas_period_ms,
+        dyn_model=extras.dyn_model,
+        tmode_mode=extras.tmode_mode,
+        elevation_mask_deg=extras.elevation_mask_deg,
+        bds_b2_enabled=extras.bds_b2_enabled,
+        spi_enabled=extras.spi_enabled,
         data_link_port=data_link_port,
         rtcm_stream=RtcmStreamConfig(matrix=matrix),
     )
+
+
+def profile_matrix_to_form_matrix(
+    profile: Profile,
+) -> dict[RtcmRowId, dict[PortId, bool]]:
+    """Normalize a profile's sparse matrix to the full catalog x port grid.
+
+    Mirrors :func:`rtcm_config_to_matrix` — the form's out-of-sync
+    comparison relies on every matrix always covering every catalog
+    row x :data:`MATRIX_PORTS` cell, whether it was seeded from a live
+    read-back or, here, a profile pick.
+    """
+    matrix = profile.rtcm_stream.matrix
+    return {
+        row_id: {port: matrix.get(row_id, {}).get(port, False) for port in MATRIX_PORTS}
+        for row_id in ALL_RTCM_MESSAGE_IDS
+    }
+
+
+def profile_to_form_extras(profile: Profile) -> FormExtras:
+    """Everything a profile pick writes into the form besides matrix/data-link."""
+    return FormExtras(
+        ports=profile.ports,
+        constellations=profile.constellations,
+        baud=profile.baud,
+        meas_period_ms=profile.meas_period_ms,
+        dyn_model=profile.dyn_model,
+        tmode_mode=profile.tmode_mode,
+        elevation_mask_deg=profile.elevation_mask_deg,
+        bds_b2_enabled=profile.bds_b2_enabled,
+        spi_enabled=profile.spi_enabled,
+    )
+
+
+def receiver_config_from_profile(profile: Profile) -> ReceiverConfig:
+    """The ``ReceiverConfig`` a profile carries, with identity stripped.
+
+    Used to compare "the form" against "the selected profile" as the
+    same type — a ``Profile`` is a ``ReceiverConfig`` plus identity
+    fields, and those must not participate in the "modified from X"
+    equality check.
+
+    Deliberately built through :func:`build_apply_config` with the
+    same :func:`profile_matrix_to_form_matrix`/:func:`profile_to_form_extras`
+    normalization :func:`_select_profile` (in the page closure) uses to
+    seed the form from this same profile — a stored profile's matrix is
+    *sparse* (absent cell = off), while the form's is always *dense*
+    (every catalog row x port present). Comparing a freshly-picked,
+    untouched form against ``ReceiverConfig(**profile.model_dump())``
+    would almost always report "modified" — the same on/off state,
+    represented as two differently-shaped dicts that don't compare
+    equal — unless both sides go through the identical normalization.
+    """
+    return build_apply_config(
+        profile_matrix_to_form_matrix(profile),
+        list(profile.data_link_port),
+        profile_to_form_extras(profile),
+    )
+
+
+def is_modified_from_profile(
+    form_config: ReceiverConfig, profile: Profile | None
+) -> bool:
+    """Whether *form_config* diverges from *profile* — the second, independent
+    indicator (form vs. selected profile), distinct from "out of sync" (form
+    vs. live receiver). ``False`` when no profile is selected — there is
+    nothing to have diverged from."""
+    if profile is None:
+        return False
+    return form_config != receiver_config_from_profile(profile)
+
+
+def save_as_enabled(
+    form_config: ReceiverConfig | None, profile: Profile | None
+) -> bool:
+    """Save-as is available whenever the form is valid, suppressed only when
+    a *selected* profile still exactly equals the form."""
+    if form_config is None:
+        return False
+    return profile is None or is_modified_from_profile(form_config, profile)
+
+
+def suggest_profile_name(profile: Profile | None, hardware_target: str) -> str:
+    """Auto-suggested Save-as name.
+
+    ``"<source> (copy)"`` when forked from a profile, a
+    hardware-derived name when capturing a bare live config — both
+    sanitized to the store's filesystem-safe slug charset
+    (``^[A-Za-z0-9_-]+$``, see ``profile_store._SAFE_NAME_RE``), since
+    a name containing a space or parentheses would fail validation
+    the instant an operator hits Save without editing it.
+    """
+    if profile is not None:
+        return f"{profile.name}-copy"
+    return f"{hardware_target.lower()}-captured"
+
+
+def resolve_save_hardware(profile: Profile | None, identity: HardwareIdentity) -> str:
+    """The ``hardware`` tag a newly-saved profile should carry.
+
+    A fork keeps its source profile's tag unchanged. A bare capture
+    (no profile selected) tags itself with the connected receiver's
+    resolved identity when that's a valid profile-hardware token
+    (a confirmed specific model, or any family token — ``is_specific_model``
+    isn't checked here, since a family token is just as valid a target as a
+    specific model) — falling back to :data:`HARDWARE_ANY` only when identity
+    hasn't resolved to a usable token at all (``unknown``, or an ``inferred``
+    guess of a specific model that a family token can't stand in for).
+    """
+    if profile is not None:
+        return profile.hardware
+    if identity.confidence == HardwareConfidence.CONFIRMED:
+        return identity.target
+    if identity.target in KNOWN_FAMILY_TOKENS:
+        return identity.target
+    return HARDWARE_ANY
+
+
+def build_saved_profile(
+    name: str,
+    form_config: ReceiverConfig,
+    hardware: str,
+    forked_from: str | None,
+) -> Profile:
+    """Construct the ``Profile`` document Save-as persists."""
+    return Profile(
+        **form_config.model_dump(),
+        name=name,
+        version=1,
+        hardware=hardware,
+        forked_from=forked_from,
+    )
+
+
+def resolve_ports_display(
+    live: PortProtocolConfig,
+    form_ports: dict[PortId, PortProtocolSet] | None,
+) -> dict[PortId, tuple[list[str], list[str]]]:
+    """Per-port (in, out) protocol name lists the "Port Protocols" display
+    renders — the live read-back, unless a profile pick set *form_ports*, in
+    which case the form is the source of truth (issue #66)."""
+    if form_ports is not None:
+        empty = PortProtocolSet()
+        return {
+            port: (
+                [p.value for p in form_ports.get(port, empty).in_],
+                [p.value for p in form_ports.get(port, empty).out],
+            )
+            for port in (PortId.UART1, PortId.UART2, PortId.USB)
+        }
+    return {
+        port: (
+            [p.value for p in live.enabled_in(port)],
+            [p.value for p in live.enabled_out(port)],
+        )
+        for port in (PortId.UART1, PortId.UART2, PortId.USB)
+    }
+
+
+def resolve_gnss_display(
+    live: GnssConfig,
+    form_constellations: list[GnssConstellation] | None,
+) -> dict[str, bool]:
+    """Constellation -> enabled map the "GNSS Constellations" display
+    renders — the live read-back, unless a profile pick set
+    *form_constellations*, in which case only those are enabled."""
+    if form_constellations is not None:
+        wanted = set(form_constellations)
+        return {c.value: c in wanted for c in GnssConstellation}
+    return {sys_cfg.constellation.value: sys_cfg.enabled for sys_cfg in live.systems}
+
+
+def _tri_state_text(value: bool | None) -> str:
+    """``"on"``/``"off"``/``"unchanged"`` for an optional bool form field."""
+    return "unchanged" if value is None else ("on" if value else "off")
+
+
+def hw_extras_display(extras: FormExtras) -> list[tuple[str, str, str]]:
+    """(css-class, label, value) triples the "Hardware Section" display
+    renders — every :class:`FormExtras` field the matrix/ports/GNSS views
+    don't already cover."""
+    baud_parts: list[str] = []
+    if extras.baud is not None:
+        if extras.baud.uart1 is not None:
+            baud_parts.append(f"UART1={extras.baud.uart1}")
+        if extras.baud.uart2 is not None:
+            baud_parts.append(f"UART2={extras.baud.uart2}")
+
+    hz = 1000 / extras.meas_period_ms
+    return [
+        ("hw-field-meas-rate", "Measurement Rate", f"{hz:g} Hz"),
+        ("hw-field-baud", "Baud", ", ".join(baud_parts) or "unchanged"),
+        (
+            "hw-field-dyn-model",
+            "Dynamics Model",
+            extras.dyn_model.value if extras.dyn_model else "unchanged",
+        ),
+        (
+            "hw-field-tmode",
+            "Time Mode",
+            extras.tmode_mode.value if extras.tmode_mode else "unchanged",
+        ),
+        (
+            "hw-field-elevation-mask",
+            "Elevation Mask",
+            f"{extras.elevation_mask_deg}°"
+            if extras.elevation_mask_deg is not None
+            else "unchanged",
+        ),
+        ("hw-field-bds-b2", "BeiDou B2", _tri_state_text(extras.bds_b2_enabled)),
+        ("hw-field-spi", "SPI", _tri_state_text(extras.spi_enabled)),
+    ]
 
 
 def copy_matrix(
@@ -357,9 +632,10 @@ def gps_config_page() -> None:
         with config_card:
             ui.label("Receiver Configuration").classes("text-h6 text-white")
             ui.label(
-                "Port protocols and GNSS reflect the receiver and aren't "
-                "editable here yet. The RTCM matrix and data-link port(s) "
-                "below are — edit, then Apply."
+                "Port protocols, GNSS and the fields below reflect the live "
+                "receiver, or a picked profile once one's selected — this "
+                "display isn't click-to-edit yet. The RTCM matrix and "
+                "data-link port(s) further down are — edit, then Apply."
             ).classes("text-grey-4 q-mt-xs text-caption")
             ui.separator()
 
@@ -368,6 +644,9 @@ def gps_config_page() -> None:
 
             ui.label("GNSS Constellations").classes("text-subtitle2 text-white q-mt-md")
             gnss_view = ui.row().classes("q-mt-xs gap-2 flex-wrap")
+
+            ui.label("Hardware Section").classes("text-subtitle2 text-white q-mt-md")
+            hw_extras_view = ui.row().classes("hw-extras-view q-mt-xs gap-4 flex-wrap")
 
             ui.label("RTCM Stream").classes("text-subtitle2 text-white q-mt-md")
             ui.label(
@@ -399,6 +678,15 @@ def gps_config_page() -> None:
             with ui.row().classes("items-center gap-3 q-mt-md"):
                 apply_btn = ui.button("Apply", icon="bolt").props("color=primary")
                 sync_badge = ui.badge("").classes("sync-badge").props("color=positive")
+                save_as_btn = (
+                    ui.button("Save as…", icon="save")
+                    .classes("save-as-btn")
+                    .props("color=secondary outline")
+                )
+                modified_badge = (
+                    ui.badge("").classes("modified-badge").props("color=warning")
+                )
+                modified_badge.set_visibility(False)
 
             apply_result_label = (
                 ui.label("")
@@ -407,6 +695,61 @@ def gps_config_page() -> None:
             )
             apply_result_label.set_visibility(False)
             apply_diff_list = ui.column().classes("apply-diff-list q-mt-xs gap-0")
+
+        # ---- Save-as dialog ----
+        with ui.dialog() as save_as_dialog, ui.card().classes("q-pa-md"):
+            ui.label("Save as new profile").classes("text-h6 text-white")
+            ui.separator()
+            save_as_name_input = ui.input("Name").classes("save-as-name w-full q-mt-sm")
+            save_as_from_label = ui.label("").classes(
+                "save-as-from text-caption text-grey-4 q-mt-xs"
+            )
+            save_as_error_label = ui.label("").classes(
+                "save-as-error text-negative text-caption q-mt-xs"
+            )
+            save_as_error_label.set_visibility(False)
+            with ui.row().classes("justify-end gap-2 q-mt-md"):
+                ui.button("Cancel", on_click=save_as_dialog.close).props("flat")
+                save_as_confirm_btn = (
+                    ui.button("Create")
+                    .classes("save-as-confirm-btn")
+                    .props("color=primary")
+                )
+
+        # ---- Rename dialog (customs only) ----
+        with ui.dialog() as rename_dialog, ui.card().classes("q-pa-md"):
+            ui.label("Rename profile").classes("text-h6 text-white")
+            ui.separator()
+            rename_name_input = ui.input("New name").classes(
+                "rename-name w-full q-mt-sm"
+            )
+            rename_error_label = ui.label("").classes(
+                "rename-error text-negative text-caption q-mt-xs"
+            )
+            rename_error_label.set_visibility(False)
+            with ui.row().classes("justify-end gap-2 q-mt-md"):
+                ui.button("Cancel", on_click=rename_dialog.close).props("flat")
+                rename_confirm_btn = (
+                    ui.button("Rename")
+                    .classes("rename-confirm-btn")
+                    .props("color=primary")
+                )
+
+        # ---- Delete confirm dialog (customs only) ----
+        with ui.dialog() as delete_dialog, ui.card().classes("q-pa-md"):
+            ui.label("Delete profile?").classes("text-h6 text-white")
+            ui.separator()
+            delete_confirm_label = ui.label("").classes("q-mt-sm")
+            ui.label("This cannot be undone. The live receiver is untouched.").classes(
+                "text-caption text-grey-4 q-mt-xs"
+            )
+            with ui.row().classes("justify-end gap-2 q-mt-md"):
+                ui.button("Cancel", on_click=delete_dialog.close).props("flat")
+                delete_confirm_btn = (
+                    ui.button("Delete")
+                    .classes("delete-confirm-btn")
+                    .props("color=negative")
+                )
 
         # ================================================================
         # Section D: Save to Flash (hidden until connected + capable)
@@ -486,11 +829,7 @@ def gps_config_page() -> None:
 
         def _render_picker() -> None:
             """Render the profile picker from the current device identity."""
-            info = svc.device_info
-            identity = resolve_identity(
-                info.hardware_target if info else None,
-                info.hardware_confidence if info else None,
-            )
+            identity = _current_identity()
             identity_label.text = (
                 f"Connected receiver hardware: {identity.target} "
                 f"({identity.confidence.value})"
@@ -506,26 +845,216 @@ def gps_config_page() -> None:
             picker_list.clear()
             with picker_list:
                 for entry in entries:
-                    row_classes = f"profile-row profile-row-{entry.profile.name} items-center gap-2 q-py-xs"
+                    is_selected = (
+                        selected_profile is not None
+                        and selected_profile.name == entry.profile.name
+                    )
+                    is_incompatible = (
+                        not entry.compatible and entry.incompatible_reason is not None
+                    )
+                    row_classes = f"profile-row profile-row-{entry.profile.name} items-center gap-2 q-py-xs justify-between"
+                    if is_selected:
+                        row_classes += " profile-row-selected"
                     with ui.row().classes(row_classes) as row:
                         name_classes = (
                             "text-white" if entry.compatible else "text-grey-6"
                         )
-                        ui.label(entry.profile.name).classes(
-                            f"profile-name {name_classes}"
+                        # The clickable "select" target is its own inner
+                        # row so the rename/delete/export icons — siblings
+                        # inside the outer row, not descendants of this one
+                        # — never bubble a click into profile selection.
+                        select_classes = "items-center gap-2" + (
+                            " cursor-pointer" if entry.compatible else ""
                         )
-                        ui.badge("built-in" if entry.is_builtin else "custom").props(
-                            "outline color=grey"
-                        )
-                        if entry.is_default:
-                            ui.badge("Suggested").classes(
-                                "profile-suggested-badge"
-                            ).props("color=primary")
-                        if not entry.compatible and entry.incompatible_reason:
+                        with ui.row().classes(select_classes) as select_area:
+                            if entry.compatible:
+                                select_area.on(
+                                    "click",
+                                    lambda _, p=entry.profile: _select_profile(p),
+                                )
+                            if is_selected:
+                                ui.icon("check_circle").classes(
+                                    "profile-selected-icon text-primary"
+                                )
+                            ui.label(entry.profile.name).classes(
+                                f"profile-name {name_classes}"
+                            )
+                            ui.badge(
+                                "built-in" if entry.is_builtin else "custom"
+                            ).props("outline color=grey")
+                            if entry.is_default:
+                                ui.badge("Suggested").classes(
+                                    "profile-suggested-badge"
+                                ).props("color=primary")
+                            if entry.incompatible_reason:
+                                ui.icon("info").classes(
+                                    "profile-incompatible-icon text-grey-5"
+                                ).tooltip(entry.incompatible_reason)
+
+                        if is_incompatible:
                             row.classes("opacity-60")
-                            ui.icon("info").classes(
-                                "profile-incompatible-icon text-grey-5"
-                            ).tooltip(entry.incompatible_reason)
+
+                        if not entry.is_builtin:
+                            with ui.row().classes("gap-2 items-center"):
+                                ui.icon("edit").classes(
+                                    "profile-rename-icon text-grey-4 cursor-pointer"
+                                ).on(
+                                    "click",
+                                    lambda _, n=entry.profile.name: _open_rename_dialog(
+                                        n
+                                    ),
+                                ).tooltip("Rename")
+                                ui.icon("delete").classes(
+                                    "profile-delete-icon text-grey-4 cursor-pointer"
+                                ).on(
+                                    "click",
+                                    lambda _, n=entry.profile.name: _open_delete_dialog(
+                                        n
+                                    ),
+                                ).tooltip("Delete")
+                                ui.icon("download").classes(
+                                    "profile-export-icon text-grey-4 cursor-pointer"
+                                ).on(
+                                    "click",
+                                    lambda _, n=entry.profile.name: _export_profile(n),
+                                ).tooltip("Export")
+
+        def _select_profile(profile: Profile) -> None:
+            """Pick a profile — pre-fills the whole form (issue #66).
+
+            This is expected to put the form out of sync with the
+            receiver (per spec that's correct and legible, precisely
+            what Apply is for) — ``_on_form_changed`` recomputes that
+            indicator same as any other edit. The form remains the
+            source of truth afterwards: further matrix/data-link edits
+            mutate it same as before, independent of the profile pick.
+            """
+            nonlocal selected_profile, form_matrix, form_data_link_ports, form_extras
+            selected_profile = profile
+            form_matrix = profile_matrix_to_form_matrix(profile)
+            form_data_link_ports = list(profile.data_link_port)
+            form_extras = profile_to_form_extras(profile)
+
+            _render_matrix()
+            _render_ports_view()
+            _render_gnss_view()
+            _render_hw_extras_view()
+            _render_picker()
+            _on_form_changed()
+
+        def _current_identity() -> HardwareIdentity:
+            info = svc.device_info
+            return resolve_identity(
+                info.hardware_target if info else None,
+                info.hardware_confidence if info else None,
+            )
+
+        def _open_save_as_dialog() -> None:
+            identity = _current_identity()
+            save_as_name_input.value = suggest_profile_name(
+                selected_profile, identity.target
+            )
+            save_as_from_label.text = (
+                f"Forked from: {selected_profile.name}" if selected_profile else ""
+            )
+            save_as_from_label.set_visibility(selected_profile is not None)
+            save_as_error_label.set_visibility(False)
+            save_as_dialog.open()
+
+        def _confirm_save_as() -> None:
+            nonlocal selected_profile
+            name = (save_as_name_input.value or "").strip()
+            if not name:
+                save_as_error_label.text = "Name is required"
+                save_as_error_label.set_visibility(True)
+                return
+
+            form_config = _current_form_config()
+            if form_config is None:
+                save_as_error_label.text = (
+                    "The form doesn't currently validate — fix the RTCM "
+                    "matrix / data-link ports before saving."
+                )
+                save_as_error_label.set_visibility(True)
+                return
+
+            hardware = resolve_save_hardware(selected_profile, _current_identity())
+            forked_from = selected_profile.name if selected_profile else None
+
+            try:
+                profile = build_saved_profile(name, form_config, hardware, forked_from)
+                created = profile_store.create_profile(profile)
+            except (ValidationError, ProfileStoreError) as exc:
+                save_as_error_label.text = str(exc)
+                save_as_error_label.set_visibility(True)
+                return
+
+            selected_profile = created
+            save_as_dialog.close()
+            ui.notify(f"Saved profile '{created.name}'", type="positive")
+            _render_picker()
+            _on_form_changed()
+
+        def _open_rename_dialog(name: str) -> None:
+            nonlocal rename_target
+            rename_target = name
+            rename_name_input.value = name
+            rename_error_label.set_visibility(False)
+            rename_dialog.open()
+
+        def _confirm_rename() -> None:
+            nonlocal selected_profile
+            if rename_target is None:
+                return
+            new_name = (rename_name_input.value or "").strip()
+            try:
+                renamed = profile_store.rename_profile(rename_target, new_name)
+            except ProfileStoreError as exc:
+                rename_error_label.text = str(exc)
+                rename_error_label.set_visibility(True)
+                return
+
+            if selected_profile is not None and selected_profile.name == rename_target:
+                selected_profile = renamed
+            rename_dialog.close()
+            ui.notify(f"Renamed to '{renamed.name}'", type="positive")
+            _render_picker()
+            _on_form_changed()
+
+        def _open_delete_dialog(name: str) -> None:
+            nonlocal delete_target
+            delete_target = name
+            delete_confirm_label.text = f"Delete custom profile '{name}'?"
+            delete_dialog.open()
+
+        def _confirm_delete() -> None:
+            nonlocal selected_profile
+            if delete_target is None:
+                return
+            try:
+                profile_store.delete_profile(delete_target)
+            except ProfileStoreError as exc:
+                ui.notify(str(exc), type="negative")
+                delete_dialog.close()
+                return
+
+            if selected_profile is not None and selected_profile.name == delete_target:
+                selected_profile = None
+            delete_dialog.close()
+            ui.notify(f"Deleted '{delete_target}'", type="positive")
+            _render_picker()
+            _on_form_changed()
+
+        def _export_profile(name: str) -> None:
+            try:
+                profile = profile_store.export_profile(name)
+            except ProfileStoreError as exc:
+                ui.notify(str(exc), type="negative")
+                return
+            data = json.dumps(
+                profile.model_dump(mode="json", exclude_none=True), indent=2
+            )
+            ui.download(data.encode("utf-8"), filename=f"{name}.json")
 
         def _update_ui_state() -> None:
             """Update UI visibility and button states based on device state."""
@@ -602,35 +1131,67 @@ def gps_config_page() -> None:
         live_matrix: dict[RtcmRowId, dict[PortId, bool]] = copy_matrix(form_matrix)
         form_data_link_ports: list[PortId] = []
 
+        # Issue #66 additions — the rest of the "hardware section" (ports,
+        # GNSS, baud, role fields, optimisations), the profile a pick
+        # selected (None = no pick, the default/transient state), and the
+        # live ports/GNSS read-backs the "Port Protocols"/"GNSS
+        # Constellations" display falls back to when no profile is picked.
+        form_extras = FormExtras()
+        selected_profile: Profile | None = None
+        live_ports = PortProtocolConfig()
+        live_gnss = GnssConfig()
+        rename_target: str | None = None
+        delete_target: str | None = None
+
         def _out_of_sync() -> bool:
             return form_matrix != live_matrix
 
-        def _render_ports_table(ports: PortProtocolConfig) -> None:
+        def _current_form_config() -> ReceiverConfig | None:
+            """The form as a ``ReceiverConfig``, or ``None`` if it doesn't
+            currently validate (e.g. no data-link port selected)."""
+            try:
+                return build_apply_config(
+                    form_matrix, form_data_link_ports, form_extras
+                )
+            except ValidationError:
+                return None
+
+        def _render_ports_view() -> None:
             ports_view.clear()
             with ports_view:
+                display = resolve_ports_display(live_ports, form_extras.ports)
                 for port_id in (PortId.UART1, PortId.UART2, PortId.USB):
+                    in_names, out_names = display[port_id]
                     with ui.row().classes("items-center gap-2"):
                         ui.label(port_id.value).classes("text-white").style(
                             "width: 60px; flex-shrink: 0"
                         )
                         ui.label("IN").classes("text-caption text-grey-5")
-                        for proto in ports.enabled_in(port_id):
-                            ui.badge(proto.value).props("outline color=grey")
+                        for name in in_names:
+                            ui.badge(name).props("outline color=grey")
                         ui.label("OUT").classes("text-caption text-grey-5 q-ml-md")
-                        for proto in ports.enabled_out(port_id):
-                            ui.badge(proto.value).props("outline color=primary")
+                        for name in out_names:
+                            ui.badge(name).props("outline color=primary")
 
-        def _render_gnss(gnss: GnssConfig) -> None:
-            enabled_map: dict[str, bool] = {
-                sys_cfg.constellation.value: sys_cfg.enabled for sys_cfg in gnss.systems
-            }
+        def _render_gnss_view() -> None:
             gnss_view.clear()
             with gnss_view:
+                enabled_map = resolve_gnss_display(
+                    live_gnss, form_extras.constellations
+                )
                 for c_val, c_name in _GNSS_DISPLAY:
                     enabled = enabled_map.get(c_val, False)
                     ui.badge(c_name).props(
                         "color=positive" if enabled else "outline color=grey"
                     )
+
+        def _render_hw_extras_view() -> None:
+            hw_extras_view.clear()
+            with hw_extras_view:
+                for css_class, label, value in hw_extras_display(form_extras):
+                    with ui.column().classes(f"{css_class} gap-0"):
+                        ui.label(label).classes("text-caption text-grey-5")
+                        ui.label(value).classes("text-white")
 
         def _toggle_matrix_cell(msg_id: RtcmRowId, port: PortId) -> None:
             form_matrix[msg_id][port] = not form_matrix[msg_id][port]
@@ -741,6 +1302,28 @@ def gps_config_page() -> None:
             data_link_blocked_label.text = reason or ""
             data_link_blocked_label.set_visibility(reason is not None)
 
+        def _render_modified_indicator() -> None:
+            """The second, independent indicator — form vs. *selected
+            profile*, distinct from "out of sync" (form vs. live receiver).
+            Hidden when no profile is selected: nothing to have diverged
+            from."""
+            form_config = _current_form_config()
+            if selected_profile is None or form_config is None:
+                modified_badge.set_visibility(False)
+                return
+            modified_badge.set_visibility(True)
+            if is_modified_from_profile(form_config, selected_profile):
+                modified_badge.text = f"Modified from {selected_profile.name}"
+                modified_badge.props("color=warning")
+            else:
+                modified_badge.text = f"Matches {selected_profile.name}"
+                modified_badge.props("color=positive")
+
+        def _render_save_as_gate() -> None:
+            save_as_btn.set_enabled(
+                save_as_enabled(_current_form_config(), selected_profile)
+            )
+
         def _on_form_changed() -> None:
             """Recompute every reactive bit of the form after an edit.
 
@@ -751,6 +1334,8 @@ def gps_config_page() -> None:
             _render_data_link_picker()
             _render_sync_indicator()
             _render_apply_gate()
+            _render_modified_indicator()
+            _render_save_as_gate()
 
         def _set_apply_result(text: str, *, ok: bool) -> None:
             apply_diff_list.clear()
@@ -774,7 +1359,18 @@ def gps_config_page() -> None:
                     )
 
         async def _apply() -> None:
-            """Push the current form (matrix + data-link ports) to the receiver."""
+            """Push the current form (matrix + data-link ports) to the receiver.
+
+            Deliberately excludes ``form_extras`` (issue #66 review):
+            those fields have no live read-back, so a profile-populated
+            value pushed through Apply could never be verified by the
+            read-back-diff below, unlike the matrix. Extending Apply to
+            the full hardware section is out of #66's scope — it isn't
+            in the acceptance criteria, and #65 deliberately scoped
+            Apply to "only the RTCM matrix and the data-link ports".
+            ``form_extras`` is still used for Save-as/"modified from X",
+            which compare in-form state and never touch the receiver.
+            """
             nonlocal live_matrix
             try:
                 config = build_apply_config(form_matrix, form_data_link_ports)
@@ -842,9 +1438,15 @@ def gps_config_page() -> None:
             The RTCM matrix and data-link ports are freshly inferred here
             every time — on connect, reload, and reconnect — so the form
             starts in sync by construction (issue #65), matching the rest
-            of this page's existing live-seeding behaviour.
+            of this page's existing live-seeding behaviour. This is also
+            the reset point for the transient profile-pick buffer (issue
+            #66): unsaved form state, including which profile (if any) is
+            selected, is discarded on nav / reload / reconnect / restart,
+            per spec — the form always re-seeds from the live receiver,
+            never from the last-loaded profile.
             """
             nonlocal form_matrix, live_matrix, form_data_link_ports
+            nonlocal form_extras, selected_profile, live_ports, live_gnss
             rtcm = await svc.get_rtcm_port_config()
             ports = await svc.get_port_protocols()
             gnss = await svc.get_gnss_config()
@@ -852,13 +1454,19 @@ def gps_config_page() -> None:
             form_matrix = rtcm_config_to_matrix(rtcm)
             live_matrix = copy_matrix(form_matrix)
             form_data_link_ports = infer_data_link_ports(form_matrix)
+            form_extras = FormExtras()
+            selected_profile = None
+            live_ports = ports
+            live_gnss = gnss
 
-            _render_ports_table(ports)
-            _render_gnss(gnss)
+            _render_ports_view()
+            _render_gnss_view()
+            _render_hw_extras_view()
             _render_matrix()
             _render_advisory(rtcm)
             _clear_apply_result()
             _on_form_changed()
+            _render_picker()
 
         async def _connect() -> None:
             """Connect to the selected device."""
@@ -957,6 +1565,10 @@ def gps_config_page() -> None:
         refresh_btn.on_click(lambda: _refresh_ports())
         reload_device_btn.on_click(_reload_device_config)
         apply_btn.on_click(_apply)
+        save_as_btn.on_click(_open_save_as_dialog)
+        save_as_confirm_btn.on_click(_confirm_save_as)
+        rename_confirm_btn.on_click(_confirm_rename)
+        delete_confirm_btn.on_click(_confirm_delete)
         save_flash_btn.on_click(_save_flash)
         handoff_btn.on_click(_handoff_to_relay)
 

--- a/tests/e2e/test_gps_profile_save_as.py
+++ b/tests/e2e/test_gps_profile_save_as.py
@@ -1,0 +1,357 @@
+"""E2E tests for profile pre-fill, Save-as, and the modified-from-profile
+indicator (issue #66).
+
+Extends the GPS page suite (``test_gps_profile_picker.py`` covers the
+read-only #64 shell, ``test_gps_apply.py`` covers #65's out-of-sync
+indicator + Apply). This ticket makes picking a profile actually write
+into the form and adds the *second*, independent indicator:
+
+- Selecting a compatible profile pre-fills the matrix, the data-link
+  picker, and the "Hardware Section" display; the "modified from X"
+  badge reads "Matches <name>" immediately after the pick (before any
+  further edit) — the sparse-vs-dense matrix representation bug this
+  guards against is covered at the unit level
+  (``TestIsModifiedFromProfile``/``TestSaveAsEnabled`` in
+  ``test_gps_config_helpers.py``).
+- Editing the form after a pick flips the badge to "Modified from X"
+  and re-enables Save-as.
+- Save-as is available with no profile selected (the bare-capture
+  usage path) and suppressed only while a selected profile still
+  exactly equals the form.
+- Saving forks an independent custom profile carrying a
+  ``forked_from`` provenance label; a name collision surfaces inline
+  rather than silently overwriting.
+- Rename/delete/export are customs-only.
+
+Locators target the stable CSS class hooks the page renders (see
+``ui/pages/gps_config.py``), matching the existing suite's convention.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+BUILTIN_NAME = "ublox-f9p-base-standard"
+
+
+def _delete_profile(api_base_url: str, name: str) -> None:
+    try:
+        httpx.delete(f"{api_base_url}/api/profiles/{name}", timeout=5.0)
+    except Exception:
+        pass
+
+
+@pytest.fixture()
+def cleanup_profiles(api_base_url: str) -> Iterator[list[str]]:
+    """Collects custom-profile names a test creates via the UI, deleting
+    them on teardown regardless of pass/fail — the API-side counterpart to
+    ``custom_incompatible_profile`` in ``test_gps_profile_picker.py``."""
+    created: list[str] = []
+    try:
+        yield created
+    finally:
+        for name in created:
+            _delete_profile(api_base_url, name)
+
+
+def _goto_gps_config(page: Page, base_url: str) -> None:
+    """Navigate to the page and wait for the initial live-seed to settle.
+
+    ``connected_gps`` connects the fake driver *before* this page ever
+    mounts, so the form's first load doesn't happen synchronously —
+    it's the page's own one-shot, 100ms-deferred "already connected"
+    timer (see ``_on_page_load``/``ui.timer`` in ``gps_config.py``)
+    that calls ``_load_receiver_config_form()``. Interacting with the
+    picker before that fires would have this reseed clobber the pick
+    a moment later, so wait for a live-seeded cell first — the fake
+    driver's default 1005/UART1 is always on.
+    """
+    page.goto(f"{base_url}/gps-config")
+    expect(page.locator("text=Advanced GPS Configuration").first).to_be_visible(
+        timeout=15_000
+    )
+    expect(page.locator(".rtcm-cell-1005-UART1")).to_have_text("✓", timeout=10_000)
+
+
+def _select_builtin(page: Page) -> None:
+    """Click the built-in row and wait for the pick to fully settle.
+
+    ``_select_profile`` re-renders several sections over the NiceGUI
+    websocket round-trip; without waiting for the last of them
+    ("modified from X" only appears once ``_on_form_changed`` has run),
+    a next action can land before the pick has actually taken effect
+    client-side.
+    """
+    builtin_row = page.locator(f".profile-row-{BUILTIN_NAME}")
+    expect(builtin_row).to_be_visible(timeout=10_000)
+    builtin_row.locator(".profile-name").click()
+    expect(page.locator(".modified-badge")).to_contain_text(
+        f"Matches {BUILTIN_NAME}", timeout=10_000
+    )
+
+
+@pytest.mark.e2e
+def test_selecting_profile_prefills_matrix_and_matches_immediately(
+    page: Page,
+    base_url: str,
+    connected_gps: None,
+) -> None:
+    """The built-in's matrix (1074 on both UARTs) and data-link ports
+    (UART1+UART2) land in the form, and "modified from X" reads "Matches"
+    before any further edit — proving the comparison survives the
+    profile's sparse-matrix vs. the form's dense-matrix representation."""
+    _goto_gps_config(page, base_url)
+    _select_builtin(page)
+
+    expect(page.locator(".rtcm-cell-1074-UART1")).to_have_text("✓", timeout=10_000)
+    expect(page.locator(".rtcm-cell-1074-UART2")).to_have_text("✓")
+    expect(page.locator(".rtcm-cell-1074-USB")).to_have_text("-")
+
+    # Quasar's checkbox drives state via `aria-checked` on the component
+    # root, not the hidden native `<input>`'s `checked` property.
+    expect(page.locator(".data-link-checkbox-UART1")).to_have_attribute(
+        "aria-checked", "true"
+    )
+    expect(page.locator(".data-link-checkbox-UART2")).to_have_attribute(
+        "aria-checked", "true"
+    )
+
+    modified_badge = page.locator(".modified-badge")
+    expect(modified_badge).to_be_visible()
+    expect(modified_badge).to_contain_text(f"Matches {BUILTIN_NAME}")
+
+    expect(page.locator(".save-as-btn")).to_be_disabled()
+
+
+@pytest.mark.e2e
+def test_editing_after_pick_flips_to_modified_and_reenables_save_as(
+    page: Page,
+    base_url: str,
+    connected_gps: None,
+) -> None:
+    """The T4 fix this ticket exists for: an edit after a successful pick
+    must not take Save-as away — quite the opposite, it's what re-enables
+    it."""
+    _goto_gps_config(page, base_url)
+    _select_builtin(page)
+    expect(page.locator(".save-as-btn")).to_be_disabled()
+
+    page.locator(".rtcm-cell-1077-UART1").click()
+
+    modified_badge = page.locator(".modified-badge")
+    expect(modified_badge).to_contain_text(f"Modified from {BUILTIN_NAME}")
+    expect(page.locator(".save-as-btn")).to_be_enabled()
+
+
+@pytest.mark.e2e
+def test_save_as_stays_enabled_after_a_real_successful_apply(
+    page: Page,
+    base_url: str,
+    connected_gps: None,
+) -> None:
+    """AC: "Save-as remains enabled after a successful apply when the form
+    still differs from its source profile." Exercises this through the
+    actual Apply button/endpoint, not just the pure-helper unit test — the
+    approved prototype's bug (gating Save-as off the *receiver* comparison)
+    would clear "modified from X" the moment Apply clears "out of sync",
+    since both would be the same indicator."""
+    _goto_gps_config(page, base_url)
+    _select_builtin(page)
+    page.locator(".rtcm-cell-1077-UART1").click()
+
+    modified_badge = page.locator(".modified-badge")
+    expect(modified_badge).to_contain_text(f"Modified from {BUILTIN_NAME}")
+
+    page.get_by_role("button", name="Apply").click()
+    expect(page.locator(".apply-result")).to_contain_text(
+        "Applied and verified", timeout=10_000
+    )
+
+    # Apply cleared "out of sync" (implicit — that's #65) but must leave
+    # "modified from X" and Save-as exactly as they were.
+    expect(modified_badge).to_contain_text(f"Modified from {BUILTIN_NAME}")
+    expect(page.locator(".save-as-btn")).to_be_enabled()
+
+
+@pytest.mark.e2e
+def test_save_as_enabled_with_no_profile_selected(
+    page: Page,
+    base_url: str,
+    connected_gps: None,
+) -> None:
+    """Usage path 3: connect, pick nothing, Save-as is still available."""
+    _goto_gps_config(page, base_url)
+    expect(page.locator(".modified-badge")).to_be_hidden()
+    expect(page.locator(".save-as-btn")).to_be_enabled()
+
+
+@pytest.mark.e2e
+def test_save_as_forks_a_custom_profile_with_provenance(
+    page: Page,
+    base_url: str,
+    api_base_url: str,
+    connected_gps: None,
+    cleanup_profiles: list[str],
+) -> None:
+    """Saving while a profile is selected forks an independent custom
+    profile carrying a "forked from" label — auto-suggested name
+    sanitized to the store's filesystem-safe slug charset."""
+    _goto_gps_config(page, base_url)
+    _select_builtin(page)
+    page.locator(".rtcm-cell-1077-UART1").click()  # diverge, so Save-as is live
+
+    page.locator(".save-as-btn").click()
+    name_input = page.locator(".save-as-name input")
+    expect(name_input).to_have_value(f"{BUILTIN_NAME}-copy")
+    expect(page.locator(".save-as-from")).to_contain_text(
+        f"Forked from: {BUILTIN_NAME}"
+    )
+
+    forked_name = f"{BUILTIN_NAME}-copy"
+    cleanup_profiles.append(forked_name)
+    page.locator(".save-as-confirm-btn").click()
+
+    expect(page.locator(".save-as-name")).to_be_hidden()  # dialog closed
+
+    resp = httpx.get(f"{api_base_url}/api/profiles/{forked_name}", timeout=5.0)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["profile"]["forked_from"] == BUILTIN_NAME
+    assert body["profile"]["hardware"] == "ZED-F9P"
+    assert body["is_builtin"] is False
+    # The edited cell made it into the saved document.
+    assert body["profile"]["rtcm_stream"]["matrix"]["1077"]["UART1"] is True
+
+    expect(page.locator(f".profile-row-{forked_name}")).to_be_visible(timeout=10_000)
+
+
+@pytest.mark.e2e
+def test_save_as_bare_capture_has_no_forked_from(
+    page: Page,
+    base_url: str,
+    api_base_url: str,
+    connected_gps: None,
+    cleanup_profiles: list[str],
+) -> None:
+    """No profile selected -> the saved document is a bare capture, named
+    from the connected receiver's identity, with no provenance label."""
+    _goto_gps_config(page, base_url)
+
+    page.locator(".save-as-btn").click()
+    expect(page.locator(".save-as-name input")).to_have_value("zed-f9p-captured")
+    expect(page.locator(".save-as-from")).to_be_hidden()
+
+    cleanup_profiles.append("zed-f9p-captured")
+    page.locator(".save-as-confirm-btn").click()
+    expect(page.locator(".save-as-name")).to_be_hidden()
+
+    resp = httpx.get(f"{api_base_url}/api/profiles/zed-f9p-captured", timeout=5.0)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["profile"]["forked_from"] is None
+
+
+@pytest.mark.e2e
+def test_save_as_name_collision_is_rejected_with_a_clear_error(
+    page: Page,
+    base_url: str,
+    api_base_url: str,
+    connected_gps: None,
+    cleanup_profiles: list[str],
+) -> None:
+    existing = {
+        "name": "e2e-collision",
+        "version": 1,
+        "hardware": "any",
+        "data_link_port": ["UART1"],
+        "rtcm_stream": {"matrix": {"1005": {"UART1": True}}},
+    }
+    resp = httpx.post(f"{api_base_url}/api/profiles", json=existing, timeout=5.0)
+    assert resp.status_code in (201, 409), resp.text
+    cleanup_profiles.append("e2e-collision")
+
+    _goto_gps_config(page, base_url)
+    page.locator(".save-as-btn").click()
+    page.locator(".save-as-name input").fill("e2e-collision")
+    page.locator(".save-as-confirm-btn").click()
+
+    expect(page.locator(".save-as-error")).to_be_visible(timeout=5_000)
+    expect(page.locator(".save-as-error")).to_contain_text("e2e-collision")
+    # Rejected, not overwritten — the dialog stays open.
+    expect(page.locator(".save-as-name")).to_be_visible()
+
+
+@pytest.mark.e2e
+def test_rename_delete_export_are_customs_only(
+    page: Page,
+    base_url: str,
+    api_base_url: str,
+    connected_gps: None,
+    cleanup_profiles: list[str],
+) -> None:
+    custom = {
+        "name": "e2e-custom-actions",
+        "version": 1,
+        "hardware": "any",
+        "data_link_port": ["UART1"],
+        "rtcm_stream": {"matrix": {"1005": {"UART1": True}}},
+    }
+    resp = httpx.post(f"{api_base_url}/api/profiles", json=custom, timeout=5.0)
+    assert resp.status_code in (201, 409), resp.text
+    cleanup_profiles.append("e2e-custom-actions")
+
+    _goto_gps_config(page, base_url)
+
+    builtin_row = page.locator(f".profile-row-{BUILTIN_NAME}")
+    expect(builtin_row).to_be_visible(timeout=10_000)
+    expect(builtin_row.locator(".profile-rename-icon")).to_have_count(0)
+    expect(builtin_row.locator(".profile-delete-icon")).to_have_count(0)
+    expect(builtin_row.locator(".profile-export-icon")).to_have_count(0)
+
+    custom_row = page.locator(".profile-row-e2e-custom-actions")
+    expect(custom_row).to_be_visible()
+    expect(custom_row.locator(".profile-rename-icon")).to_have_count(1)
+    expect(custom_row.locator(".profile-delete-icon")).to_have_count(1)
+    expect(custom_row.locator(".profile-export-icon")).to_have_count(1)
+
+
+@pytest.mark.e2e
+def test_rename_then_delete_custom_profile(
+    page: Page,
+    base_url: str,
+    api_base_url: str,
+    connected_gps: None,
+    cleanup_profiles: list[str],
+) -> None:
+    custom = {
+        "name": "e2e-rename-me",
+        "version": 1,
+        "hardware": "any",
+        "data_link_port": ["UART1"],
+        "rtcm_stream": {"matrix": {"1005": {"UART1": True}}},
+    }
+    resp = httpx.post(f"{api_base_url}/api/profiles", json=custom, timeout=5.0)
+    assert resp.status_code in (201, 409), resp.text
+    cleanup_profiles.append("e2e-rename-me")
+    cleanup_profiles.append("e2e-renamed")
+
+    _goto_gps_config(page, base_url)
+
+    old_row = page.locator(".profile-row-e2e-rename-me")
+    expect(old_row).to_be_visible(timeout=10_000)
+    old_row.locator(".profile-rename-icon").click()
+
+    expect(page.locator(".rename-name input")).to_have_value("e2e-rename-me")
+    page.locator(".rename-name input").fill("e2e-renamed")
+    page.locator(".rename-confirm-btn").click()
+
+    new_row = page.locator(".profile-row-e2e-renamed")
+    expect(new_row).to_be_visible(timeout=10_000)
+    expect(page.locator(".profile-row-e2e-rename-me")).to_have_count(0)
+
+    new_row.locator(".profile-delete-icon").click()
+    page.locator(".delete-confirm-btn").click()
+    expect(page.locator(".profile-row-e2e-renamed")).to_have_count(0, timeout=10_000)

--- a/tests/unit/test_gps_config_helpers.py
+++ b/tests/unit/test_gps_config_helpers.py
@@ -15,10 +15,19 @@ import pytest
 
 from sp_rtk_base.models.device_models import (
     ApplyConfigCellDiff,
+    DynModel,
+    GnssConfig,
+    GnssConstellation,
+    GnssSystemConfig,
     PortId,
+    PortProtocolConfig,
     RtcmOutputPort,
     RtcmPortConfig,
     RtcmRowId,
+    UbxProtocol,
+)
+from sp_rtk_base.models.device_models import (
+    BaseMode as TmodeMode,
 )
 from sp_rtk_base.models.hardware_identity import (
     HARDWARE_ANY,
@@ -26,21 +35,33 @@ from sp_rtk_base.models.hardware_identity import (
     HardwareConfidence,
     identity_from_target,
 )
-from sp_rtk_base.models.profile_models import Profile
+from sp_rtk_base.models.profile_models import BaudConfig, PortProtocolSet, Profile
 from sp_rtk_base.services.profile_store import ProfileStore
 from sp_rtk_base.ui.pages.gps_config import (
     MATRIX_PORTS,
     REQUIRED_RTCM_ROW,
+    FormExtras,
     apply_blocked_reason,
     build_apply_config,
     build_picker_entries,
+    build_saved_profile,
     format_cell_diff,
+    hw_extras_display,
     i2c_spi_advisory_rows,
     infer_data_link_ports,
+    is_modified_from_profile,
     matrix_cell_on,
+    profile_matrix_to_form_matrix,
+    profile_to_form_extras,
+    receiver_config_from_profile,
+    resolve_gnss_display,
     resolve_identity,
+    resolve_ports_display,
+    resolve_save_hardware,
     row_slug,
     rtcm_config_to_matrix,
+    save_as_enabled,
+    suggest_profile_name,
 )
 
 
@@ -301,3 +322,317 @@ class TestFormatCellDiff:
         assert "UART1" in text
         assert "on" in text
         assert "off" in text
+
+
+def _full_profile(name: str = "full-profile") -> Profile:
+    """A profile with every ``ReceiverConfig`` field populated — used to
+    exercise pre-fill/comparison helpers that need more than the matrix."""
+    return Profile.model_validate(
+        {
+            "name": name,
+            "version": 1,
+            "hardware": "ZED-F9P",
+            "baud": {"uart1": 57600, "uart2": 115200},
+            "meas_period_ms": 500,
+            "constellations": ["gps", "glonass"],
+            "ports": {
+                "UART1": {"in": ["UBX", "NMEA", "RTCM3X"], "out": ["RTCM3X"]},
+                "UART2": {"in": ["UBX", "RTCM3X"], "out": ["RTCM3X"]},
+            },
+            "data_link_port": ["UART1", "UART2"],
+            "dyn_model": "stationary",
+            "elevation_mask_deg": 15,
+            "bds_b2_enabled": False,
+            "spi_enabled": True,
+            "rtcm_stream": {
+                "matrix": {
+                    "1005": {"UART1": True, "UART2": True},
+                    "1074": {"UART1": True, "UART2": True},
+                }
+            },
+        }
+    )
+
+
+class TestFormExtras:
+    """Defaults mirror ``ReceiverConfig``'s own "leave untouched" semantics."""
+
+    def test_defaults_are_all_none_except_meas_period(self) -> None:
+        extras = FormExtras()
+        assert extras.ports is None
+        assert extras.constellations is None
+        assert extras.baud is None
+        assert extras.meas_period_ms == 1000
+        assert extras.dyn_model is None
+        assert extras.tmode_mode is None
+        assert extras.elevation_mask_deg is None
+        assert extras.bds_b2_enabled is None
+        assert extras.spi_enabled is None
+
+
+class TestBuildApplyConfigWithExtras:
+    def test_extras_flow_into_the_config(self) -> None:
+        matrix = rtcm_config_to_matrix(
+            RtcmPortConfig(messages={RtcmRowId.RTCM_1005: {"UART1": 1}})
+        )
+        extras = FormExtras(
+            baud=BaudConfig(uart1=57600),
+            meas_period_ms=200,
+            constellations=[GnssConstellation.GPS],
+            dyn_model=DynModel.STATIONARY,
+            tmode_mode=TmodeMode.DISABLED,
+            elevation_mask_deg=15,
+            bds_b2_enabled=False,
+            spi_enabled=True,
+        )
+        config = build_apply_config(matrix, [PortId.UART1], extras)
+        assert config.baud is not None and config.baud.uart1 == 57600
+        assert config.meas_period_ms == 200
+        assert config.constellations == [GnssConstellation.GPS]
+        assert config.dyn_model == DynModel.STATIONARY
+        assert config.tmode_mode == TmodeMode.DISABLED
+        assert config.elevation_mask_deg == 15
+        assert config.bds_b2_enabled is False
+        assert config.spi_enabled is True
+
+
+class TestProfileMatrixToFormMatrix:
+    def test_covers_every_catalog_row_and_matrix_port(self) -> None:
+        matrix = profile_matrix_to_form_matrix(_full_profile())
+        assert set(matrix.keys()) == set(RtcmRowId)
+        for row in matrix.values():
+            assert set(row.keys()) == set(MATRIX_PORTS)
+
+    def test_reflects_the_profiles_sparse_matrix(self) -> None:
+        matrix = profile_matrix_to_form_matrix(_full_profile())
+        assert matrix[RtcmRowId.RTCM_1005][PortId.UART1] is True
+        assert matrix[RtcmRowId.RTCM_1005][PortId.USB] is False
+        assert matrix[RtcmRowId.RTCM_1077][PortId.UART1] is False
+
+
+class TestProfileToFormExtras:
+    def test_copies_every_field(self) -> None:
+        extras = profile_to_form_extras(_full_profile())
+        assert extras.ports is not None
+        assert extras.constellations == [
+            GnssConstellation.GPS,
+            GnssConstellation.GLONASS,
+        ]
+        assert extras.baud == BaudConfig(uart1=57600, uart2=115200)
+        assert extras.meas_period_ms == 500
+        assert extras.dyn_model == DynModel.STATIONARY
+        assert extras.tmode_mode is None
+        assert extras.elevation_mask_deg == 15
+        assert extras.bds_b2_enabled is False
+        assert extras.spi_enabled is True
+
+
+class TestReceiverConfigFromProfile:
+    def test_strips_identity_fields(self) -> None:
+        config = receiver_config_from_profile(_full_profile())
+        assert not hasattr(config, "name")
+        assert not hasattr(config, "hardware")
+        assert not hasattr(config, "forked_from")
+        assert config.meas_period_ms == 500
+
+    def test_equals_the_form_built_from_the_same_profile(self) -> None:
+        profile = _full_profile()
+        matrix = profile_matrix_to_form_matrix(profile)
+        extras = profile_to_form_extras(profile)
+        form_config = build_apply_config(matrix, profile.data_link_port, extras)
+        assert form_config == receiver_config_from_profile(profile)
+
+
+class TestIsModifiedFromProfile:
+    def test_false_when_no_profile_selected(self) -> None:
+        config = build_apply_config(
+            rtcm_config_to_matrix(
+                RtcmPortConfig(messages={RtcmRowId.RTCM_1005: {"UART1": 1}})
+            ),
+            [PortId.UART1],
+        )
+        assert not is_modified_from_profile(config, None)
+
+    def test_false_when_form_exactly_equals_the_profile(self) -> None:
+        profile = _full_profile()
+        matrix = profile_matrix_to_form_matrix(profile)
+        extras = profile_to_form_extras(profile)
+        form_config = build_apply_config(matrix, profile.data_link_port, extras)
+        assert not is_modified_from_profile(form_config, profile)
+
+    def test_true_once_the_form_diverges(self) -> None:
+        profile = _full_profile()
+        matrix = profile_matrix_to_form_matrix(profile)
+        matrix[RtcmRowId.RTCM_1074][PortId.UART1] = False
+        extras = profile_to_form_extras(profile)
+        form_config = build_apply_config(matrix, profile.data_link_port, extras)
+        assert is_modified_from_profile(form_config, profile)
+
+
+class TestSaveAsEnabled:
+    def test_disabled_when_form_is_invalid(self) -> None:
+        assert not save_as_enabled(None, None)
+
+    def test_enabled_with_no_profile_selected(self) -> None:
+        config = build_apply_config(
+            rtcm_config_to_matrix(
+                RtcmPortConfig(messages={RtcmRowId.RTCM_1005: {"UART1": 1}})
+            ),
+            [PortId.UART1],
+        )
+        assert save_as_enabled(config, None)
+
+    def test_suppressed_when_selected_profile_exactly_equals_the_form(self) -> None:
+        profile = _full_profile()
+        matrix = profile_matrix_to_form_matrix(profile)
+        extras = profile_to_form_extras(profile)
+        form_config = build_apply_config(matrix, profile.data_link_port, extras)
+        assert not save_as_enabled(form_config, profile)
+
+    def test_enabled_again_once_the_form_diverges_from_the_selected_profile(
+        self,
+    ) -> None:
+        """The #66 fix: applying edits must not take Save-as away again."""
+        profile = _full_profile()
+        matrix = profile_matrix_to_form_matrix(profile)
+        matrix[RtcmRowId.RTCM_1074][PortId.UART2] = False
+        extras = profile_to_form_extras(profile)
+        form_config = build_apply_config(matrix, profile.data_link_port, extras)
+        assert save_as_enabled(form_config, profile)
+
+
+class TestSuggestProfileName:
+    def test_forked_name_is_slug_safe(self) -> None:
+        name = suggest_profile_name(_full_profile("ublox-f9p-base-standard"), "ZED-F9P")
+        assert name == "ublox-f9p-base-standard-copy"
+        assert " " not in name and "(" not in name
+
+    def test_bare_capture_derives_from_hardware_target(self) -> None:
+        assert suggest_profile_name(None, "ZED-F9P") == "zed-f9p-captured"
+
+
+class TestResolveSaveHardware:
+    def test_fork_keeps_the_source_profiles_hardware(self) -> None:
+        profile = _full_profile()
+        identity = identity_from_target("ZED-F9R", HardwareConfidence.CONFIRMED)
+        assert resolve_save_hardware(profile, identity) == "ZED-F9P"
+
+    def test_bare_capture_with_confirmed_identity_uses_the_target(self) -> None:
+        identity = identity_from_target("ZED-F9P", HardwareConfidence.CONFIRMED)
+        assert resolve_save_hardware(None, identity) == "ZED-F9P"
+
+    def test_bare_capture_with_a_family_target_uses_the_family(self) -> None:
+        identity = identity_from_target("gen9", HardwareConfidence.INFERRED)
+        assert resolve_save_hardware(None, identity) == "gen9"
+
+    def test_unknown_identity_falls_back_to_any(self) -> None:
+        identity = identity_from_target(HARDWARE_UNKNOWN, HardwareConfidence.UNKNOWN)
+        assert resolve_save_hardware(None, identity) == HARDWARE_ANY
+
+    def test_inferred_specific_model_falls_back_to_any(self) -> None:
+        """An inferred guess of a *specific* model can't be trusted as a save
+        tag — only a family token is safe to fall back to."""
+        identity = identity_from_target("ZED-F9P", HardwareConfidence.INFERRED)
+        assert resolve_save_hardware(None, identity) == HARDWARE_ANY
+
+
+class TestBuildSavedProfile:
+    def test_builds_a_valid_profile_with_identity_fields(self) -> None:
+        config = build_apply_config(
+            rtcm_config_to_matrix(
+                RtcmPortConfig(messages={RtcmRowId.RTCM_1005: {"UART1": 1}})
+            ),
+            [PortId.UART1],
+        )
+        profile = build_saved_profile("my-base", config, "ZED-F9P", "source-profile")
+        assert profile.name == "my-base"
+        assert profile.version == 1
+        assert profile.hardware == "ZED-F9P"
+        assert profile.forked_from == "source-profile"
+        assert profile.data_link_port == [PortId.UART1]
+
+    def test_bare_capture_has_no_forked_from(self) -> None:
+        config = build_apply_config(
+            rtcm_config_to_matrix(
+                RtcmPortConfig(messages={RtcmRowId.RTCM_1005: {"UART1": 1}})
+            ),
+            [PortId.UART1],
+        )
+        profile = build_saved_profile("captured", config, "ZED-F9P", None)
+        assert profile.forked_from is None
+
+
+class TestResolvePortsDisplay:
+    def test_falls_back_to_live_when_no_form_ports(self) -> None:
+        live = PortProtocolConfig(
+            in_protocols={PortId.UART1: [UbxProtocol.UBX]},
+            out_protocols={PortId.UART1: [UbxProtocol.RTCM3X]},
+        )
+        display = resolve_ports_display(live, None)
+        assert display[PortId.UART1] == (["UBX"], ["RTCM3X"])
+        assert display[PortId.UART2] == ([], [])
+
+    def test_form_ports_take_priority_over_live(self) -> None:
+        live = PortProtocolConfig(
+            in_protocols={PortId.UART1: [UbxProtocol.UBX]},
+        )
+        form_ports = {
+            PortId.UART1: PortProtocolSet(
+                **{"in": [UbxProtocol.UBX, UbxProtocol.NMEA], "out": []}
+            ),
+        }
+        display = resolve_ports_display(live, form_ports)
+        assert display[PortId.UART1] == (["UBX", "NMEA"], [])
+        # A port omitted from the profile's ports is untouched -> empty.
+        assert display[PortId.UART2] == ([], [])
+
+
+class TestResolveGnssDisplay:
+    def test_falls_back_to_live_when_no_form_constellations(self) -> None:
+        live = GnssConfig(
+            systems=[
+                GnssSystemConfig(constellation=GnssConstellation.GPS, enabled=True),
+                GnssSystemConfig(constellation=GnssConstellation.SBAS, enabled=False),
+            ]
+        )
+        display = resolve_gnss_display(live, None)
+        assert display["gps"] is True
+        assert display["sbas"] is False
+
+    def test_form_constellations_take_priority_over_live(self) -> None:
+        live = GnssConfig(
+            systems=[
+                GnssSystemConfig(constellation=GnssConstellation.GPS, enabled=False),
+            ]
+        )
+        display = resolve_gnss_display(live, [GnssConstellation.GLONASS])
+        assert display["gps"] is False
+        assert display["glonass"] is True
+
+
+class TestHwExtrasDisplay:
+    def test_default_extras_show_unchanged(self) -> None:
+        rows = {label: value for _cls, label, value in hw_extras_display(FormExtras())}
+        assert rows["Baud"] == "unchanged"
+        assert rows["Dynamics Model"] == "unchanged"
+        assert rows["BeiDou B2"] == "unchanged"
+        assert rows["Measurement Rate"] == "1 Hz"
+
+    def test_populated_extras_render_their_values(self) -> None:
+        extras = FormExtras(
+            baud=BaudConfig(uart1=57600),
+            meas_period_ms=500,
+            dyn_model=DynModel.STATIONARY,
+            tmode_mode=TmodeMode.FIXED,
+            elevation_mask_deg=15,
+            bds_b2_enabled=False,
+            spi_enabled=True,
+        )
+        rows = {label: value for _cls, label, value in hw_extras_display(extras)}
+        assert rows["Baud"] == "UART1=57600"
+        assert rows["Measurement Rate"] == "2 Hz"
+        assert rows["Dynamics Model"] == "stationary"
+        assert rows["Time Mode"] == "fixed"
+        assert rows["Elevation Mask"] == "15°"
+        assert rows["BeiDou B2"] == "off"
+        assert rows["SPI"] == "on"


### PR DESCRIPTION
## Summary
- Picking a profile now writes its full `ReceiverConfig` (matrix, data-link ports, and the rest of the hardware section) into the form, instead of only rendering it — the form remains the source of truth afterwards.
- Adds a second, independent "modified from X" indicator (form vs. *selected profile*), alongside #65's "out of sync" one (form vs. *live receiver*) — gates Save-as and survives a successful Apply, fixing the regression the approved prototype had (conflating the two indicators would silently disable Save-as right after a successful apply).
- Save-as is available with no profile selected (bare-capture usage path) and suppressed only when a selected profile exactly equals the form. Auto-suggests a name (`<source>-copy` when forked, `<hardware>-captured` for a bare capture — sanitized to the profile store's filesystem-safe slug charset), forks an independent custom profile with a `forked_from` provenance label, and rejects name collisions with a clear error.
- Rename, delete (with confirm), and export are wired up for custom profiles only; built-ins stay immutable.
- Apply deliberately stays scoped to the matrix + data-link ports (per #65) — the rest of the hardware section has no live read-back to verify a write against, so extending Apply's write footprint was out of scope for this ticket (pulled back out during review).

Closes #66

## Test plan
- [x] `uv run pytest tests/unit` — 1357 passed, 93.2% coverage
- [x] `uv run pytest tests/e2e` — 61 passed (Chromium via Playwright), including a new `tests/e2e/test_gps_profile_save_as.py` covering pre-fill, the modified-from indicator surviving a real Apply, Save-as (fork + bare-capture + collision), and rename/delete/export customs-only
- [x] `uv run pyright src/` / `uv run mypy src/` / `uv run ruff check` / `uv run ruff format --check` — all clean
- [x] `/code-review` (Standards + Spec axes) run against `main`; one real finding (Apply scope creep) fixed before commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)