### PR TITLE
Advanced GPS page: CFG reader prefactor, profile display names, Fixed Position card

### DIFF
--- a/src/sp_rtk_base/api/profiles.py
+++ b/src/sp_rtk_base/api/profiles.py
@@ -171,12 +171,16 @@ async def rename_profile(
     request: ProfileRenameRequest,
     store: ProfileStore = Depends(get_profile_store),
 ) -> ProfileDetailResponse | JSONResponse:
-    """Rename an existing custom profile."""
+    """Rename an existing custom profile.
+
+    Renaming edits ``display_name`` only — the slug/filename never
+    changes, so fork references pointing at *name* stay valid.
+    """
     try:
-        renamed = store.rename_profile(name, request.new_name)
+        renamed = store.rename_profile(name, request.new_display_name)
     except ProfileStoreError as exc:
         return _error_response(exc)
-    logger.info("Renamed profile: %s -> %s", name, request.new_name)
+    logger.info("Renamed profile %s -> display_name=%r", name, request.new_display_name)
     return _detail(store, renamed)
 
 

--- a/src/sp_rtk_base/models/api_models.py
+++ b/src/sp_rtk_base/models/api_models.py
@@ -347,6 +347,10 @@ class ProfileDetailResponse(BaseModel):
 
 
 class ProfileRenameRequest(BaseModel):
-    """Body for ``PATCH /api/profiles/{name}`` — rename a custom profile."""
+    """Body for ``PATCH /api/profiles/{name}`` — rename a custom profile.
 
-    new_name: str = Field(min_length=1)
+    Renaming edits ``display_name`` only — the profile's slug (its
+    ``name``, also its filename) is immortal and never changes.
+    """
+
+    new_display_name: str = Field(min_length=1)

--- a/src/sp_rtk_base/models/profile_models.py
+++ b/src/sp_rtk_base/models/profile_models.py
@@ -5,8 +5,15 @@ Two nested types:
 - ``ReceiverConfig`` — everything writable to a receiver (no ``name``).
   This is what Apply takes.
 - ``Profile`` — ``ReceiverConfig`` plus identity metadata (``name``,
-  ``version``, ``hardware``, ``forked_from``). This is what gets
-  saved, listed, exported and imported.
+  ``version``, ``hardware``, ``forked_from``, ``display_name``). This
+  is what gets saved, listed, exported and imported.
+
+``name`` is the profile's immutable slug — also its filename and the
+key fork references (``forked_from``) point at. ``display_name`` is
+an optional human-readable label; when absent, every UI surface falls
+back to rendering ``name``. Renaming a profile only ever changes
+``display_name`` — the slug is frozen at creation so fork references
+never dangle and no files ever move.
 
 Only *context-free* validation lives here — rules that need no live
 device state. The UBX-in liveness guard and the ``tmode_mode: fixed``
@@ -179,6 +186,7 @@ class Profile(ReceiverConfig):
     version: int
     hardware: str
     forked_from: str | None = Field(default=None)
+    display_name: str | None = Field(default=None)
 
     @model_validator(mode="after")
     def _validate_identity(self) -> Profile:

--- a/src/sp_rtk_base/profiles/builtin/ublox-f9p-base-standard.yaml
+++ b/src/sp_rtk_base/profiles/builtin/ublox-f9p-base-standard.yaml
@@ -5,6 +5,7 @@
 # docs/zed-f9p-base-station-config-reference.md for the hardware
 # audit this file reproduces cell-for-cell.
 name: ublox-f9p-base-standard
+display_name: "u-blox F9P — Base Station (Standard)"
 version: 1
 hardware: ZED-F9P
 

--- a/src/sp_rtk_base/services/drivers/ublox.py
+++ b/src/sp_rtk_base/services/drivers/ublox.py
@@ -388,6 +388,13 @@ class UbloxDriver(GpsReceiverDriver):
     # BBR pinned at TMODE=1 across host restarts.
     _TMODE_DISABLE_ALL_LAYERS: int = 7
 
+    # CFG-VALGET poll-layer enum — NOT the CFG-VALSET bitmask above.
+    # u-blox defines this field as 0=RAM, 1=BBR, 2=Flash, 7=Default,
+    # a plain enum rather than an OR-able bitmask. Default for
+    # ``_read_cfg_keys_locked`` (issue #94): every existing caller
+    # wants RAM, matching this method's pre-#94 hardcoded behaviour.
+    _CFG_LAYER_RAM: int = 0
+
     # How long to wait after a UBX-CFG-RST resetMode=0 (hardware
     # reset) for the chip to re-enumerate on USB and be ready to
     # accept a fresh serial connection.  Empirically ~2-3 s.  5 s
@@ -720,17 +727,33 @@ class UbloxDriver(GpsReceiverDriver):
             ecef_z,
         )
 
-    def _read_cfg_keys_locked(self, keys: list[str]) -> dict[str, int]:
-        """Poll arbitrary CFG keys and return them as a dict (must hold ``self._lock``).
+    def _read_cfg_keys_locked(
+        self, keys: list[str], layer: int = _CFG_LAYER_RAM
+    ) -> dict[str, int]:
+        """Poll arbitrary CFG keys at ``layer`` (must hold ``self._lock``).
 
         Used to verify a CFG-VALSET write actually took effect — same
         read-back pattern as ``_read_ecef_locked``, generalised to an
-        arbitrary key list (issue #42).
+        arbitrary key list (issue #42). Defaults to the RAM layer,
+        matching this method's behaviour before it accepted a layer
+        parameter (issue #94).
+
+        A key the receiver doesn't recognise — or that was never
+        written at ``layer`` — is simply absent from the returned
+        dict, distinguishable from a key that read back with an
+        unexpected value. Callers that previously relied on a
+        sentinel ``-1`` for "unknown key" must not: this method now
+        reports that state as key-not-present instead (issue #94).
+
+        Raises:
+            RuntimeError: if the receiver NAKs the poll (naming the
+                NAK), or if neither a CFG-VALGET nor an ACK-NAK
+                response arrives within the read budget.
         """
         ser, reader = self._require_connection()
 
         poll_keys: list[str | int] = list(keys)
-        msg = UBXMessage.config_poll(0, 0, poll_keys)
+        msg = UBXMessage.config_poll(layer, 0, poll_keys)
         ser.reset_input_buffer()
         ser.write(msg.serialize())  # type: ignore[union-attr]
 
@@ -741,7 +764,18 @@ class UbloxDriver(GpsReceiverDriver):
                     continue
                 identity = getattr(parsed, "identity", "")
                 if identity == "CFG-VALGET":
-                    return {key: int(getattr(parsed, key, -1)) for key in keys}
+                    result: dict[str, int] = {}
+                    for key in keys:
+                        val = getattr(parsed, key, None)
+                        if val is not None:
+                            result[key] = int(val)
+                    return result
+                if identity == "ACK-NAK":
+                    raise RuntimeError(
+                        f"Device rejected CFG-VALGET poll for {keys} (NAK)"
+                    )
+            except RuntimeError:
+                raise
             except Exception:
                 continue
 

--- a/src/sp_rtk_base/services/profile_store.py
+++ b/src/sp_rtk_base/services/profile_store.py
@@ -157,46 +157,73 @@ class ProfileStore:
         logger.info("Created custom profile: %s", profile.name)
         return profile
 
-    def rename_profile(self, name: str, new_name: str) -> Profile:
+    def rename_profile(self, name: str, new_display_name: str) -> Profile:
         """Rename an existing custom profile.
 
+        Renaming edits ``display_name`` only. The slug (``name``,
+        also the filename) is immortal — frozen at creation like a
+        database id — so it never changes here: no file ever moves,
+        and any ``forked_from`` reference pointing at *name* stays
+        valid. The accepted cost is that a long-lived profile's
+        filename may drift from its label.
+
         Args:
-            name: Current name of the custom profile.
-            new_name: New name to give it.
+            name: Slug of the custom profile to rename.
+            new_display_name: The new human-readable label.
 
         Returns:
-            The renamed profile.
+            The profile with its ``display_name`` updated.
 
         Raises:
             ProfileImmutableError: *name* identifies a built-in.
             ProfileNotFoundError: No custom profile named *name* exists.
-            ProfileBusinessRuleError: *new_name* isn't filesystem-safe.
-            ProfileConflictError: *new_name* collides with a built-in or
-                another existing custom profile.
+            ProfileBusinessRuleError: *new_display_name* is blank.
         """
         if name in BUILTIN_PROFILES:
             raise ProfileImmutableError(f"'{name}' is a built-in and cannot be renamed")
-        customs = self._load_customs()
-        existing = customs.get(name)
+        existing = self._load_customs().get(name)
         if existing is None:
             raise ProfileNotFoundError(f"No profile named '{name}'")
 
-        if new_name == name:
-            return existing
+        if not new_display_name.strip():
+            raise ProfileBusinessRuleError("display name must not be blank")
 
-        self._validate_name_is_safe(new_name)
-        if new_name in BUILTIN_PROFILES:
-            raise ProfileConflictError(f"'{new_name}' collides with a built-in profile")
-        if new_name in customs:
-            raise ProfileConflictError(
-                f"A custom profile named '{new_name}' already exists"
-            )
-
-        renamed = existing.model_copy(update={"name": new_name})
+        renamed = existing.model_copy(update={"display_name": new_display_name})
         self._write_custom(renamed)
-        self._custom_path(name).unlink()
-        logger.info("Renamed custom profile: %s -> %s", name, new_name)
+        logger.info(
+            "Renamed custom profile %s -> display_name=%r", name, new_display_name
+        )
         return renamed
+
+    def update_profile(self, profile: Profile) -> Profile:
+        """Overwrite an existing custom profile's content in place.
+
+        Same slug, same filename — the collision path ``create_profile``'s
+        error message has always promised but the store never
+        implemented.
+
+        Args:
+            profile: The full replacement document. ``profile.name``
+                identifies which existing custom to overwrite.
+
+        Returns:
+            The persisted profile (the same object passed in).
+
+        Raises:
+            ProfileImmutableError: *profile.name* identifies a built-in.
+            ProfileNotFoundError: No custom profile named *profile.name*
+                exists yet — use :meth:`create_profile` instead.
+        """
+        if profile.name in BUILTIN_PROFILES:
+            raise ProfileImmutableError(
+                f"'{profile.name}' is a built-in and cannot be overwritten"
+            )
+        if profile.name not in self._load_customs():
+            raise ProfileNotFoundError(f"No profile named '{profile.name}'")
+
+        self._write_custom(profile)
+        logger.info("Updated custom profile: %s", profile.name)
+        return profile
 
     def delete_profile(self, name: str) -> None:
         """Delete a custom profile.

--- a/src/sp_rtk_base/ui/pages/gps_config.py
+++ b/src/sp_rtk_base/ui/pages/gps_config.py
@@ -159,6 +159,18 @@ def resolve_identity(
     return identity_from_target(hardware_target, hardware_confidence)
 
 
+def display_label(profile: Profile) -> str:
+    """The human-facing label for *profile* — its display name, falling
+    back to the slug (``name``) when none is set.
+
+    Every operator-visible rendering of a profile's identity (picker
+    rows, provenance labels like "Forked from"/"Modified from", the
+    rename dialog's prefill) goes through this one helper so the
+    fallback rule lives in exactly one place.
+    """
+    return profile.display_name or profile.name
+
+
 def build_picker_entries(
     profiles: list[Profile],
     store: ProfileStore,
@@ -727,7 +739,7 @@ def gps_config_page() -> None:
         with ui.dialog() as rename_dialog, ui.card().classes("q-pa-md"):
             ui.label("Rename profile").classes("text-h6 text-white")
             ui.separator()
-            rename_name_input = ui.input("New name").classes(
+            rename_name_input = ui.input("Display name").classes(
                 "rename-name w-full q-mt-sm"
             )
             rename_error_label = ui.label("").classes(
@@ -880,7 +892,7 @@ def gps_config_page() -> None:
                                 ui.icon("check_circle").classes(
                                     "profile-selected-icon text-primary"
                                 )
-                            ui.label(entry.profile.name).classes(
+                            ui.label(display_label(entry.profile)).classes(
                                 f"profile-name {name_classes}"
                             )
                             ui.badge(
@@ -904,17 +916,13 @@ def gps_config_page() -> None:
                                     "profile-rename-icon text-grey-4 cursor-pointer"
                                 ).on(
                                     "click",
-                                    lambda _, n=entry.profile.name: _open_rename_dialog(
-                                        n
-                                    ),
+                                    lambda _, p=entry.profile: _open_rename_dialog(p),
                                 ).tooltip("Rename")
                                 ui.icon("delete").classes(
                                     "profile-delete-icon text-grey-4 cursor-pointer"
                                 ).on(
                                     "click",
-                                    lambda _, n=entry.profile.name: _open_delete_dialog(
-                                        n
-                                    ),
+                                    lambda _, p=entry.profile: _open_delete_dialog(p),
                                 ).tooltip("Delete")
                                 ui.icon("download").classes(
                                     "profile-export-icon text-grey-4 cursor-pointer"
@@ -959,7 +967,9 @@ def gps_config_page() -> None:
                 selected_profile, identity.target
             )
             save_as_from_label.text = (
-                f"Forked from: {selected_profile.name}" if selected_profile else ""
+                f"Forked from: {display_label(selected_profile)}"
+                if selected_profile
+                else ""
             )
             save_as_from_label.set_visibility(selected_profile is not None)
             save_as_error_label.set_visibility(False)
@@ -999,10 +1009,10 @@ def gps_config_page() -> None:
             _render_picker()
             _on_form_changed()
 
-        def _open_rename_dialog(name: str) -> None:
+        def _open_rename_dialog(profile: Profile) -> None:
             nonlocal rename_target
-            rename_target = name
-            rename_name_input.value = name
+            rename_target = profile.name
+            rename_name_input.value = display_label(profile)
             rename_error_label.set_visibility(False)
             rename_dialog.open()
 
@@ -1010,9 +1020,9 @@ def gps_config_page() -> None:
             nonlocal selected_profile
             if rename_target is None:
                 return
-            new_name = (rename_name_input.value or "").strip()
+            new_display_name = (rename_name_input.value or "").strip()
             try:
-                renamed = profile_store.rename_profile(rename_target, new_name)
+                renamed = profile_store.rename_profile(rename_target, new_display_name)
             except ProfileStoreError as exc:
                 rename_error_label.text = str(exc)
                 rename_error_label.set_visibility(True)
@@ -1021,14 +1031,17 @@ def gps_config_page() -> None:
             if selected_profile is not None and selected_profile.name == rename_target:
                 selected_profile = renamed
             rename_dialog.close()
-            ui.notify(f"Renamed to '{renamed.name}'", type="positive")
+            ui.notify(f"Renamed to '{display_label(renamed)}'", type="positive")
             _render_picker()
             _on_form_changed()
 
-        def _open_delete_dialog(name: str) -> None:
-            nonlocal delete_target
-            delete_target = name
-            delete_confirm_label.text = f"Delete custom profile '{name}'?"
+        def _open_delete_dialog(profile: Profile) -> None:
+            nonlocal delete_target, delete_target_label
+            delete_target = profile.name
+            delete_target_label = display_label(profile)
+            delete_confirm_label.text = (
+                f"Delete custom profile '{delete_target_label}'?"
+            )
             delete_dialog.open()
 
         def _confirm_delete() -> None:
@@ -1045,7 +1058,7 @@ def gps_config_page() -> None:
             if selected_profile is not None and selected_profile.name == delete_target:
                 selected_profile = None
             delete_dialog.close()
-            ui.notify(f"Deleted '{delete_target}'", type="positive")
+            ui.notify(f"Deleted '{delete_target_label}'", type="positive")
             _render_picker()
             _on_form_changed()
 
@@ -1145,6 +1158,7 @@ def gps_config_page() -> None:
         live_gnss = GnssConfig()
         rename_target: str | None = None
         delete_target: str | None = None
+        delete_target_label: str = ""
 
         def _out_of_sync() -> bool:
             return form_matrix != live_matrix
@@ -1316,10 +1330,10 @@ def gps_config_page() -> None:
                 return
             modified_badge.set_visibility(True)
             if is_modified_from_profile(form_config, selected_profile):
-                modified_badge.text = f"Modified from {selected_profile.name}"
+                modified_badge.text = f"Modified from {display_label(selected_profile)}"
                 modified_badge.props("color=warning")
             else:
-                modified_badge.text = f"Matches {selected_profile.name}"
+                modified_badge.text = f"Matches {display_label(selected_profile)}"
                 modified_badge.props("color=positive")
 
         def _render_save_as_gate() -> None:

--- a/src/sp_rtk_base/ui/pages/gps_config.py
+++ b/src/sp_rtk_base/ui/pages/gps_config.py
@@ -53,6 +53,7 @@ from sp_rtk_base.models.device_models import (
     ALL_RTCM_MESSAGE_IDS,
     RTCM_MESSAGE_GROUPS,
     ApplyConfigCellDiff,
+    CurrentBaseConfig,
     DeviceCapability,
     DeviceConnectionState,
     DynModel,
@@ -63,6 +64,7 @@ from sp_rtk_base.models.device_models import (
     RtcmOutputPort,
     RtcmPortConfig,
     RtcmRowId,
+    SurveyInProgress,
 )
 from sp_rtk_base.models.device_models import (
     BaseMode as TmodeMode,
@@ -542,6 +544,69 @@ def row_slug(row_id: RtcmRowId) -> str:
     return row_id.value.replace(".", "_")
 
 
+# ---------------------------------------------------------------------------
+# Fixed Position three-step card (issue #96) — deliberately separate from
+# the profile-form helpers above. This card's state is derived entirely
+# from live receiver polls (``CurrentBaseConfig`` + ``SurveyInProgress``),
+# never from the selected/applied profile — a profile has no position
+# field, per the card's own "not part of the profile" copy.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FixedPositionStepState:
+    """Which step of Apply -> survey-in -> fixed-position the receiver is
+    currently at, plus the per-step status text the card renders.
+
+    ``current_step`` is 1 (apply profile), 2 (run survey-in) or 3 (fixed
+    position set) — steps before it are "done", steps after are "pending".
+    """
+
+    current_step: int
+    survey_state_text: str
+    fixed_pos_text: str
+
+
+def fixed_position_step_state(
+    base_config: CurrentBaseConfig, survey: SurveyInProgress
+) -> FixedPositionStepState:
+    """Derive the three-step card's current step + status text.
+
+    Step 3 (fixed position set) is current once the receiver reports
+    ``BaseMode.FIXED`` — a promoted survey-in and a manually restored
+    position both land here identically, and survey-in's own state is
+    irrelevant once fixed mode is reached. Step 2 (run survey-in) is
+    current while the receiver is in ``BaseMode.SURVEY_IN`` *or* the
+    survey-in poll reports ``active`` (covers a receiver mid-survey
+    whose TMODE read-back hasn't caught up yet). Anything else is step
+    1 (apply profile) — the baseline a freshly-applied, not-yet-surveyed
+    base sits in.
+    """
+    if base_config.mode == TmodeMode.FIXED:
+        return FixedPositionStepState(
+            current_step=3,
+            survey_state_text="— complete" if survey.valid else "— done",
+            fixed_pos_text=(
+                f"{base_config.latitude:.7f}°, {base_config.longitude:.7f}° "
+                f"± {base_config.accuracy_mm} mm"
+            ),
+        )
+    if base_config.mode == TmodeMode.SURVEY_IN or survey.active:
+        return FixedPositionStepState(
+            current_step=2,
+            survey_state_text=(
+                f"— running ({survey.duration_seconds}s, "
+                f"{survey.mean_accuracy_mm:.0f} mm, {survey.observations} obs)"
+            ),
+            fixed_pos_text="— none",
+        )
+    return FixedPositionStepState(
+        current_step=1,
+        survey_state_text="— not started",
+        fixed_pos_text="— none",
+    )
+
+
 @ui.page("/gps-config")
 def gps_config_page() -> None:
     """Render the advanced GPS configuration page."""
@@ -788,6 +853,63 @@ def gps_config_page() -> None:
                 ui.label(
                     "Persist current receiver configuration to non-volatile memory"
                 ).classes("text-grey-4")
+
+        # ================================================================
+        # Section E: Fixed Position — three-step Apply -> survey-in ->
+        # fixed-position card (issue #96). Hidden until connected, like
+        # every other card but Connection. Deliberately NOT part of the
+        # Profile section above — a profile has no position field, and
+        # the card says so explicitly. Survey-in and position-setting
+        # stay owned by the Survey page; this card only links there
+        # rather than duplicating those controls (issue #96 acceptance
+        # criteria).
+        # ================================================================
+        fixed_position_card = ui.card().classes(
+            "fixed-position-card w-full q-pa-md q-mt-md"
+        )
+        fixed_position_card.set_visibility(False)
+
+        with fixed_position_card:
+            with ui.row().classes("items-center gap-2"):
+                ui.label("Fixed Position").classes("text-h6 text-white")
+                ui.badge("separate operator step — not part of the profile").classes(
+                    "fixed-position-not-in-profile"
+                ).props("outline color=grey")
+            ui.separator()
+            ui.label(
+                "A profile has no position field. After Apply, the base is a "
+                "correctly-configured fixed-mode receiver still without a "
+                "fixed point — positioning is your deliberate step, "
+                "unchanged from today's Survey-In page."
+            ).classes("text-grey-4 q-mt-xs text-caption")
+
+            with ui.row().classes(
+                "fixed-position-steps items-center gap-2 q-mt-md flex-wrap"
+            ):
+                fp_step1_label = ui.label("").classes("fixed-position-step-1 q-pa-xs")
+                ui.icon("arrow_forward").classes("text-grey-6")
+                fp_step2_label = ui.label("").classes("fixed-position-step-2 q-pa-xs")
+                ui.icon("arrow_forward").classes("text-grey-6")
+                fp_step3_label = ui.label("").classes("fixed-position-step-3 q-pa-xs")
+
+            with ui.row().classes("items-center gap-2 q-mt-md"):
+                ui.button("Run survey-in", icon="open_in_new").classes(
+                    "fixed-position-survey-link"
+                ).props("outline color=primary").on(
+                    "click", lambda: ui.navigate.to("/survey")
+                )
+                ui.button("Set fixed position", icon="open_in_new").classes(
+                    "fixed-position-manual-link"
+                ).props("outline color=primary").on(
+                    "click", lambda: ui.navigate.to("/survey")
+                )
+
+            ui.label(
+                "Survey-in is a live observation session (see Survey) — "
+                "this step is shown here only to make the apply -> "
+                "position sequence legible at a glance. It never blocks "
+                "Apply, and the profile never carries it."
+            ).classes("text-grey-5 q-mt-sm text-caption")
 
         # ================================================================
         # Event handlers
@@ -1112,6 +1234,7 @@ def gps_config_page() -> None:
             flash_card.set_visibility(
                 connected and DeviceCapability.SAVE_TO_FLASH in caps
             )
+            fixed_position_card.set_visibility(connected)
             reload_device_btn.set_visibility(connected)
 
             if connected:
@@ -1435,6 +1558,55 @@ def gps_config_page() -> None:
             else:
                 advisory_label.set_visibility(False)
 
+        def _render_fixed_position_step(
+            label: ui.label, step_index: int, current_step: int, text: str
+        ) -> None:
+            label.text = text
+            if step_index == current_step:
+                modifier = "is-current"
+            elif step_index < current_step:
+                modifier = "is-done"
+            else:
+                modifier = "is-pending"
+            label.classes(
+                remove="is-current is-done is-pending",
+                add=modifier,
+            )
+
+        async def _render_fixed_position() -> None:
+            """Refresh the Fixed Position card's three-step state (issue #96).
+
+            Polls the live receiver directly — ``get_base_config`` /
+            ``get_survey_in_status`` — never the profile-seeded form
+            state above. Called alongside the rest of the live-seeding
+            refresh flow in ``_load_receiver_config_form``, so it stays
+            current on connect, reload/reconnect, and page (re)load
+            while already connected.
+            """
+            try:
+                base_config = await svc.get_base_config()
+                survey = await svc.get_survey_in_status()
+            except Exception:
+                logger.debug("Failed to read fixed-position step state")
+                return
+
+            state = fixed_position_step_state(base_config, survey)
+            _render_fixed_position_step(
+                fp_step1_label, 1, state.current_step, "① Apply profile"
+            )
+            _render_fixed_position_step(
+                fp_step2_label,
+                2,
+                state.current_step,
+                f"② Run survey-in {state.survey_state_text}",
+            )
+            _render_fixed_position_step(
+                fp_step3_label,
+                3,
+                state.current_step,
+                f"③ Fixed position set {state.fixed_pos_text}",
+            )
+
         async def _load_receiver_config_form() -> None:
             """Seed the form from the live receiver.
 
@@ -1470,6 +1642,7 @@ def gps_config_page() -> None:
             _clear_apply_result()
             _on_form_changed()
             _render_picker()
+            await _render_fixed_position()
 
         async def _connect() -> None:
             """Connect to the selected device."""

--- a/tests/e2e/test_gps_fixed_position_card.py
+++ b/tests/e2e/test_gps_fixed_position_card.py
@@ -1,0 +1,182 @@
+"""E2E tests for the Fixed Position three-step card (issue #96).
+
+The card is an accepted layout element of the T5 prototype
+(``origin/prototype/gps-page-t5:tools/prototype-gps-page/index.html``,
+operator-approved) that was missing from the shipped Advanced GPS
+page entirely. It shows the Apply -> survey-in -> fixed-position
+sequence as three ordered steps, states explicitly that fixed
+position is *not* part of the profile, and links to the Survey page
+for the survey-in/position-setting actions rather than duplicating
+that page's own controls.
+
+Covers the acceptance criteria from the issue:
+
+- Hidden when disconnected, like every other card but Connection.
+- Renders with three ordered steps once connected, indicating step 1
+  (Apply profile) as current for a freshly-connected, never-surveyed
+  receiver.
+- Reflects the receiver's live state — step 2 current mid-survey-in,
+  step 3 current once fixed-position mode is reached — driven through
+  ``FakeGpsDriver`` via the real ``/api/device/configure/survey-in``
+  and ``/api/device/configure/fixed-base`` endpoints (not fixture
+  internals), then observed after a fresh page load, matching how the
+  page itself refreshes this card (``_load_receiver_config_form``).
+- States the "not part of the profile" copy.
+- Survey-in/position-setting actions navigate to ``/survey`` rather
+  than duplicating those controls here.
+
+Locators target the stable ``fixed-position-*`` CSS class hooks the
+page renders (see ``ui/pages/gps_config.py``) rather than text
+substrings, matching the rest of this suite's convention
+(``test_gps_profile_picker.py`` docstring explains why).
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+
+def _goto_gps_config(page: Page, base_url: str) -> None:
+    page.goto(f"{base_url}/gps-config")
+    expect(page.locator("text=Advanced GPS Configuration").first).to_be_visible(
+        timeout=15_000
+    )
+
+
+@pytest.mark.e2e
+def test_card_hidden_when_disconnected(page: Page, base_url: str) -> None:
+    """The card exists in the DOM but is not visible while disconnected."""
+    page.goto(f"{base_url}/gps-config")
+    expect(page.locator("text=Advanced GPS Configuration").first).to_be_visible(
+        timeout=15_000
+    )
+    expect(page.locator(".fixed-position-card")).to_be_hidden(timeout=5_000)
+
+
+@pytest.mark.e2e
+def test_card_visible_with_step_1_current_after_connect(
+    page: Page,
+    base_url: str,
+    connected_gps: None,
+) -> None:
+    """A freshly-connected, never-surveyed receiver shows step 1 current.
+
+    ``FakeGpsDriver`` starts every connection in ``BaseMode.DISABLED``
+    with no survey-in ever started, so this is the baseline state.
+    """
+    _goto_gps_config(page, base_url)
+
+    card = page.locator(".fixed-position-card")
+    expect(card).to_be_visible(timeout=10_000)
+
+    # States it's not part of the profile.
+    expect(card.locator(".fixed-position-not-in-profile")).to_be_visible()
+    expect(card).to_contain_text("not part of the profile")
+
+    # Three ordered steps, step 1 current, steps 2/3 pending.
+    expect(card.locator(".fixed-position-step-1")).to_have_class(
+        "fixed-position-step-1 q-pa-xs is-current"
+    )
+    expect(card.locator(".fixed-position-step-2")).to_have_class(
+        "fixed-position-step-2 q-pa-xs is-pending"
+    )
+    expect(card.locator(".fixed-position-step-3")).to_have_class(
+        "fixed-position-step-3 q-pa-xs is-pending"
+    )
+
+
+@pytest.mark.e2e
+def test_survey_and_manual_links_navigate_to_survey_page(
+    page: Page,
+    base_url: str,
+    connected_gps: None,
+) -> None:
+    """The card links to /survey rather than duplicating its controls."""
+    _goto_gps_config(page, base_url)
+
+    card = page.locator(".fixed-position-card")
+    expect(card).to_be_visible(timeout=10_000)
+
+    card.locator(".fixed-position-survey-link").click()
+    expect(page).to_have_url(f"{base_url}/survey", timeout=10_000)
+
+    _goto_gps_config(page, base_url)
+    card = page.locator(".fixed-position-card")
+    expect(card).to_be_visible(timeout=10_000)
+    card.locator(".fixed-position-manual-link").click()
+    expect(page).to_have_url(f"{base_url}/survey", timeout=10_000)
+
+
+@pytest.mark.e2e
+def test_step_2_current_while_survey_in_is_running(
+    page: Page,
+    base_url: str,
+    api_base_url: str,
+    connected_gps: None,
+) -> None:
+    """Driving the fake driver into survey-in reflects step 2 as current.
+
+    ``FakeGpsDriver.get_survey_in_status`` fast-completes a survey
+    after ~3s (``_SURVEY_FAST_COMPLETE_SECONDS``), so this posts the
+    real API endpoint and reloads the page immediately — well inside
+    that window — rather than waiting for any UI-side timer.
+    """
+    resp = httpx.post(
+        f"{api_base_url}/api/device/configure/survey-in",
+        json={"min_duration_seconds": 3600, "accuracy_limit_mm": 1000},
+        timeout=5.0,
+    )
+    assert resp.status_code == 200, resp.text
+
+    _goto_gps_config(page, base_url)
+
+    card = page.locator(".fixed-position-card")
+    expect(card).to_be_visible(timeout=10_000)
+    expect(card.locator(".fixed-position-step-2")).to_have_class(
+        "fixed-position-step-2 q-pa-xs is-current"
+    )
+    expect(card.locator(".fixed-position-step-1")).to_have_class(
+        "fixed-position-step-1 q-pa-xs is-done"
+    )
+    expect(card.locator(".fixed-position-step-3")).to_have_class(
+        "fixed-position-step-3 q-pa-xs is-pending"
+    )
+
+
+@pytest.mark.e2e
+def test_step_3_current_once_fixed_position_is_set(
+    page: Page,
+    base_url: str,
+    api_base_url: str,
+    connected_gps: None,
+) -> None:
+    """Driving the fake driver into fixed mode reflects step 3 as current,
+    with the surveyed coordinates shown."""
+    resp = httpx.post(
+        f"{api_base_url}/api/device/configure/fixed-base",
+        json={
+            "latitude": 32.7329015,
+            "longitude": -117.2362788,
+            "altitude_m": 27.940,
+            "accuracy_mm": 47308,
+        },
+        timeout=5.0,
+    )
+    assert resp.status_code == 200, resp.text
+
+    _goto_gps_config(page, base_url)
+
+    card = page.locator(".fixed-position-card")
+    expect(card).to_be_visible(timeout=10_000)
+    expect(card.locator(".fixed-position-step-3")).to_have_class(
+        "fixed-position-step-3 q-pa-xs is-current"
+    )
+    expect(card.locator(".fixed-position-step-1")).to_have_class(
+        "fixed-position-step-1 q-pa-xs is-done"
+    )
+    expect(card.locator(".fixed-position-step-2")).to_have_class(
+        "fixed-position-step-2 q-pa-xs is-done"
+    )
+    expect(card.locator(".fixed-position-step-3")).to_contain_text("32.7329015")

--- a/tests/e2e/test_gps_profile_save_as.py
+++ b/tests/e2e/test_gps_profile_save_as.py
@@ -36,6 +36,10 @@ import pytest
 from playwright.sync_api import Page, expect
 
 BUILTIN_NAME = "ublox-f9p-base-standard"
+#: The built-in's ``display_name`` (issue #95) — provenance labels
+#: (picker row, "Matches"/"Modified from", "Forked from") render this,
+#: not the slug ``BUILTIN_NAME``.
+BUILTIN_DISPLAY_NAME = "u-blox F9P — Base Station (Standard)"
 
 
 def _delete_profile(api_base_url: str, name: str) -> None:
@@ -90,7 +94,7 @@ def _select_builtin(page: Page) -> None:
     expect(builtin_row).to_be_visible(timeout=10_000)
     builtin_row.locator(".profile-name").click()
     expect(page.locator(".modified-badge")).to_contain_text(
-        f"Matches {BUILTIN_NAME}", timeout=10_000
+        f"Matches {BUILTIN_DISPLAY_NAME}", timeout=10_000
     )
 
 
@@ -122,7 +126,7 @@ def test_selecting_profile_prefills_matrix_and_matches_immediately(
 
     modified_badge = page.locator(".modified-badge")
     expect(modified_badge).to_be_visible()
-    expect(modified_badge).to_contain_text(f"Matches {BUILTIN_NAME}")
+    expect(modified_badge).to_contain_text(f"Matches {BUILTIN_DISPLAY_NAME}")
 
     expect(page.locator(".save-as-btn")).to_be_disabled()
 
@@ -143,7 +147,7 @@ def test_editing_after_pick_flips_to_modified_and_reenables_save_as(
     page.locator(".rtcm-cell-1077-UART1").click()
 
     modified_badge = page.locator(".modified-badge")
-    expect(modified_badge).to_contain_text(f"Modified from {BUILTIN_NAME}")
+    expect(modified_badge).to_contain_text(f"Modified from {BUILTIN_DISPLAY_NAME}")
     expect(page.locator(".save-as-btn")).to_be_enabled()
 
 
@@ -164,7 +168,7 @@ def test_save_as_stays_enabled_after_a_real_successful_apply(
     page.locator(".rtcm-cell-1077-UART1").click()
 
     modified_badge = page.locator(".modified-badge")
-    expect(modified_badge).to_contain_text(f"Modified from {BUILTIN_NAME}")
+    expect(modified_badge).to_contain_text(f"Modified from {BUILTIN_DISPLAY_NAME}")
 
     page.get_by_role("button", name="Apply").click()
     expect(page.locator(".apply-result")).to_contain_text(
@@ -173,7 +177,7 @@ def test_save_as_stays_enabled_after_a_real_successful_apply(
 
     # Apply cleared "out of sync" (implicit — that's #65) but must leave
     # "modified from X" and Save-as exactly as they were.
-    expect(modified_badge).to_contain_text(f"Modified from {BUILTIN_NAME}")
+    expect(modified_badge).to_contain_text(f"Modified from {BUILTIN_DISPLAY_NAME}")
     expect(page.locator(".save-as-btn")).to_be_enabled()
 
 
@@ -208,7 +212,7 @@ def test_save_as_forks_a_custom_profile_with_provenance(
     name_input = page.locator(".save-as-name input")
     expect(name_input).to_have_value(f"{BUILTIN_NAME}-copy")
     expect(page.locator(".save-as-from")).to_contain_text(
-        f"Forked from: {BUILTIN_NAME}"
+        f"Forked from: {BUILTIN_DISPLAY_NAME}"
     )
 
     forked_name = f"{BUILTIN_NAME}-copy"
@@ -326,6 +330,9 @@ def test_rename_then_delete_custom_profile(
     connected_gps: None,
     cleanup_profiles: list[str],
 ) -> None:
+    """Rename edits the display name only — the slug (and so the row's
+    CSS identity, ``.profile-row-e2e-rename-me``) never changes; only
+    the rendered label updates."""
     custom = {
         "name": "e2e-rename-me",
         "version": 1,
@@ -336,22 +343,22 @@ def test_rename_then_delete_custom_profile(
     resp = httpx.post(f"{api_base_url}/api/profiles", json=custom, timeout=5.0)
     assert resp.status_code in (201, 409), resp.text
     cleanup_profiles.append("e2e-rename-me")
-    cleanup_profiles.append("e2e-renamed")
 
     _goto_gps_config(page, base_url)
 
-    old_row = page.locator(".profile-row-e2e-rename-me")
-    expect(old_row).to_be_visible(timeout=10_000)
-    old_row.locator(".profile-rename-icon").click()
+    row = page.locator(".profile-row-e2e-rename-me")
+    expect(row).to_be_visible(timeout=10_000)
+    row.locator(".profile-rename-icon").click()
 
+    # No display_name set yet — the dialog falls back to the slug.
     expect(page.locator(".rename-name input")).to_have_value("e2e-rename-me")
-    page.locator(".rename-name input").fill("e2e-renamed")
+    page.locator(".rename-name input").fill("e2e Renamed")
     page.locator(".rename-confirm-btn").click()
 
-    new_row = page.locator(".profile-row-e2e-renamed")
-    expect(new_row).to_be_visible(timeout=10_000)
-    expect(page.locator(".profile-row-e2e-rename-me")).to_have_count(0)
+    # Same row (same slug) — only the visible label changed.
+    expect(row).to_be_visible(timeout=10_000)
+    expect(row.locator(".profile-name")).to_have_text("e2e Renamed")
 
-    new_row.locator(".profile-delete-icon").click()
+    row.locator(".profile-delete-icon").click()
     page.locator(".delete-confirm-btn").click()
-    expect(page.locator(".profile-row-e2e-renamed")).to_have_count(0, timeout=10_000)
+    expect(page.locator(".profile-row-e2e-rename-me")).to_have_count(0, timeout=10_000)

--- a/tests/unit/test_api_profiles.py
+++ b/tests/unit/test_api_profiles.py
@@ -141,62 +141,58 @@ class TestCreateProfile:
 
 
 class TestRenameProfile:
-    def test_rename_returns_updated_profile(
+    """Rename edits ``display_name`` only — the slug (``name``) never
+    changes, so there's no more "colliding name" or "unsafe name" case."""
+
+    def test_rename_sets_display_name_and_keeps_slug(
         self, api_client_with_services: TestClient
     ) -> None:
         api_client_with_services.post(
             "/api/profiles", json=_profile_payload("old-name")
         )
         resp = api_client_with_services.patch(
-            "/api/profiles/old-name", json={"new_name": "new-name"}
+            "/api/profiles/old-name", json={"new_display_name": "Pretty Name"}
         )
         assert resp.status_code == 200
-        assert resp.json()["profile"]["name"] == "new-name"
+        body = resp.json()["profile"]
+        assert body["name"] == "old-name"
+        assert body["display_name"] == "Pretty Name"
 
     def test_rename_builtin_is_403(self, api_client_with_services: TestClient) -> None:
         resp = api_client_with_services.patch(
-            f"/api/profiles/{BUILTIN_NAME}", json={"new_name": "something-else"}
+            f"/api/profiles/{BUILTIN_NAME}", json={"new_display_name": "Something Else"}
         )
         assert resp.status_code == 403
 
     def test_rename_unknown_is_404(self, api_client_with_services: TestClient) -> None:
         resp = api_client_with_services.patch(
-            "/api/profiles/does-not-exist", json={"new_name": "something-else"}
+            "/api/profiles/does-not-exist", json={"new_display_name": "Something Else"}
         )
         assert resp.status_code == 404
 
-    def test_rename_to_colliding_name_is_409(
-        self, api_client_with_services: TestClient
-    ) -> None:
-        api_client_with_services.post("/api/profiles", json=_profile_payload("first"))
-        api_client_with_services.post("/api/profiles", json=_profile_payload("second"))
-        resp = api_client_with_services.patch(
-            "/api/profiles/first", json={"new_name": "second"}
-        )
-        assert resp.status_code == 409
-
-    def test_rename_to_unsafe_name_is_400(
+    def test_rename_to_blank_display_name_is_400(
         self, api_client_with_services: TestClient
     ) -> None:
         api_client_with_services.post(
             "/api/profiles", json=_profile_payload("old-name")
         )
         resp = api_client_with_services.patch(
-            "/api/profiles/old-name", json={"new_name": "has/slash"}
+            "/api/profiles/old-name", json={"new_display_name": "   "}
         )
         assert resp.status_code == 400
 
-    def test_rename_to_same_name_is_a_noop_not_a_conflict(
+    def test_rename_to_a_name_matching_another_profiles_slug_is_not_a_conflict(
         self, api_client_with_services: TestClient
     ) -> None:
-        api_client_with_services.post(
-            "/api/profiles", json=_profile_payload("same-name")
-        )
+        api_client_with_services.post("/api/profiles", json=_profile_payload("first"))
+        api_client_with_services.post("/api/profiles", json=_profile_payload("second"))
         resp = api_client_with_services.patch(
-            "/api/profiles/same-name", json={"new_name": "same-name"}
+            "/api/profiles/first", json={"new_display_name": "second"}
         )
         assert resp.status_code == 200
-        assert resp.json()["profile"]["name"] == "same-name"
+        body = resp.json()["profile"]
+        assert body["name"] == "first"
+        assert body["display_name"] == "second"
 
 
 class TestDeleteProfile:

--- a/tests/unit/test_builtin_profiles.py
+++ b/tests/unit/test_builtin_profiles.py
@@ -38,6 +38,9 @@ class TestUbloxF9pBaseStandard:
         assert self.profile.version == 1
         assert self.profile.hardware == "ZED-F9P"
 
+    def test_display_name(self) -> None:
+        assert self.profile.display_name == "u-blox F9P — Base Station (Standard)"
+
     def test_baud_split(self) -> None:
         assert self.profile.baud is not None
         assert self.profile.baud.uart1 == 57600

--- a/tests/unit/test_gps_config_helpers.py
+++ b/tests/unit/test_gps_config_helpers.py
@@ -15,6 +15,7 @@ import pytest
 
 from sp_rtk_base.models.device_models import (
     ApplyConfigCellDiff,
+    CurrentBaseConfig,
     DynModel,
     GnssConfig,
     GnssConstellation,
@@ -24,6 +25,7 @@ from sp_rtk_base.models.device_models import (
     RtcmOutputPort,
     RtcmPortConfig,
     RtcmRowId,
+    SurveyInProgress,
     UbxProtocol,
 )
 from sp_rtk_base.models.device_models import (
@@ -45,6 +47,7 @@ from sp_rtk_base.ui.pages.gps_config import (
     build_apply_config,
     build_picker_entries,
     build_saved_profile,
+    fixed_position_step_state,
     format_cell_diff,
     hw_extras_display,
     i2c_spi_advisory_rows,
@@ -636,3 +639,67 @@ class TestHwExtrasDisplay:
         assert rows["Elevation Mask"] == "15°"
         assert rows["BeiDou B2"] == "off"
         assert rows["SPI"] == "on"
+
+
+class TestFixedPositionStepState:
+    """Step derivation for the Fixed Position three-step card (issue #96)."""
+
+    def test_disabled_mode_and_no_survey_is_step_1(self) -> None:
+        state = fixed_position_step_state(
+            CurrentBaseConfig(mode=TmodeMode.DISABLED),
+            SurveyInProgress(active=False, valid=False),
+        )
+        assert state.current_step == 1
+        assert state.survey_state_text == "— not started"
+        assert state.fixed_pos_text == "— none"
+
+    def test_survey_in_mode_is_step_2(self) -> None:
+        state = fixed_position_step_state(
+            CurrentBaseConfig(mode=TmodeMode.SURVEY_IN),
+            SurveyInProgress(
+                active=True,
+                valid=False,
+                duration_seconds=42,
+                mean_accuracy_mm=1234.5,
+                observations=168,
+            ),
+        )
+        assert state.current_step == 2
+        assert "42s" in state.survey_state_text
+        assert "1234 mm" in state.survey_state_text
+        assert "168 obs" in state.survey_state_text
+        assert state.fixed_pos_text == "— none"
+
+    def test_active_survey_poll_is_step_2_even_if_mode_lags(self) -> None:
+        """``survey.active`` alone is enough — covers a receiver mid-survey
+        whose ``CurrentBaseConfig`` read-back hasn't caught up yet."""
+        state = fixed_position_step_state(
+            CurrentBaseConfig(mode=TmodeMode.DISABLED),
+            SurveyInProgress(active=True, valid=False),
+        )
+        assert state.current_step == 2
+
+    def test_fixed_mode_is_step_3(self) -> None:
+        state = fixed_position_step_state(
+            CurrentBaseConfig(
+                mode=TmodeMode.FIXED,
+                latitude=32.7329015,
+                longitude=-117.2362788,
+                altitude_m=27.94,
+                accuracy_mm=47308,
+            ),
+            SurveyInProgress(active=False, valid=True),
+        )
+        assert state.current_step == 3
+        assert "32.7329015" in state.fixed_pos_text
+        assert "-117.2362788" in state.fixed_pos_text
+        assert "47308 mm" in state.fixed_pos_text
+
+    def test_fixed_mode_wins_over_stale_active_survey_flag(self) -> None:
+        """Fixed mode is terminal — a stale ``active=True`` poll can't
+        regress the card back to step 2."""
+        state = fixed_position_step_state(
+            CurrentBaseConfig(mode=TmodeMode.FIXED, latitude=1.0, longitude=2.0),
+            SurveyInProgress(active=True, valid=False),
+        )
+        assert state.current_step == 3

--- a/tests/unit/test_gps_config_helpers.py
+++ b/tests/unit/test_gps_config_helpers.py
@@ -45,6 +45,7 @@ from sp_rtk_base.ui.pages.gps_config import (
     build_apply_config,
     build_picker_entries,
     build_saved_profile,
+    display_label,
     format_cell_diff,
     hw_extras_display,
     i2c_spi_advisory_rows,
@@ -499,6 +500,19 @@ class TestSaveAsEnabled:
         extras = profile_to_form_extras(profile)
         form_config = build_apply_config(matrix, profile.data_link_port, extras)
         assert save_as_enabled(form_config, profile)
+
+
+class TestDisplayLabel:
+    def test_renders_display_name_when_set(self) -> None:
+        profile = _full_profile("some-slug").model_copy(
+            update={"display_name": "Pretty Name"}
+        )
+        assert display_label(profile) == "Pretty Name"
+
+    def test_falls_back_to_slug_when_absent(self) -> None:
+        profile = _full_profile("some-slug")
+        assert profile.display_name is None
+        assert display_label(profile) == "some-slug"
 
 
 class TestSuggestProfileName:

--- a/tests/unit/test_profile_models.py
+++ b/tests/unit/test_profile_models.py
@@ -262,6 +262,34 @@ class TestProfile:
         profile = Profile.model_validate(kwargs)
         assert profile.forked_from == "ublox-f9p-base-standard"
 
+    def test_display_name_defaults_to_none(self) -> None:
+        profile = Profile.model_validate(self._profile_kwargs())
+        assert profile.display_name is None
+
+    def test_display_name_settable(self) -> None:
+        kwargs = self._profile_kwargs()
+        kwargs["display_name"] = "u-blox F9P — Base Station (Standard)"
+        profile = Profile.model_validate(kwargs)
+        assert profile.display_name == "u-blox F9P — Base Station (Standard)"
+
+    def test_display_name_roundtrips_through_serialization(self) -> None:
+        kwargs = self._profile_kwargs()
+        kwargs["display_name"] = "My Pretty Name"
+        profile = Profile.model_validate(kwargs)
+        data = profile.model_dump(mode="json")
+        restored = Profile.model_validate(data)
+        assert restored.display_name == "My Pretty Name"
+
+    def test_profile_without_display_name_still_loads(self) -> None:
+        kwargs = self._profile_kwargs()
+        assert "display_name" not in kwargs
+        profile = Profile.model_validate(kwargs)
+        data = profile.model_dump(mode="json", exclude_none=True)
+        assert "display_name" not in data
+        restored = Profile.model_validate(data)
+        assert restored.display_name is None
+        assert restored == profile
+
     def test_inherits_receiver_config_validation(self) -> None:
         kwargs = self._profile_kwargs()
         kwargs["meas_period_ms"] = 1

--- a/tests/unit/test_profile_store.py
+++ b/tests/unit/test_profile_store.py
@@ -139,48 +139,99 @@ class TestCreateProfile:
 
 
 class TestRenameProfile:
-    def test_rename_moves_file(self, store: ProfileStore, profiles_dir: Path) -> None:
-        store.create_profile(_custom("old-name"))
-        store.rename_profile("old-name", "new-name")
-        assert not (profiles_dir / "old-name.yaml").exists()
-        assert (profiles_dir / "new-name.yaml").exists()
+    """Rename edits ``display_name`` only — the slug is immortal.
 
-    def test_rename_returns_updated_profile(self, store: ProfileStore) -> None:
+    It's frozen at creation like a database id: the filename never
+    moves and inbound ``forked_from`` references never dangle.
+    """
+
+    def test_rename_sets_display_name(self, store: ProfileStore) -> None:
         store.create_profile(_custom("old-name"))
-        renamed = store.rename_profile("old-name", "new-name")
-        assert renamed.name == "new-name"
+        renamed = store.rename_profile("old-name", "Pretty Name")
+        assert renamed.display_name == "Pretty Name"
+
+    def test_rename_never_changes_the_slug(self, store: ProfileStore) -> None:
+        store.create_profile(_custom("old-name"))
+        renamed = store.rename_profile("old-name", "Pretty Name")
+        assert renamed.name == "old-name"
+
+    def test_rename_never_moves_the_file(
+        self, store: ProfileStore, profiles_dir: Path
+    ) -> None:
+        store.create_profile(_custom("old-name"))
+        store.rename_profile("old-name", "Pretty Name")
+        assert (profiles_dir / "old-name.yaml").exists()
+        assert len(list(profiles_dir.glob("*.yaml"))) == 1
+
+    def test_rename_persists_display_name_to_disk(self, store: ProfileStore) -> None:
+        store.create_profile(_custom("old-name"))
+        store.rename_profile("old-name", "Pretty Name")
+        reloaded = store.get_profile("old-name")
+        assert reloaded is not None
+        assert reloaded.display_name == "Pretty Name"
+
+    def test_rename_does_not_dangle_fork_references(self, store: ProfileStore) -> None:
+        store.create_profile(_custom("source-profile"))
+        store.create_profile(_custom("fork", forked_from="source-profile"))
+        store.rename_profile("source-profile", "Renamed Source")
+        fork = store.get_profile("fork")
+        assert fork is not None
+        assert fork.forked_from == "source-profile"
 
     def test_rename_builtin_is_forbidden(self, store: ProfileStore) -> None:
         with pytest.raises(ProfileImmutableError):
-            store.rename_profile(BUILTIN_NAME, "something-else")
+            store.rename_profile(BUILTIN_NAME, "Something Else")
 
     def test_rename_unknown_is_not_found(self, store: ProfileStore) -> None:
         with pytest.raises(ProfileNotFoundError):
-            store.rename_profile("does-not-exist", "something-else")
+            store.rename_profile("does-not-exist", "Something Else")
 
-    def test_rename_to_existing_builtin_conflicts(self, store: ProfileStore) -> None:
+    def test_rename_to_a_name_matching_a_builtin_slug_is_not_a_conflict(
+        self, store: ProfileStore
+    ) -> None:
+        # display_name has no charset/uniqueness constraint — it can even
+        # read the same as another profile's slug, since it never becomes
+        # a filesystem path.
         store.create_profile(_custom("old-name"))
-        with pytest.raises(ProfileConflictError):
-            store.rename_profile("old-name", BUILTIN_NAME)
+        renamed = store.rename_profile("old-name", BUILTIN_NAME)
+        assert renamed.display_name == BUILTIN_NAME
+        assert renamed.name == "old-name"
 
-    def test_rename_to_existing_custom_conflicts(self, store: ProfileStore) -> None:
-        store.create_profile(_custom("first"))
-        store.create_profile(_custom("second"))
-        with pytest.raises(ProfileConflictError):
-            store.rename_profile("first", "second")
-
-    def test_rename_to_unsafe_name_rejected(self, store: ProfileStore) -> None:
+    def test_rename_to_empty_display_name_rejected(self, store: ProfileStore) -> None:
         store.create_profile(_custom("old-name"))
         with pytest.raises(ProfileBusinessRuleError):
-            store.rename_profile("old-name", "has/slash")
+            store.rename_profile("old-name", "   ")
 
-    def test_rename_to_same_name_is_a_noop(
+
+class TestUpdateProfile:
+    """The overwrite path the collision error text promises but the
+    store didn't previously implement."""
+
+    def test_update_overwrites_existing_custom_in_place(
+        self, store: ProfileStore
+    ) -> None:
+        store.create_profile(_custom("my-custom", hardware="ZED-F9P"))
+        updated = store.update_profile(_custom("my-custom", hardware="any"))
+        assert updated.hardware == "any"
+        reloaded = store.get_profile("my-custom")
+        assert reloaded is not None
+        assert reloaded.hardware == "any"
+
+    def test_update_does_not_create_a_new_file(
         self, store: ProfileStore, profiles_dir: Path
     ) -> None:
-        created = store.create_profile(_custom("same-name"))
-        renamed = store.rename_profile("same-name", "same-name")
-        assert renamed == created
-        assert (profiles_dir / "same-name.yaml").exists()
+        store.create_profile(_custom("my-custom"))
+        store.update_profile(_custom("my-custom", hardware="any"))
+        assert len(list(profiles_dir.glob("*.yaml"))) == 1
+
+    def test_update_rejects_builtin(self, store: ProfileStore) -> None:
+        with pytest.raises(ProfileImmutableError):
+            store.update_profile(_custom(BUILTIN_NAME))
+        assert BUILTIN_PROFILES[BUILTIN_NAME].hardware == "ZED-F9P"
+
+    def test_update_rejects_unknown_custom(self, store: ProfileStore) -> None:
+        with pytest.raises(ProfileNotFoundError):
+            store.update_profile(_custom("does-not-exist"))
 
 
 class TestDeleteProfile:

--- a/tests/unit/test_ublox_driver.py
+++ b/tests/unit/test_ublox_driver.py
@@ -1911,6 +1911,188 @@ class TestGetUartBaudRates:
         assert result == {PortId.UART1: 57600, PortId.UART2: 115200}
 
 
+class TestReadCfgKeysLocked:
+    """Tests for ``UbloxDriver._read_cfg_keys_locked`` (issue #94).
+
+    Covers the layer parameter, the tri-state (present / absent /
+    NAK) result, and the immediate-NAK-raise behaviour that
+    distinguishes this from ``_wait_for_ack``'s write-side sibling.
+    """
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_defaults_to_ram_layer(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        """No layer arg polls RAM (0) — unchanged pre-#94 behaviour."""
+        driver, _reader = _connect_driver(
+            mock_serial_cls,
+            mock_reader_cls,
+            mock_ubx_msg,
+            [_make_dyn_model_valget(2)],
+        )
+
+        with driver._lock:  # pyright: ignore[reportPrivateUsage]
+            result = driver._read_cfg_keys_locked(  # pyright: ignore[reportPrivateUsage]
+                ["CFG_NAVSPG_DYNMODEL"]
+            )
+
+        assert result == {"CFG_NAVSPG_DYNMODEL": 2}
+        mock_ubx_msg.config_poll.assert_called_once_with(0, 0, ["CFG_NAVSPG_DYNMODEL"])
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_polls_requested_layer(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        """An explicit layer is forwarded to ``config_poll``."""
+        driver, _reader = _connect_driver(
+            mock_serial_cls,
+            mock_reader_cls,
+            mock_ubx_msg,
+            [_make_dyn_model_valget(2)],
+        )
+
+        with driver._lock:  # pyright: ignore[reportPrivateUsage]
+            driver._read_cfg_keys_locked(  # pyright: ignore[reportPrivateUsage]
+                ["CFG_NAVSPG_DYNMODEL"], layer=2
+            )
+
+        mock_ubx_msg.config_poll.assert_called_once_with(2, 0, ["CFG_NAVSPG_DYNMODEL"])
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_unrecognised_key_omitted_not_sentineled(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        """A key the receiver doesn't recognise is absent from the
+        dict, not sentinelled to a fake ``-1`` reading."""
+        read_back = SimpleNamespace(identity="CFG-VALGET")  # no attrs
+        driver, _reader = _connect_driver(
+            mock_serial_cls, mock_reader_cls, mock_ubx_msg, [read_back]
+        )
+
+        with driver._lock:  # pyright: ignore[reportPrivateUsage]
+            result = driver._read_cfg_keys_locked(  # pyright: ignore[reportPrivateUsage]
+                ["CFG_UNKNOWN_KEY"]
+            )
+
+        assert result == {}
+        assert "CFG_UNKNOWN_KEY" not in result
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_nak_raises_immediately_naming_nak(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        """A NAK is detected on the first read, not after exhausting
+        the read loop, and the error names the NAK."""
+        driver, reader = _connect_driver(
+            mock_serial_cls, mock_reader_cls, mock_ubx_msg, [_make_nak_response()]
+        )
+
+        with pytest.raises(RuntimeError, match="NAK"):
+            with driver._lock:  # pyright: ignore[reportPrivateUsage]
+                driver._read_cfg_keys_locked(  # pyright: ignore[reportPrivateUsage]
+                    ["CFG_NAVSPG_DYNMODEL"]
+                )
+
+        # 1 read for MON-VER during connect() + 1 for the NAK — proves
+        # it raised immediately rather than looping to exhaustion.
+        assert reader.read.call_count == 2
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_mixed_batch_returns_only_present_keys(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        """A batch poll where only some keys are set at the requested
+        layer returns the ones that are, without failing."""
+        read_back = SimpleNamespace(identity="CFG-VALGET", CFG_UART1_BAUDRATE=57600)
+        driver, _reader = _connect_driver(
+            mock_serial_cls, mock_reader_cls, mock_ubx_msg, [read_back]
+        )
+
+        with driver._lock:  # pyright: ignore[reportPrivateUsage]
+            result = driver._read_cfg_keys_locked(  # pyright: ignore[reportPrivateUsage]
+                ["CFG_UART1_BAUDRATE", "CFG_UART2_BAUDRATE"]
+            )
+
+        assert result == {"CFG_UART1_BAUDRATE": 57600}
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_key_absent_at_other_layer_present_at_ram(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        """A key never written to a layer reads as absent at that
+        layer while still returning its value at RAM."""
+        absent_at_bbr = SimpleNamespace(identity="CFG-VALGET")  # no attrs
+        present_at_ram = SimpleNamespace(identity="CFG-VALGET", CFG_NAVSPG_DYNMODEL=2)
+        driver, _reader = _connect_driver(
+            mock_serial_cls,
+            mock_reader_cls,
+            mock_ubx_msg,
+            [absent_at_bbr, present_at_ram],
+        )
+
+        with driver._lock:  # pyright: ignore[reportPrivateUsage]
+            bbr_result = driver._read_cfg_keys_locked(  # pyright: ignore[reportPrivateUsage]
+                ["CFG_NAVSPG_DYNMODEL"], layer=2
+            )
+            ram_result = driver._read_cfg_keys_locked(  # pyright: ignore[reportPrivateUsage]
+                ["CFG_NAVSPG_DYNMODEL"]
+            )
+
+        assert bbr_result == {}
+        assert ram_result == {"CFG_NAVSPG_DYNMODEL": 2}
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_no_response_raises_no_cfg_valget_error(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        """Total timeout (no CFG-VALGET or ACK-NAK at all) still
+        raises the existing 'no response' error."""
+        driver, _reader = _connect_driver(
+            mock_serial_cls, mock_reader_cls, mock_ubx_msg, []
+        )
+
+        with pytest.raises(RuntimeError, match="No CFG-VALGET response"):
+            with driver._lock:  # pyright: ignore[reportPrivateUsage]
+                driver._read_cfg_keys_locked(  # pyright: ignore[reportPrivateUsage]
+                    ["CFG_NAVSPG_DYNMODEL"]
+                )
+
+
 class TestConfigureBaud:
     """Tests for ``UbloxDriver.configure_baud`` (issue #62)."""
 


### PR DESCRIPTION
## Summary

Implements three independently-scoped, parallel children of spec #93 (Editable one-shot Advanced GPS page):

- Closes #94 — **Prefactor: CFG key reader gains a layer, a NAK branch, and a tri-state result.** `_read_cfg_keys_locked` in the u-blox driver now accepts a layer (defaulting to RAM, no change for existing callers), reports an unrecognised key by omission instead of a `-1` sentinel, and raises immediately on NAK instead of exhausting the read loop and reporting "no response". Converges the driver onto the same pattern the CLI's config-audit poller already used correctly.
- Closes #95 — **Profile identity: optional display name, store overwrite, slug-immortal rename.** `Profile` gains an optional `display_name`; the picker and every provenance label render it with a slug fallback. The built-in ships its human name. Renaming now edits only the display name — the slug/filename/fork references are frozen — and the store gains an `update_profile` overwrite method (rejecting built-ins).
- Closes #96 — **Add the Fixed Position three-step card to the Advanced GPS page.** New card on `/gps-config` showing the profile → survey-in → fixed-position sequence with the receiver's current step highlighted, stating the position is not part of the profile, and linking (not duplicating) to the Survey page for the survey-in/position-setting actions.

## Test plan

- [x] `uv run pyright src/` — 0 errors
- [x] `uv run ruff check` / `ruff format --check` — clean
- [x] `uv run pytest` (unit suite) — 1380 passed, 93.31% coverage (gate 90%)
- [x] `uv run pytest tests/e2e --no-cov` — 66 passed, including new `test_gps_fixed_position_card.py`
- [x] `/code-review` (Standards + Spec axes) — no hard standards violations, no spec gaps or scope creep; two minor judgement-call smells noted (unwired `ProfileStore.update_profile`, a small duplicated label-toggle shape) left as-is since both are deliberate/low-risk

🤖 Generated with [Claude Code](https://claude.com/claude-code)