### PR TITLE
feat(gps): read the whole receiver as one ReceiverAssertion (#97)

### DIFF
--- a/src/sp_rtk_base/models/device_models.py
+++ b/src/sp_rtk_base/models/device_models.py
@@ -428,6 +428,28 @@ class GnssConfig(BaseModel):
         return [s.constellation for s in self.systems if s.enabled]
 
 
+class ReceiverScalarConfig(BaseModel):
+    """Every scalar (non-matrix, non-per-port) CFG value the Advanced GPS
+    page's full receiver read needs — baud, measurement rate, dynamics
+    model, TMODE mode, elevation mask, BeiDou B2 and SPI enablement.
+
+    Read from the receiver in a single CFG-VALGET poll (issue #97),
+    replacing what would otherwise be up to seven separate getters —
+    three of which (dyn model, UART baud, TMODE mode) already existed,
+    the other four (measurement rate, elevation mask, BeiDou B2, SPI)
+    had no standalone getter at all before this.
+    """
+
+    uart1_baud: int = Field(description="UART1 baud rate")
+    uart2_baud: int = Field(description="UART2 baud rate")
+    meas_period_ms: int = Field(description="Measurement period in milliseconds")
+    dyn_model: DynModel = Field(description="Dynamics platform model")
+    tmode_mode: BaseMode = Field(description="Active base station mode")
+    elevation_mask_deg: int = Field(description="Minimum satellite elevation, degrees")
+    bds_b2_enabled: bool = Field(description="Whether the BeiDou B2 signal is enabled")
+    spi_enabled: bool = Field(description="Whether the SPI interface is enabled")
+
+
 # ---------------------------------------------------------------------------
 # Survey-in progress
 # ---------------------------------------------------------------------------

--- a/src/sp_rtk_base/models/profile_models.py
+++ b/src/sp_rtk_base/models/profile_models.py
@@ -25,14 +25,15 @@ from __future__ import annotations
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from sp_rtk_base.models.device_models import (
-    BaseMode as TmodeMode,
-)
-from sp_rtk_base.models.device_models import (
+    ALL_RTCM_MESSAGE_IDS,
     DynModel,
     GnssConstellation,
     PortId,
     RtcmRowId,
     UbxProtocol,
+)
+from sp_rtk_base.models.device_models import (
+    BaseMode as TmodeMode,
 )
 from sp_rtk_base.models.hardware_identity import (
     HARDWARE_ANY,
@@ -65,6 +66,12 @@ _DATA_LINK_CANDIDATE_PORTS: frozenset[PortId] = frozenset({PortId.UART1, PortId.
 
 _SANE_BAUD_MIN = 9600
 _SANE_BAUD_MAX = 921600
+
+#: Ports the RTCM matrix covers, in ``ReceiverAssertion``/``ReceiverConfig``
+#: alike — deliberately excludes I2C/SPI, which the schema doesn't claim.
+#: Public: shared with ``device_service.build_receiver_assertion`` and
+#: ``ui.pages.gps_config`` so the port set is defined in exactly one place.
+MATRIX_PORTS: tuple[PortId, ...] = (PortId.UART1, PortId.UART2, PortId.USB)
 
 
 # ---------------------------------------------------------------------------
@@ -206,3 +213,144 @@ class Profile(ReceiverConfig):
             )
 
         return self
+
+
+# ---------------------------------------------------------------------------
+# ReceiverAssertion — the shape a full receiver read returns (issue #97)
+# ---------------------------------------------------------------------------
+
+
+class BaudAssertion(BaseModel):
+    """Per-UART baud rate, both required — a live read always has both."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    uart1: int = Field(ge=_SANE_BAUD_MIN, le=_SANE_BAUD_MAX)
+    uart2: int = Field(ge=_SANE_BAUD_MIN, le=_SANE_BAUD_MAX)
+
+
+class ReceiverAssertion(BaseModel):
+    """Every receiver field required — no optional values.
+
+    Deliberately symmetric with ``ReceiverConfig``: the same field list
+    Apply will eventually send is the field list a full read returns
+    (``data_link_port`` excepted — that stays page state, inferred from
+    the matrix rather than asserted). Unlike ``ReceiverConfig``, there
+    is no "omitted means leave it alone" here — every field always
+    carries the receiver's actual value, which is exactly what makes a
+    ``ReceiverAssertion`` usable as both ``form`` and ``live`` state: on
+    seed they're equal by construction, and every field the page
+    displays reflects the receiver rather than a schema default.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    baud: BaudAssertion
+    meas_period_ms: int = Field(ge=100, le=60000)
+    constellations: list[GnssConstellation]
+    ports: dict[PortId, PortProtocolSet]
+    dyn_model: DynModel
+    tmode_mode: TmodeMode
+    elevation_mask_deg: int = Field(ge=0, le=90)
+    bds_b2_enabled: bool
+    spi_enabled: bool
+    rtcm_stream: RtcmStreamConfig
+
+
+def _dense_matrix(
+    matrix: dict[RtcmRowId, dict[PortId, bool]],
+) -> dict[RtcmRowId, dict[PortId, bool]]:
+    """Normalize a possibly-sparse row x port matrix to the full catalog
+    x :data:`MATRIX_PORTS` grid (absent cell = off).
+
+    A profile's matrix is sparse by design (``RtcmStreamConfig``: absent
+    cell = off); a live read-back is already dense. Routing both through
+    this same normalization is what makes a merged/live/form matrix
+    comparable by plain equality.
+    """
+    return {
+        row_id: {port: matrix.get(row_id, {}).get(port, False) for port in MATRIX_PORTS}
+        for row_id in ALL_RTCM_MESSAGE_IDS
+    }
+
+
+def merge_profile_into_assertion(
+    profile: Profile, live: ReceiverAssertion
+) -> ReceiverAssertion:
+    """Resolve a profile pick's optional omissions against a live-seeded
+    assertion, producing a fully-populated ``form``.
+
+    Wherever *profile* leaves a field unset, *live*'s value stays in
+    place instead of falling back to a schema default — e.g. the
+    built-in profile omits USB port protocols and ``tmode_mode`` on
+    purpose, and both stay whatever the receiver already reports.
+    ``ports`` is merged per-port (a profile may set some ports and
+    leave others alone); every other field is whole-field.
+
+    ``rtcm_stream`` is the one exception to the omission rule: a
+    profile's matrix is always assertive (absent cell = off, never
+    "leave alone" — see ``RtcmStreamConfig``), so it's taken from
+    *profile* outright, normalized to the same dense grid *live*'s
+    matrix already uses.
+
+    ``meas_period_ms`` is a second, narrower exception, inherited from
+    ``ReceiverConfig`` rather than introduced here: that field is a
+    plain ``int`` defaulting to ``1000`` (see ``ReceiverConfig``), not
+    ``int | None`` like every other optimisation/role field, so a
+    profile that never mentions it is indistinguishable from one that
+    explicitly wants ``1000`` — there is no wire-level "omitted" state
+    to fall back to *live* from. ``profile.meas_period_ms`` is always
+    used as-is.
+
+    A pure, module-level function (issue #97) — no device I/O, no page
+    state — so the omission rule is an explicit, testable merge step
+    rather than implicit driver or page-closure behaviour.
+    """
+    merged_ports = dict(live.ports)
+    if profile.ports is not None:
+        merged_ports.update(profile.ports)
+
+    profile_baud = profile.baud
+    baud = BaudAssertion(
+        uart1=(
+            profile_baud.uart1
+            if profile_baud is not None and profile_baud.uart1 is not None
+            else live.baud.uart1
+        ),
+        uart2=(
+            profile_baud.uart2
+            if profile_baud is not None and profile_baud.uart2 is not None
+            else live.baud.uart2
+        ),
+    )
+
+    return ReceiverAssertion(
+        baud=baud,
+        meas_period_ms=profile.meas_period_ms,
+        constellations=(
+            profile.constellations
+            if profile.constellations is not None
+            else live.constellations
+        ),
+        ports=merged_ports,
+        dyn_model=profile.dyn_model
+        if profile.dyn_model is not None
+        else live.dyn_model,
+        tmode_mode=(
+            profile.tmode_mode if profile.tmode_mode is not None else live.tmode_mode
+        ),
+        elevation_mask_deg=(
+            profile.elevation_mask_deg
+            if profile.elevation_mask_deg is not None
+            else live.elevation_mask_deg
+        ),
+        bds_b2_enabled=(
+            profile.bds_b2_enabled
+            if profile.bds_b2_enabled is not None
+            else live.bds_b2_enabled
+        ),
+        spi_enabled=(
+            profile.spi_enabled if profile.spi_enabled is not None else live.spi_enabled
+        ),
+        rtcm_stream=RtcmStreamConfig(matrix=_dense_matrix(profile.rtcm_stream.matrix)),
+    )

--- a/src/sp_rtk_base/services/device_service.py
+++ b/src/sp_rtk_base/services/device_service.py
@@ -12,9 +12,10 @@ from __future__ import annotations
 import asyncio
 import logging
 from datetime import datetime, timezone
-from typing import Protocol
+from typing import NamedTuple, Protocol
 
 from sp_rtk_base.models.device_models import (
+    ALL_RTCM_MESSAGE_IDS,
     ApplyConfigCellDiff,
     ApplyConfigResult,
     BaseInvariantsCheck,
@@ -28,6 +29,8 @@ from sp_rtk_base.models.device_models import (
     GpsPosition,
     PortId,
     PortProtocolConfig,
+    ReceiverScalarConfig,
+    RtcmOutputPort,
     RtcmPortConfig,
     RtcmRowId,
     SurveyInConfig,
@@ -37,7 +40,14 @@ from sp_rtk_base.models.device_models import (
 from sp_rtk_base.models.device_models import (
     BaseMode as TmodeMode,
 )
-from sp_rtk_base.models.profile_models import ReceiverConfig
+from sp_rtk_base.models.profile_models import (
+    MATRIX_PORTS,
+    BaudAssertion,
+    PortProtocolSet,
+    ReceiverAssertion,
+    ReceiverConfig,
+    RtcmStreamConfig,
+)
 from sp_rtk_base.profiles import BUILTIN_PROFILES
 from sp_rtk_base.services.drivers.base import GpsReceiverDriver
 
@@ -158,6 +168,61 @@ def _throughput_warnings(
                 "— consider a higher baud rate or fewer messages."
             )
     return warnings
+
+
+def build_receiver_assertion(
+    rtcm: RtcmPortConfig,
+    ports: PortProtocolConfig,
+    gnss: GnssConfig,
+    scalars: ReceiverScalarConfig,
+) -> ReceiverAssertion:
+    """Compose a full live receiver read into one ``ReceiverAssertion``.
+
+    Pure — reshapes the driver's four already-fetched reads (RTCM
+    matrix, port protocols, GNSS constellations, the batched scalar
+    poll) into the schema the Advanced GPS page seeds ``form``/``live``
+    from (issue #97). No device I/O of its own.
+    """
+    matrix = {
+        row_id: {
+            port: rtcm.is_enabled(row_id, RtcmOutputPort(port.value))
+            for port in MATRIX_PORTS
+        }
+        for row_id in ALL_RTCM_MESSAGE_IDS
+    }
+    port_set = {
+        port: PortProtocolSet(
+            **{"in": ports.enabled_in(port), "out": ports.enabled_out(port)}
+        )
+        for port in PortId
+    }
+    return ReceiverAssertion(
+        baud=BaudAssertion(uart1=scalars.uart1_baud, uart2=scalars.uart2_baud),
+        meas_period_ms=scalars.meas_period_ms,
+        constellations=gnss.enabled_constellations(),
+        ports=port_set,
+        dyn_model=scalars.dyn_model,
+        tmode_mode=scalars.tmode_mode,
+        elevation_mask_deg=scalars.elevation_mask_deg,
+        bds_b2_enabled=scalars.bds_b2_enabled,
+        spi_enabled=scalars.spi_enabled,
+        rtcm_stream=RtcmStreamConfig(matrix=matrix),
+    )
+
+
+class ReceiverAssertionRead(NamedTuple):
+    """One ``get_receiver_assertion()`` read: the sync-set assertion plus
+    the raw multi-port RTCM read-back the page's I2C/SPI advisory needs.
+
+    I2C/SPI aren't part of ``assertion.rtcm_stream``'s matrix — that
+    mirrors ``ReceiverConfig``'s UART1/UART2/USB-only scope — so the
+    advisory display needs the wider read ``rtcm`` already carries.
+    Bundling both here means one receiver read serves both, rather than
+    the page re-polling RTCM a second time.
+    """
+
+    assertion: ReceiverAssertion
+    rtcm: RtcmPortConfig
 
 
 class DeviceService:
@@ -679,6 +744,34 @@ class DeviceService:
         """
         driver = self._require_connected()
         return await asyncio.to_thread(driver.get_base_config)
+
+    async def get_receiver_assertion(self) -> ReceiverAssertionRead:
+        """Read the whole receiver in one go as a ``ReceiverAssertion``.
+
+        Four driver reads — RTCM matrix, port protocols, GNSS
+        constellations, and the batched scalar poll (baud, meas rate,
+        dyn model, tmode mode, elevation mask, BeiDou B2, SPI) — landing
+        as three CFG-VALGET polls rather than seven separate round
+        trips, composed by the pure :func:`build_receiver_assertion`
+        (issue #97). Every field the Advanced GPS page seeds ``form``/
+        ``live`` from reflects the receiver's actual value.
+
+        Returns the raw RTCM read alongside the assertion — the page's
+        I2C/SPI advisory needs it (ports the matrix doesn't claim), and
+        re-polling it separately would reintroduce exactly the extra
+        lock-acquire/RX-drain/read-loop round trip this method exists
+        to collapse away.
+
+        Raises:
+            RuntimeError: If not connected.
+        """
+        driver = self._require_connected()
+        rtcm = await asyncio.to_thread(driver.get_rtcm_port_config)
+        ports = await asyncio.to_thread(driver.get_port_protocols)
+        gnss = await asyncio.to_thread(driver.get_gnss_config)
+        scalars = await asyncio.to_thread(driver.get_receiver_scalars)
+        assertion = build_receiver_assertion(rtcm, ports, gnss, scalars)
+        return ReceiverAssertionRead(assertion=assertion, rtcm=rtcm)
 
     async def configure_gnss(self, config: GnssConfig) -> None:
         """Write GNSS constellation configuration to the receiver.

--- a/src/sp_rtk_base/services/drivers/base.py
+++ b/src/sp_rtk_base/services/drivers/base.py
@@ -20,6 +20,7 @@ from sp_rtk_base.models.device_models import (
     GpsPosition,
     PortId,
     PortProtocolConfig,
+    ReceiverScalarConfig,
     RtcmPortConfig,
     RtcmRowId,
     SerialPortInfo,
@@ -326,6 +327,22 @@ class GpsReceiverDriver(abc.ABC):
         Raises:
             ConnectionError: If not connected.
             RuntimeError: If the write fails.
+        """
+
+    @abc.abstractmethod
+    def get_receiver_scalars(self) -> ReceiverScalarConfig:
+        """Batched read of every scalar CFG value the full receiver read needs.
+
+        Baud (UART1/UART2), measurement rate, dynamics model, TMODE
+        mode, elevation mask, BeiDou B2 and SPI enablement — one poll
+        instead of up to seven separate getters (issue #97).
+
+        Returns:
+            The current scalar configuration.
+
+        Raises:
+            ConnectionError: If not connected.
+            RuntimeError: If the read fails.
         """
 
     @abc.abstractmethod

--- a/src/sp_rtk_base/services/drivers/fake.py
+++ b/src/sp_rtk_base/services/drivers/fake.py
@@ -64,6 +64,7 @@ from sp_rtk_base.models.device_models import (
     GpsPosition,
     PortId,
     PortProtocolConfig,
+    ReceiverScalarConfig,
     RtcmPortConfig,
     RtcmRowId,
     SerialPortInfo,
@@ -494,6 +495,20 @@ class FakeGpsDriver(GpsReceiverDriver):
             self._uart_baud_rates[PortId.UART1] = uart1
         if uart2 is not None:
             self._uart_baud_rates[PortId.UART2] = uart2
+
+    def get_receiver_scalars(self) -> ReceiverScalarConfig:
+        """Return the fake driver's in-memory scalar config (issue #97)."""
+        self._ensure_connected()
+        return ReceiverScalarConfig(
+            uart1_baud=self._uart_baud_rates[PortId.UART1],
+            uart2_baud=self._uart_baud_rates[PortId.UART2],
+            meas_period_ms=self._meas_period_ms,
+            dyn_model=self._dyn_model,
+            tmode_mode=self._base_config.mode,
+            elevation_mask_deg=self._elevation_mask_deg,
+            bds_b2_enabled=self._bds_b2_enabled,
+            spi_enabled=self._spi_enabled,
+        )
 
     def reconnect_at_baud(self, baud_rate: int) -> DeviceInfo:
         """Simulate reopening at a new baud — no I/O, always succeeds."""

--- a/src/sp_rtk_base/services/drivers/ublox.py
+++ b/src/sp_rtk_base/services/drivers/ublox.py
@@ -40,6 +40,7 @@ from sp_rtk_base.models.device_models import (
     GpsPosition,
     PortId,
     PortProtocolConfig,
+    ReceiverScalarConfig,
     RtcmOutputPort,
     RtcmPortConfig,
     RtcmRowId,
@@ -140,6 +141,23 @@ _TMODE_MODE_VALUES: dict[BaseMode, int] = {
     BaseMode.SURVEY_IN: 1,
     BaseMode.FIXED: 2,
 }
+
+# Reverse of ``_TMODE_MODE_VALUES`` — for ``get_receiver_scalars``'s
+# read-back and ``_parse_cfg_tmode``.
+_TMODE_MODE_NAMES: dict[int, BaseMode] = {v: k for k, v in _TMODE_MODE_VALUES.items()}
+
+# The scalar CFG keys ``get_receiver_scalars`` polls in one CFG-VALGET
+# round trip (issue #97) — 8 keys, well under the 64-key poll cap.
+_RECEIVER_SCALAR_KEYS: list[str] = [
+    "CFG_UART1_BAUDRATE",
+    "CFG_UART2_BAUDRATE",
+    "CFG_RATE_MEAS",
+    "CFG_NAVSPG_DYNMODEL",
+    "CFG_TMODE_MODE",
+    "CFG_NAVSPG_INFIL_MINELEV",
+    "CFG_SIGNAL_BDS_B2_ENA",
+    "CFG_SPI_ENABLED",
+]
 
 # Ports the RTCM matrix write covers — deliberately excludes I2C/SPI,
 # which the profile schema doesn't claim (see RtcmStreamConfig).
@@ -1228,6 +1246,29 @@ class UbloxDriver(GpsReceiverDriver):
         with self._lock:
             self._send_cfg_valset_locked(cfg_data, layer=5)
 
+    def get_receiver_scalars(self) -> ReceiverScalarConfig:
+        """Batched read of baud, meas rate, dyn model, tmode mode and the
+        three optimisation fields — one CFG-VALGET poll (issue #97).
+
+        Replaces what would otherwise be up to seven separate getters:
+        the three that already existed (``get_dyn_model``,
+        ``get_uart_baud_rates``, the TMODE portion of ``get_base_config``)
+        plus the four that had no standalone getter at all
+        (measurement rate, elevation mask, BeiDou B2, SPI).
+        """
+        with self._lock:
+            raw = self._read_cfg_keys_locked(_RECEIVER_SCALAR_KEYS)
+        return ReceiverScalarConfig(
+            uart1_baud=raw["CFG_UART1_BAUDRATE"],
+            uart2_baud=raw["CFG_UART2_BAUDRATE"],
+            meas_period_ms=raw["CFG_RATE_MEAS"],
+            dyn_model=_DYN_MODEL_NAMES[raw["CFG_NAVSPG_DYNMODEL"]],
+            tmode_mode=_TMODE_MODE_NAMES[raw["CFG_TMODE_MODE"]],
+            elevation_mask_deg=raw["CFG_NAVSPG_INFIL_MINELEV"],
+            bds_b2_enabled=bool(raw["CFG_SIGNAL_BDS_B2_ENA"]),
+            spi_enabled=bool(raw["CFG_SPI_ENABLED"]),
+        )
+
     def reconnect_at_baud(self, baud_rate: int) -> DeviceInfo:
         """Reopen the serial port at ``baud_rate`` without resetting the receiver.
 
@@ -1717,12 +1758,7 @@ class UbloxDriver(GpsReceiverDriver):
         - POS_TYPE=1 (LLH): reads LAT/LON/HEIGHT directly
         """
         mode_raw = int(getattr(parsed, "CFG_TMODE_MODE", 0))
-        _MODE_MAP: dict[int, BaseMode] = {
-            0: BaseMode.DISABLED,
-            1: BaseMode.SURVEY_IN,
-            2: BaseMode.FIXED,
-        }
-        mode = _MODE_MAP.get(mode_raw, BaseMode.DISABLED)
+        mode = _TMODE_MODE_NAMES.get(mode_raw, BaseMode.DISABLED)
 
         pos_type_raw = int(getattr(parsed, "CFG_TMODE_POS_TYPE", 1))
         # CFG_TMODE_FIXED_POS_ACC is in 0.1 mm units on the wire —

--- a/src/sp_rtk_base/ui/pages/gps_config.py
+++ b/src/sp_rtk_base/ui/pages/gps_config.py
@@ -57,10 +57,8 @@ from sp_rtk_base.models.device_models import (
     DeviceCapability,
     DeviceConnectionState,
     DynModel,
-    GnssConfig,
     GnssConstellation,
     PortId,
-    PortProtocolConfig,
     RtcmOutputPort,
     RtcmPortConfig,
     RtcmRowId,
@@ -81,11 +79,15 @@ from sp_rtk_base.models.hardware_identity import (
     is_compatible,
 )
 from sp_rtk_base.models.profile_models import (
+    MATRIX_PORTS,
+    BaudAssertion,
     BaudConfig,
     PortProtocolSet,
     Profile,
+    ReceiverAssertion,
     ReceiverConfig,
     RtcmStreamConfig,
+    merge_profile_into_assertion,
 )
 from sp_rtk_base.services import (
     get_config_service,
@@ -115,11 +117,6 @@ _GNSS_DISPLAY: list[tuple[str, str]] = [
     ("sbas", "SBAS"),
     ("qzss", "QZSS"),
 ]
-
-#: Ports the boolean RTCM matrix covers — matches
-#: ``RtcmStreamConfig.matrix``'s column set (``PortId``), not the full
-#: 5-port live read-back.
-MATRIX_PORTS: list[PortId] = [PortId.UART1, PortId.UART2, PortId.USB]
 
 #: Data-link-capable ports — highlighted matrix columns. Mirrors
 #: ``profile_models._DATA_LINK_CANDIDATE_PORTS`` (USB excluded).
@@ -256,43 +253,24 @@ def apply_blocked_reason(data_link_port: list[PortId]) -> str | None:
     return None
 
 
-@dataclass
-class FormExtras:
-    """The hardware-section fields beyond the matrix and data-link ports.
-
-    Not editable via any widget on this page yet (see the module
-    docstring) — this only carries values a *profile pick* pre-fills,
-    so Apply can push them and Save-as / "modified from X" can compare
-    against them. ``None`` mirrors ``ReceiverConfig``'s own "leave
-    untouched" semantics for every field except ``meas_period_ms``,
-    which ``ReceiverConfig`` itself always defaults to ``1000``.
-    """
-
-    ports: dict[PortId, PortProtocolSet] | None = None
-    constellations: list[GnssConstellation] | None = None
-    baud: BaudConfig | None = None
-    meas_period_ms: int = 1000
-    dyn_model: DynModel | None = None
-    tmode_mode: TmodeMode | None = None
-    elevation_mask_deg: int | None = None
-    bds_b2_enabled: bool | None = None
-    spi_enabled: bool | None = None
-
-
 def build_apply_config(
     matrix: dict[RtcmRowId, dict[PortId, bool]],
     data_link_port: list[PortId],
-    extras: FormExtras | None = None,
+    assertion: ReceiverAssertion | None = None,
 ) -> ReceiverConfig:
     """Build a ``ReceiverConfig`` from the form state.
 
-    *extras* defaults to an all-``None`` :class:`FormExtras` — nothing
-    but the matrix and data-link ports set. ``_apply()`` always uses
-    that default (Apply stays scoped to the matrix + data-link ports,
-    per #65 — the other fields have no live read-back to verify a
-    write against). Save-as and the "modified from X" comparison pass
-    the real *extras* through, since those only compare in-form state
-    and never touch the receiver.
+    *assertion* defaults to ``None`` — nothing but the matrix and
+    data-link ports set. ``_apply()`` always uses that default (Apply
+    stays scoped to the matrix + data-link ports, per #65 — the other
+    fields have no live read-back to verify a write against). Save-as
+    and the "modified from X" comparison pass the current ``form``
+    :class:`ReceiverAssertion` through, since those only compare
+    in-form state and never touch the receiver. *matrix* is always
+    passed explicitly, even when it's the same value as
+    ``assertion.rtcm_stream.matrix`` — every caller that has an
+    *assertion* happens to derive *matrix* from it directly beforehand,
+    so the two never actually diverge in practice.
 
     Raises:
         pydantic.ValidationError: If the resulting config fails a
@@ -300,82 +278,55 @@ def build_apply_config(
             data-link port) — a client-side pre-write refusal, nothing
             is sent to the receiver.
     """
-    extras = extras or FormExtras()
+    if assertion is None:
+        return ReceiverConfig(
+            data_link_port=data_link_port,
+            rtcm_stream=RtcmStreamConfig(matrix=matrix),
+        )
     return ReceiverConfig(
-        ports=extras.ports,
-        constellations=extras.constellations,
-        baud=extras.baud,
-        meas_period_ms=extras.meas_period_ms,
-        dyn_model=extras.dyn_model,
-        tmode_mode=extras.tmode_mode,
-        elevation_mask_deg=extras.elevation_mask_deg,
-        bds_b2_enabled=extras.bds_b2_enabled,
-        spi_enabled=extras.spi_enabled,
+        ports=assertion.ports,
+        constellations=assertion.constellations,
+        baud=BaudConfig(uart1=assertion.baud.uart1, uart2=assertion.baud.uart2),
+        meas_period_ms=assertion.meas_period_ms,
+        dyn_model=assertion.dyn_model,
+        tmode_mode=assertion.tmode_mode,
+        elevation_mask_deg=assertion.elevation_mask_deg,
+        bds_b2_enabled=assertion.bds_b2_enabled,
+        spi_enabled=assertion.spi_enabled,
         data_link_port=data_link_port,
         rtcm_stream=RtcmStreamConfig(matrix=matrix),
     )
 
 
-def profile_matrix_to_form_matrix(
-    profile: Profile,
-) -> dict[RtcmRowId, dict[PortId, bool]]:
-    """Normalize a profile's sparse matrix to the full catalog x port grid.
-
-    Mirrors :func:`rtcm_config_to_matrix` — the form's out-of-sync
-    comparison relies on every matrix always covering every catalog
-    row x :data:`MATRIX_PORTS` cell, whether it was seeded from a live
-    read-back or, here, a profile pick.
-    """
-    matrix = profile.rtcm_stream.matrix
-    return {
-        row_id: {port: matrix.get(row_id, {}).get(port, False) for port in MATRIX_PORTS}
-        for row_id in ALL_RTCM_MESSAGE_IDS
-    }
-
-
-def profile_to_form_extras(profile: Profile) -> FormExtras:
-    """Everything a profile pick writes into the form besides matrix/data-link."""
-    return FormExtras(
-        ports=profile.ports,
-        constellations=profile.constellations,
-        baud=profile.baud,
-        meas_period_ms=profile.meas_period_ms,
-        dyn_model=profile.dyn_model,
-        tmode_mode=profile.tmode_mode,
-        elevation_mask_deg=profile.elevation_mask_deg,
-        bds_b2_enabled=profile.bds_b2_enabled,
-        spi_enabled=profile.spi_enabled,
-    )
-
-
-def receiver_config_from_profile(profile: Profile) -> ReceiverConfig:
-    """The ``ReceiverConfig`` a profile carries, with identity stripped.
+def receiver_config_from_profile(
+    profile: Profile, live: ReceiverAssertion
+) -> ReceiverConfig:
+    """The ``ReceiverConfig`` picking *profile* against *live* would produce,
+    with identity stripped.
 
     Used to compare "the form" against "the selected profile" as the
     same type — a ``Profile`` is a ``ReceiverConfig`` plus identity
     fields, and those must not participate in the "modified from X"
     equality check.
 
-    Deliberately built through :func:`build_apply_config` with the
-    same :func:`profile_matrix_to_form_matrix`/:func:`profile_to_form_extras`
-    normalization :func:`_select_profile` (in the page closure) uses to
-    seed the form from this same profile — a stored profile's matrix is
-    *sparse* (absent cell = off), while the form's is always *dense*
-    (every catalog row x port present). Comparing a freshly-picked,
-    untouched form against ``ReceiverConfig(**profile.model_dump())``
-    would almost always report "modified" — the same on/off state,
-    represented as two differently-shaped dicts that don't compare
-    equal — unless both sides go through the identical normalization.
+    Deliberately built through the same :func:`merge_profile_into_assertion`
+    resolution :func:`_select_profile` (in the page closure) uses to seed
+    the form from this same profile against the current *live* state —
+    a stored profile's matrix is *sparse* (absent cell = off) and its
+    optional fields mean "leave the live value alone", while the form
+    is always fully populated. Comparing a freshly-picked, untouched
+    form against a bare ``profile.model_dump()`` would almost always
+    report "modified" unless both sides go through the identical
+    resolution.
     """
+    merged = merge_profile_into_assertion(profile, live)
     return build_apply_config(
-        profile_matrix_to_form_matrix(profile),
-        list(profile.data_link_port),
-        profile_to_form_extras(profile),
+        merged.rtcm_stream.matrix, list(profile.data_link_port), merged
     )
 
 
 def is_modified_from_profile(
-    form_config: ReceiverConfig, profile: Profile | None
+    form_config: ReceiverConfig, profile: Profile | None, live: ReceiverAssertion
 ) -> bool:
     """Whether *form_config* diverges from *profile* — the second, independent
     indicator (form vs. selected profile), distinct from "out of sync" (form
@@ -383,17 +334,17 @@ def is_modified_from_profile(
     nothing to have diverged from."""
     if profile is None:
         return False
-    return form_config != receiver_config_from_profile(profile)
+    return form_config != receiver_config_from_profile(profile, live)
 
 
 def save_as_enabled(
-    form_config: ReceiverConfig | None, profile: Profile | None
+    form_config: ReceiverConfig | None, profile: Profile | None, live: ReceiverAssertion
 ) -> bool:
     """Save-as is available whenever the form is valid, suppressed only when
     a *selected* profile still exactly equals the form."""
     if form_config is None:
         return False
-    return profile is None or is_modified_from_profile(form_config, profile)
+    return profile is None or is_modified_from_profile(form_config, profile, live)
 
 
 def suggest_profile_name(profile: Profile | None, hardware_target: str) -> str:
@@ -449,82 +400,54 @@ def build_saved_profile(
 
 
 def resolve_ports_display(
-    live: PortProtocolConfig,
-    form_ports: dict[PortId, PortProtocolSet] | None,
+    ports: dict[PortId, PortProtocolSet],
 ) -> dict[PortId, tuple[list[str], list[str]]]:
     """Per-port (in, out) protocol name lists the "Port Protocols" display
-    renders — the live read-back, unless a profile pick set *form_ports*, in
-    which case the form is the source of truth (issue #66)."""
-    if form_ports is not None:
-        empty = PortProtocolSet()
-        return {
-            port: (
-                [p.value for p in form_ports.get(port, empty).in_],
-                [p.value for p in form_ports.get(port, empty).out],
-            )
-            for port in (PortId.UART1, PortId.UART2, PortId.USB)
-        }
+    renders, straight from the form's always-populated ``ports`` map."""
+    empty = PortProtocolSet()
     return {
         port: (
-            [p.value for p in live.enabled_in(port)],
-            [p.value for p in live.enabled_out(port)],
+            [p.value for p in ports.get(port, empty).in_],
+            [p.value for p in ports.get(port, empty).out],
         )
         for port in (PortId.UART1, PortId.UART2, PortId.USB)
     }
 
 
-def resolve_gnss_display(
-    live: GnssConfig,
-    form_constellations: list[GnssConstellation] | None,
-) -> dict[str, bool]:
+def resolve_gnss_display(constellations: list[GnssConstellation]) -> dict[str, bool]:
     """Constellation -> enabled map the "GNSS Constellations" display
-    renders — the live read-back, unless a profile pick set
-    *form_constellations*, in which case only those are enabled."""
-    if form_constellations is not None:
-        wanted = set(form_constellations)
-        return {c.value: c in wanted for c in GnssConstellation}
-    return {sys_cfg.constellation.value: sys_cfg.enabled for sys_cfg in live.systems}
+    renders, straight from the form's always-populated ``constellations``
+    list."""
+    wanted = set(constellations)
+    return {c.value: c in wanted for c in GnssConstellation}
 
 
-def _tri_state_text(value: bool | None) -> str:
-    """``"on"``/``"off"``/``"unchanged"`` for an optional bool form field."""
-    return "unchanged" if value is None else ("on" if value else "off")
-
-
-def hw_extras_display(extras: FormExtras) -> list[tuple[str, str, str]]:
+def hw_extras_display(assertion: ReceiverAssertion) -> list[tuple[str, str, str]]:
     """(css-class, label, value) triples the "Hardware Section" display
-    renders — every :class:`FormExtras` field the matrix/ports/GNSS views
-    don't already cover."""
-    baud_parts: list[str] = []
-    if extras.baud is not None:
-        if extras.baud.uart1 is not None:
-            baud_parts.append(f"UART1={extras.baud.uart1}")
-        if extras.baud.uart2 is not None:
-            baud_parts.append(f"UART2={extras.baud.uart2}")
-
-    hz = 1000 / extras.meas_period_ms
+    renders — every :class:`ReceiverAssertion` field the matrix/ports/GNSS
+    views don't already cover. Every field is always populated (issue
+    #97), so every value shown is real — never a placeholder."""
+    hz = 1000 / assertion.meas_period_ms
     return [
         ("hw-field-meas-rate", "Measurement Rate", f"{hz:g} Hz"),
-        ("hw-field-baud", "Baud", ", ".join(baud_parts) or "unchanged"),
         (
-            "hw-field-dyn-model",
-            "Dynamics Model",
-            extras.dyn_model.value if extras.dyn_model else "unchanged",
+            "hw-field-baud",
+            "Baud",
+            f"UART1={assertion.baud.uart1}, UART2={assertion.baud.uart2}",
         ),
-        (
-            "hw-field-tmode",
-            "Time Mode",
-            extras.tmode_mode.value if extras.tmode_mode else "unchanged",
-        ),
+        ("hw-field-dyn-model", "Dynamics Model", assertion.dyn_model.value),
+        ("hw-field-tmode", "Time Mode", assertion.tmode_mode.value),
         (
             "hw-field-elevation-mask",
             "Elevation Mask",
-            f"{extras.elevation_mask_deg}°"
-            if extras.elevation_mask_deg is not None
-            else "unchanged",
+            f"{assertion.elevation_mask_deg}°",
         ),
-        ("hw-field-bds-b2", "BeiDou B2", _tri_state_text(extras.bds_b2_enabled)),
-        ("hw-field-spi", "SPI", _tri_state_text(extras.spi_enabled)),
+        (
+            "hw-field-bds-b2",
+            "BeiDou B2",
+            "on" if assertion.bds_b2_enabled else "off",
+        ),
+        ("hw-field-spi", "SPI", "on" if assertion.spi_enabled else "off"),
     ]
 
 
@@ -539,6 +462,23 @@ def copy_matrix(
     comparison.
     """
     return {row: dict(ports) for row, ports in matrix.items()}
+
+
+def placeholder_assertion() -> ReceiverAssertion:
+    """An empty ``ReceiverAssertion`` for the page's pre-connect state,
+    before any live receiver read has happened."""
+    return ReceiverAssertion(
+        baud=BaudAssertion(uart1=DEFAULT_BAUD, uart2=DEFAULT_BAUD),
+        meas_period_ms=1000,
+        constellations=[],
+        ports={},
+        dyn_model=DynModel.PORTABLE,
+        tmode_mode=TmodeMode.DISABLED,
+        elevation_mask_deg=0,
+        bds_b2_enabled=False,
+        spi_enabled=False,
+        rtcm_stream=RtcmStreamConfig(matrix=rtcm_config_to_matrix(RtcmPortConfig())),
+    )
 
 
 def format_cell_diff(diff: ApplyConfigCellDiff) -> str:
@@ -1063,11 +1003,10 @@ def gps_config_page() -> None:
             source of truth afterwards: further matrix/data-link edits
             mutate it same as before, independent of the profile pick.
             """
-            nonlocal selected_profile, form_matrix, form_data_link_ports, form_extras
+            nonlocal selected_profile, form, form_data_link_ports
             selected_profile = profile
-            form_matrix = profile_matrix_to_form_matrix(profile)
+            form = merge_profile_into_assertion(profile, live)
             form_data_link_ports = list(profile.data_link_port)
-            form_extras = profile_to_form_extras(profile)
 
             _render_matrix()
             _render_ports_view()
@@ -1261,37 +1200,34 @@ def gps_config_page() -> None:
             else:
                 error_label.set_visibility(False)
 
-        # Editable form state (issue #65) — seeded from the live receiver on
-        # every load/reload/reconnect, then mutated by matrix clicks and the
-        # data-link checkboxes until the next Apply or reseed.
-        form_matrix: dict[RtcmRowId, dict[PortId, bool]] = rtcm_config_to_matrix(
-            RtcmPortConfig()
-        )
-        live_matrix: dict[RtcmRowId, dict[PortId, bool]] = copy_matrix(form_matrix)
+        # Editable form state (issue #97) — a ``form``/``live`` assertion
+        # pair plus the data-link port selection, seeded from the live
+        # receiver on every load/reload/reconnect. ``form`` holds operator
+        # intent (mutated by matrix clicks, profile picks, and the
+        # data-link checkboxes until the next Apply or reseed); ``live``
+        # holds receiver truth. On seed they are equal by construction.
+        form: ReceiverAssertion = placeholder_assertion()
+        live: ReceiverAssertion = form.model_copy(deep=True)
         form_data_link_ports: list[PortId] = []
 
-        # Issue #66 additions — the rest of the "hardware section" (ports,
-        # GNSS, baud, role fields, optimisations), the profile a pick
-        # selected (None = no pick, the default/transient state), and the
-        # live ports/GNSS read-backs the "Port Protocols"/"GNSS
-        # Constellations" display falls back to when no profile is picked.
-        form_extras = FormExtras()
+        # The profile a pick selected (None = no pick, the default/
+        # transient state).
         selected_profile: Profile | None = None
-        live_ports = PortProtocolConfig()
-        live_gnss = GnssConfig()
         rename_target: str | None = None
         delete_target: str | None = None
         delete_target_label: str = ""
 
         def _out_of_sync() -> bool:
-            return form_matrix != live_matrix
+            """Matrix-only, matching what Apply actually pushes (#65/#66) —
+            the rest of ``form`` has no live read-back to verify against."""
+            return form.rtcm_stream.matrix != live.rtcm_stream.matrix
 
         def _current_form_config() -> ReceiverConfig | None:
             """The form as a ``ReceiverConfig``, or ``None`` if it doesn't
             currently validate (e.g. no data-link port selected)."""
             try:
                 return build_apply_config(
-                    form_matrix, form_data_link_ports, form_extras
+                    form.rtcm_stream.matrix, form_data_link_ports, form
                 )
             except ValidationError:
                 return None
@@ -1299,7 +1235,7 @@ def gps_config_page() -> None:
         def _render_ports_view() -> None:
             ports_view.clear()
             with ports_view:
-                display = resolve_ports_display(live_ports, form_extras.ports)
+                display = resolve_ports_display(form.ports)
                 for port_id in (PortId.UART1, PortId.UART2, PortId.USB):
                     in_names, out_names = display[port_id]
                     with ui.row().classes("items-center gap-2"):
@@ -1316,9 +1252,7 @@ def gps_config_page() -> None:
         def _render_gnss_view() -> None:
             gnss_view.clear()
             with gnss_view:
-                enabled_map = resolve_gnss_display(
-                    live_gnss, form_extras.constellations
-                )
+                enabled_map = resolve_gnss_display(form.constellations)
                 for c_val, c_name in _GNSS_DISPLAY:
                     enabled = enabled_map.get(c_val, False)
                     ui.badge(c_name).props(
@@ -1328,13 +1262,15 @@ def gps_config_page() -> None:
         def _render_hw_extras_view() -> None:
             hw_extras_view.clear()
             with hw_extras_view:
-                for css_class, label, value in hw_extras_display(form_extras):
+                for css_class, label, value in hw_extras_display(form):
                     with ui.column().classes(f"{css_class} gap-0"):
                         ui.label(label).classes("text-caption text-grey-5")
                         ui.label(value).classes("text-white")
 
         def _toggle_matrix_cell(msg_id: RtcmRowId, port: PortId) -> None:
-            form_matrix[msg_id][port] = not form_matrix[msg_id][port]
+            form.rtcm_stream.matrix[msg_id][port] = not form.rtcm_stream.matrix[msg_id][
+                port
+            ]
             _render_matrix()
             _on_form_changed()
 
@@ -1386,7 +1322,7 @@ def gps_config_page() -> None:
                                     ui.badge("Required").props("outline color=warning")
 
                             for port in MATRIX_PORTS:
-                                on = form_matrix[msg_id][port]
+                                on = form.rtcm_stream.matrix[msg_id][port]
                                 cell_classes = (
                                     f"rtcm-cell rtcm-cell-{slug}-{port.value} "
                                     "text-center cursor-pointer"
@@ -1402,7 +1338,7 @@ def gps_config_page() -> None:
                                 )
 
         def _render_data_link_picker() -> None:
-            inferred = infer_data_link_ports(form_matrix)
+            inferred = infer_data_link_ports(form.rtcm_stream.matrix)
             data_link_hint.text = (
                 f"Inferred from current RTCM state: "
                 f"{', '.join(p.value for p in inferred)}"
@@ -1452,7 +1388,7 @@ def gps_config_page() -> None:
                 modified_badge.set_visibility(False)
                 return
             modified_badge.set_visibility(True)
-            if is_modified_from_profile(form_config, selected_profile):
+            if is_modified_from_profile(form_config, selected_profile, live):
                 modified_badge.text = f"Modified from {display_label(selected_profile)}"
                 modified_badge.props("color=warning")
             else:
@@ -1461,7 +1397,7 @@ def gps_config_page() -> None:
 
         def _render_save_as_gate() -> None:
             save_as_btn.set_enabled(
-                save_as_enabled(_current_form_config(), selected_profile)
+                save_as_enabled(_current_form_config(), selected_profile, live)
             )
 
         def _on_form_changed() -> None:
@@ -1501,19 +1437,22 @@ def gps_config_page() -> None:
         async def _apply() -> None:
             """Push the current form (matrix + data-link ports) to the receiver.
 
-            Deliberately excludes ``form_extras`` (issue #66 review):
-            those fields have no live read-back, so a profile-populated
-            value pushed through Apply could never be verified by the
-            read-back-diff below, unlike the matrix. Extending Apply to
-            the full hardware section is out of #66's scope — it isn't
-            in the acceptance criteria, and #65 deliberately scoped
-            Apply to "only the RTCM matrix and the data-link ports".
-            ``form_extras`` is still used for Save-as/"modified from X",
-            which compare in-form state and never touch the receiver.
+            Deliberately excludes the rest of ``form`` (issue #66
+            review): those fields have no live read-back, so a
+            profile-populated value pushed through Apply could never be
+            verified by the read-back-diff below, unlike the matrix.
+            Extending Apply to the full hardware section is out of
+            #66's scope — it isn't in the acceptance criteria, and #65
+            deliberately scoped Apply to "only the RTCM matrix and the
+            data-link ports". The rest of ``form`` is still used for
+            Save-as/"modified from X", which compare in-form state and
+            never touch the receiver.
             """
-            nonlocal live_matrix
+            nonlocal live
             try:
-                config = build_apply_config(form_matrix, form_data_link_ports)
+                config = build_apply_config(
+                    form.rtcm_stream.matrix, form_data_link_ports
+                )
             except ValidationError as exc:
                 _set_apply_result(
                     f"Apply refused: {exc.errors()[0]['msg']} — nothing was written.",
@@ -1538,15 +1477,25 @@ def gps_config_page() -> None:
                 return
 
             if result.status == "ok":
-                live_matrix = copy_matrix(form_matrix)
+                live = live.model_copy(
+                    update={
+                        "rtcm_stream": RtcmStreamConfig(
+                            matrix=copy_matrix(form.rtcm_stream.matrix)
+                        )
+                    }
+                )
                 _set_apply_result("Applied and verified ✓", ok=True)
                 ui.notify("Applied and verified ✓", type="positive")
             else:
                 # The writes landed but the read-back disagrees — reflect
                 # the receiver's *actual* state so "out of sync" stays
                 # honest even though only a successful apply clears it.
+                new_matrix = copy_matrix(live.rtcm_stream.matrix)
                 for cell in result.diff:
-                    live_matrix[cell.row_id][cell.port] = cell.actual
+                    new_matrix[cell.row_id][cell.port] = cell.actual
+                live = live.model_copy(
+                    update={"rtcm_stream": RtcmStreamConfig(matrix=new_matrix)}
+                )
                 _set_apply_result(
                     "Applied, but verification found mismatches — nothing "
                     "was rolled back.",
@@ -1634,19 +1583,19 @@ def gps_config_page() -> None:
             per spec — the form always re-seeds from the live receiver,
             never from the last-loaded profile.
             """
-            nonlocal form_matrix, live_matrix, form_data_link_ports
-            nonlocal form_extras, selected_profile, live_ports, live_gnss
-            rtcm = await svc.get_rtcm_port_config()
-            ports = await svc.get_port_protocols()
-            gnss = await svc.get_gnss_config()
-
-            form_matrix = rtcm_config_to_matrix(rtcm)
-            live_matrix = copy_matrix(form_matrix)
-            form_data_link_ports = infer_data_link_ports(form_matrix)
-            form_extras = FormExtras()
+            nonlocal form, live, form_data_link_ports, selected_profile
+            read = await svc.get_receiver_assertion()
+            live = read.assertion
+            form = live.model_copy(deep=True)
+            form_data_link_ports = infer_data_link_ports(live.rtcm_stream.matrix)
             selected_profile = None
-            live_ports = ports
-            live_gnss = gnss
+
+            # The I2C/SPI advisory (rows enabled on a port the matrix
+            # doesn't manage) needs the raw multi-port read-back, which
+            # ``ReceiverAssertion`` doesn't carry — ``read.rtcm`` reuses
+            # the one poll ``get_receiver_assertion`` already made rather
+            # than re-polling RTCM a second time.
+            rtcm = read.rtcm
 
             _render_ports_view()
             _render_gnss_view()

--- a/tests/unit/test_device_service.py
+++ b/tests/unit/test_device_service.py
@@ -19,6 +19,8 @@ from sp_rtk_base.models.device_models import (
     GnssConstellation,
     GnssSystemConfig,
     PortId,
+    PortProtocolConfig,
+    ReceiverScalarConfig,
     RtcmPortConfig,
     RtcmRowId,
     SurveyInConfig,
@@ -35,6 +37,7 @@ from sp_rtk_base.services.device_service import (
     ApplyConfigLinkLostError,
     ApplyConfigRefusedError,
     DeviceService,
+    build_receiver_assertion,
 )
 from sp_rtk_base.services.drivers.base import GpsReceiverDriver
 
@@ -371,6 +374,133 @@ class TestConfiguration:
         assert connected_svc.state == DeviceConnectionState.CONNECTED
         status = connected_svc.get_status()
         assert status.last_error == "NAK"
+
+
+# ---------------------------------------------------------------------------
+# Tests: build_receiver_assertion + get_receiver_assertion (issue #97)
+# ---------------------------------------------------------------------------
+
+
+def _scalars(**overrides: object) -> ReceiverScalarConfig:
+    defaults: dict[str, object] = {
+        "uart1_baud": 57600,
+        "uart2_baud": 115200,
+        "meas_period_ms": 250,
+        "dyn_model": DynModel.STATIONARY,
+        "tmode_mode": BaseMode.FIXED,
+        "elevation_mask_deg": 15,
+        "bds_b2_enabled": False,
+        "spi_enabled": True,
+    }
+    defaults.update(overrides)
+    return ReceiverScalarConfig(**defaults)  # type: ignore[arg-type]
+
+
+class TestBuildReceiverAssertion:
+    """Pure composition of four driver reads into one ``ReceiverAssertion``."""
+
+    def test_composes_every_field(self) -> None:
+        rtcm = RtcmPortConfig(
+            messages={RtcmRowId.RTCM_1005: {"UART1": 1, "UART2": 0, "USB": 0}}
+        )
+        ports = PortProtocolConfig(
+            in_protocols={PortId.UART1: [UbxProtocol.UBX]},
+            out_protocols={PortId.UART1: [UbxProtocol.RTCM3X]},
+        )
+        gnss = GnssConfig(
+            systems=[
+                GnssSystemConfig(constellation=GnssConstellation.GPS, enabled=True),
+                GnssSystemConfig(constellation=GnssConstellation.SBAS, enabled=False),
+            ]
+        )
+        scalars = _scalars()
+
+        assertion = build_receiver_assertion(rtcm, ports, gnss, scalars)
+
+        assert assertion.rtcm_stream.matrix[RtcmRowId.RTCM_1005][PortId.UART1] is True
+        assert assertion.rtcm_stream.matrix[RtcmRowId.RTCM_1005][PortId.UART2] is False
+        assert assertion.ports[PortId.UART1].in_ == [UbxProtocol.UBX]
+        assert assertion.ports[PortId.UART1].out == [UbxProtocol.RTCM3X]
+        assert assertion.constellations == [GnssConstellation.GPS]
+        assert assertion.baud.uart1 == 57600
+        assert assertion.baud.uart2 == 115200
+        assert assertion.meas_period_ms == 250
+        assert assertion.dyn_model == DynModel.STATIONARY
+        assert assertion.tmode_mode == BaseMode.FIXED
+        assert assertion.elevation_mask_deg == 15
+        assert assertion.bds_b2_enabled is False
+        assert assertion.spi_enabled is True
+
+    def test_matrix_covers_every_catalog_row_and_matrix_port(self) -> None:
+        assertion = build_receiver_assertion(
+            RtcmPortConfig(), PortProtocolConfig(), GnssConfig(), _scalars()
+        )
+        assert set(assertion.rtcm_stream.matrix.keys()) == set(RtcmRowId)
+        for row in assertion.rtcm_stream.matrix.values():
+            assert set(row.keys()) == {PortId.UART1, PortId.UART2, PortId.USB}
+
+    def test_ports_covers_all_three_ports_even_when_unset(self) -> None:
+        assertion = build_receiver_assertion(
+            RtcmPortConfig(), PortProtocolConfig(), GnssConfig(), _scalars()
+        )
+        assert set(assertion.ports.keys()) == {PortId.UART1, PortId.UART2, PortId.USB}
+
+
+class TestGetReceiverAssertion:
+    @pytest.fixture()
+    def connected_svc(self) -> DeviceService:
+        svc = DeviceService()
+        driver = _make_mock_driver()
+        driver.get_rtcm_port_config.return_value = RtcmPortConfig(
+            messages={RtcmRowId.RTCM_1005: {"UART1": 1}}
+        )
+        driver.get_port_protocols.return_value = PortProtocolConfig()
+        driver.get_gnss_config.return_value = GnssConfig()
+        driver.get_receiver_scalars.return_value = _scalars()
+        svc.set_driver(driver)
+        svc._state = DeviceConnectionState.CONNECTED
+        svc._info = DeviceInfo(vendor="MockVendor", model="MockModel")
+        return svc
+
+    @pytest.mark.asyncio()
+    async def test_composes_the_four_driver_reads(
+        self, connected_svc: DeviceService
+    ) -> None:
+        read = await connected_svc.get_receiver_assertion()
+
+        assertion = read.assertion
+        assert assertion.rtcm_stream.matrix[RtcmRowId.RTCM_1005][PortId.UART1] is True
+        assert assertion.meas_period_ms == 250
+        assert assertion.dyn_model == DynModel.STATIONARY
+        driver = connected_svc.driver
+        assert driver is not None
+        driver.get_rtcm_port_config.assert_called_once()  # type: ignore[union-attr]
+        driver.get_port_protocols.assert_called_once()  # type: ignore[union-attr]
+        driver.get_gnss_config.assert_called_once()  # type: ignore[union-attr]
+        driver.get_receiver_scalars.assert_called_once()  # type: ignore[union-attr]
+
+    @pytest.mark.asyncio()
+    async def test_returns_the_raw_rtcm_read_alongside_the_assertion(
+        self, connected_svc: DeviceService
+    ) -> None:
+        """The raw RTCM read is bundled in, not re-polled (issue #97
+        review): the page's I2C/SPI advisory needs it, and a second call
+        to ``get_rtcm_port_config`` would reintroduce the extra round
+        trip this method exists to collapse away."""
+        driver = connected_svc.driver
+        assert driver is not None
+
+        read = await connected_svc.get_receiver_assertion()
+
+        assert read.rtcm is driver.get_rtcm_port_config.return_value  # type: ignore[union-attr]
+        driver.get_rtcm_port_config.assert_called_once()  # type: ignore[union-attr]
+
+    @pytest.mark.asyncio()
+    async def test_not_connected_raises(self) -> None:
+        svc = DeviceService()
+        svc.set_driver(_make_mock_driver())
+        with pytest.raises(RuntimeError, match="Device not connected"):
+            await svc.get_receiver_assertion()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_driver_registry.py
+++ b/tests/unit/test_driver_registry.py
@@ -15,6 +15,7 @@ from sp_rtk_base.models.device_models import (
     GpsPosition,
     PortId,
     PortProtocolConfig,
+    ReceiverScalarConfig,
     RtcmPortConfig,
     RtcmRowId,
     SurveyInConfig,
@@ -127,6 +128,18 @@ class StubDriver(GpsReceiverDriver):
 
     def get_uart_baud_rates(self) -> dict[PortId, int]:
         return {}
+
+    def get_receiver_scalars(self) -> ReceiverScalarConfig:
+        return ReceiverScalarConfig(
+            uart1_baud=115200,
+            uart2_baud=115200,
+            meas_period_ms=1000,
+            dyn_model=DynModel.PORTABLE,
+            tmode_mode=BaseMode.DISABLED,
+            elevation_mask_deg=0,
+            bds_b2_enabled=False,
+            spi_enabled=False,
+        )
 
     def configure_baud(self, uart1: int | None, uart2: int | None) -> None:
         pass

--- a/tests/unit/test_fake_driver.py
+++ b/tests/unit/test_fake_driver.py
@@ -8,7 +8,7 @@ behaviour from the e2e harness.
 
 What we assert
 --------------
-- All 18 abstract methods of :class:`GpsReceiverDriver` are
+- All 19 abstract methods of :class:`GpsReceiverDriver` are
   implemented (mypy already enforces this; we verify at runtime too).
 - ``connect`` / ``disconnect`` flip the ``is_connected`` flag.
 - Every method that touches device state raises ``ConnectionError``
@@ -466,6 +466,46 @@ class TestConfigurationRoundTrips:
         info = connected_driver.reconnect_at_baud(115200)
         assert info.model == "FAKE-F9P"
         assert connected_driver._baud_rate == 115200
+
+    def test_get_receiver_scalars_returns_defaults(
+        self, connected_driver: FakeGpsDriver
+    ) -> None:
+        """Defaults mirror the shipped built-in profile (issue #97)."""
+        scalars = connected_driver.get_receiver_scalars()
+        assert scalars.uart1_baud == 57600
+        assert scalars.uart2_baud == 115200
+        assert scalars.meas_period_ms == 1000
+        assert scalars.dyn_model == DynModel.PORTABLE
+        assert scalars.tmode_mode == BaseMode.DISABLED
+        assert scalars.elevation_mask_deg == 15
+        assert scalars.bds_b2_enabled is False
+        assert scalars.spi_enabled is True
+
+    def test_get_receiver_scalars_reflects_writes(
+        self, connected_driver: FakeGpsDriver
+    ) -> None:
+        connected_driver.configure_measurement_rate(250)
+        connected_driver.configure_dyn_model(DynModel.STATIONARY)
+        connected_driver.configure_tmode_mode(BaseMode.FIXED)
+        connected_driver.configure_optimisations(5, True, False)
+        connected_driver.configure_baud(9600, 9600)
+
+        scalars = connected_driver.get_receiver_scalars()
+
+        assert scalars.meas_period_ms == 250
+        assert scalars.dyn_model == DynModel.STATIONARY
+        assert scalars.tmode_mode == BaseMode.FIXED
+        assert scalars.elevation_mask_deg == 5
+        assert scalars.bds_b2_enabled is True
+        assert scalars.spi_enabled is False
+        assert scalars.uart1_baud == 9600
+        assert scalars.uart2_baud == 9600
+
+    def test_get_receiver_scalars_requires_connection(
+        self, driver: FakeGpsDriver
+    ) -> None:
+        with pytest.raises(ConnectionError):
+            driver.get_receiver_scalars()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_gps_config_helpers.py
+++ b/tests/unit/test_gps_config_helpers.py
@@ -17,16 +17,12 @@ from sp_rtk_base.models.device_models import (
     ApplyConfigCellDiff,
     CurrentBaseConfig,
     DynModel,
-    GnssConfig,
     GnssConstellation,
-    GnssSystemConfig,
     PortId,
-    PortProtocolConfig,
     RtcmOutputPort,
     RtcmPortConfig,
     RtcmRowId,
     SurveyInProgress,
-    UbxProtocol,
 )
 from sp_rtk_base.models.device_models import (
     BaseMode as TmodeMode,
@@ -37,12 +33,19 @@ from sp_rtk_base.models.hardware_identity import (
     HardwareConfidence,
     identity_from_target,
 )
-from sp_rtk_base.models.profile_models import BaudConfig, PortProtocolSet, Profile
+from sp_rtk_base.models.profile_models import (
+    BaudAssertion,
+    BaudConfig,
+    PortProtocolSet,
+    Profile,
+    ReceiverAssertion,
+    RtcmStreamConfig,
+    merge_profile_into_assertion,
+)
 from sp_rtk_base.services.profile_store import ProfileStore
 from sp_rtk_base.ui.pages.gps_config import (
     MATRIX_PORTS,
     REQUIRED_RTCM_ROW,
-    FormExtras,
     apply_blocked_reason,
     build_apply_config,
     build_picker_entries,
@@ -55,8 +58,6 @@ from sp_rtk_base.ui.pages.gps_config import (
     infer_data_link_ports,
     is_modified_from_profile,
     matrix_cell_on,
-    profile_matrix_to_form_matrix,
-    profile_to_form_extras,
     receiver_config_from_profile,
     resolve_gnss_display,
     resolve_identity,
@@ -358,20 +359,28 @@ def _full_profile(name: str = "full-profile") -> Profile:
     )
 
 
-class TestFormExtras:
-    """Defaults mirror ``ReceiverConfig``'s own "leave untouched" semantics."""
-
-    def test_defaults_are_all_none_except_meas_period(self) -> None:
-        extras = FormExtras()
-        assert extras.ports is None
-        assert extras.constellations is None
-        assert extras.baud is None
-        assert extras.meas_period_ms == 1000
-        assert extras.dyn_model is None
-        assert extras.tmode_mode is None
-        assert extras.elevation_mask_deg is None
-        assert extras.bds_b2_enabled is None
-        assert extras.spi_enabled is None
+def _live_assertion() -> ReceiverAssertion:
+    """A live-seeded assertion with values distinct from ``_full_profile()``'s
+    — used to prove a merge/comparison falls back to *live* wherever the
+    profile omits a field, rather than to a schema default."""
+    return ReceiverAssertion(
+        baud=BaudAssertion(uart1=9600, uart2=9600),
+        meas_period_ms=2000,
+        constellations=[GnssConstellation.BEIDOU],
+        ports={
+            PortId.UART1: PortProtocolSet(**{"in": ["UBX"], "out": []}),
+            PortId.UART2: PortProtocolSet(**{"in": ["UBX"], "out": []}),
+            PortId.USB: PortProtocolSet(
+                **{"in": ["UBX", "NMEA"], "out": ["UBX", "NMEA"]}
+            ),
+        },
+        dyn_model=DynModel.PORTABLE,
+        tmode_mode=TmodeMode.SURVEY_IN,
+        elevation_mask_deg=5,
+        bds_b2_enabled=True,
+        spi_enabled=False,
+        rtcm_stream=RtcmStreamConfig(matrix={}),
+    )
 
 
 class TestBuildApplyConfigWithExtras:
@@ -379,18 +388,20 @@ class TestBuildApplyConfigWithExtras:
         matrix = rtcm_config_to_matrix(
             RtcmPortConfig(messages={RtcmRowId.RTCM_1005: {"UART1": 1}})
         )
-        extras = FormExtras(
-            baud=BaudConfig(uart1=57600),
+        extras = ReceiverAssertion(
+            baud=BaudAssertion(uart1=57600, uart2=115200),
             meas_period_ms=200,
             constellations=[GnssConstellation.GPS],
+            ports={},
             dyn_model=DynModel.STATIONARY,
             tmode_mode=TmodeMode.DISABLED,
             elevation_mask_deg=15,
             bds_b2_enabled=False,
             spi_enabled=True,
+            rtcm_stream=RtcmStreamConfig(matrix=matrix),
         )
         config = build_apply_config(matrix, [PortId.UART1], extras)
-        assert config.baud is not None and config.baud.uart1 == 57600
+        assert config.baud == BaudConfig(uart1=57600, uart2=115200)
         assert config.meas_period_ms == 200
         assert config.constellations == [GnssConstellation.GPS]
         assert config.dyn_model == DynModel.STATIONARY
@@ -400,51 +411,30 @@ class TestBuildApplyConfigWithExtras:
         assert config.spi_enabled is True
 
 
-class TestProfileMatrixToFormMatrix:
-    def test_covers_every_catalog_row_and_matrix_port(self) -> None:
-        matrix = profile_matrix_to_form_matrix(_full_profile())
-        assert set(matrix.keys()) == set(RtcmRowId)
-        for row in matrix.values():
-            assert set(row.keys()) == set(MATRIX_PORTS)
-
-    def test_reflects_the_profiles_sparse_matrix(self) -> None:
-        matrix = profile_matrix_to_form_matrix(_full_profile())
-        assert matrix[RtcmRowId.RTCM_1005][PortId.UART1] is True
-        assert matrix[RtcmRowId.RTCM_1005][PortId.USB] is False
-        assert matrix[RtcmRowId.RTCM_1077][PortId.UART1] is False
-
-
-class TestProfileToFormExtras:
-    def test_copies_every_field(self) -> None:
-        extras = profile_to_form_extras(_full_profile())
-        assert extras.ports is not None
-        assert extras.constellations == [
-            GnssConstellation.GPS,
-            GnssConstellation.GLONASS,
-        ]
-        assert extras.baud == BaudConfig(uart1=57600, uart2=115200)
-        assert extras.meas_period_ms == 500
-        assert extras.dyn_model == DynModel.STATIONARY
-        assert extras.tmode_mode is None
-        assert extras.elevation_mask_deg == 15
-        assert extras.bds_b2_enabled is False
-        assert extras.spi_enabled is True
-
-
 class TestReceiverConfigFromProfile:
     def test_strips_identity_fields(self) -> None:
-        config = receiver_config_from_profile(_full_profile())
+        config = receiver_config_from_profile(_full_profile(), _live_assertion())
         assert not hasattr(config, "name")
         assert not hasattr(config, "hardware")
         assert not hasattr(config, "forked_from")
         assert config.meas_period_ms == 500
 
+    def test_falls_back_to_live_for_fields_the_profile_omits(self) -> None:
+        """``_full_profile()`` omits ``tmode_mode`` and USB ports on purpose."""
+        live = _live_assertion()
+        config = receiver_config_from_profile(_full_profile(), live)
+        assert config.tmode_mode == live.tmode_mode
+        assert config.ports is not None
+        assert config.ports[PortId.USB] == live.ports[PortId.USB]
+
     def test_equals_the_form_built_from_the_same_profile(self) -> None:
         profile = _full_profile()
-        matrix = profile_matrix_to_form_matrix(profile)
-        extras = profile_to_form_extras(profile)
-        form_config = build_apply_config(matrix, profile.data_link_port, extras)
-        assert form_config == receiver_config_from_profile(profile)
+        live = _live_assertion()
+        merged = merge_profile_into_assertion(profile, live)
+        form_config = build_apply_config(
+            merged.rtcm_stream.matrix, profile.data_link_port, merged
+        )
+        assert form_config == receiver_config_from_profile(profile, live)
 
 
 class TestIsModifiedFromProfile:
@@ -455,27 +445,25 @@ class TestIsModifiedFromProfile:
             ),
             [PortId.UART1],
         )
-        assert not is_modified_from_profile(config, None)
+        assert not is_modified_from_profile(config, None, _live_assertion())
 
     def test_false_when_form_exactly_equals_the_profile(self) -> None:
         profile = _full_profile()
-        matrix = profile_matrix_to_form_matrix(profile)
-        extras = profile_to_form_extras(profile)
-        form_config = build_apply_config(matrix, profile.data_link_port, extras)
-        assert not is_modified_from_profile(form_config, profile)
+        live = _live_assertion()
+        form_config = receiver_config_from_profile(profile, live)
+        assert not is_modified_from_profile(form_config, profile, live)
 
     def test_true_once_the_form_diverges(self) -> None:
         profile = _full_profile()
-        matrix = profile_matrix_to_form_matrix(profile)
-        matrix[RtcmRowId.RTCM_1074][PortId.UART1] = False
-        extras = profile_to_form_extras(profile)
-        form_config = build_apply_config(matrix, profile.data_link_port, extras)
-        assert is_modified_from_profile(form_config, profile)
+        live = _live_assertion()
+        form_config = receiver_config_from_profile(profile, live)
+        diverged = form_config.model_copy(update={"meas_period_ms": 999})
+        assert is_modified_from_profile(diverged, profile, live)
 
 
 class TestSaveAsEnabled:
     def test_disabled_when_form_is_invalid(self) -> None:
-        assert not save_as_enabled(None, None)
+        assert not save_as_enabled(None, None, _live_assertion())
 
     def test_enabled_with_no_profile_selected(self) -> None:
         config = build_apply_config(
@@ -484,25 +472,23 @@ class TestSaveAsEnabled:
             ),
             [PortId.UART1],
         )
-        assert save_as_enabled(config, None)
+        assert save_as_enabled(config, None, _live_assertion())
 
     def test_suppressed_when_selected_profile_exactly_equals_the_form(self) -> None:
         profile = _full_profile()
-        matrix = profile_matrix_to_form_matrix(profile)
-        extras = profile_to_form_extras(profile)
-        form_config = build_apply_config(matrix, profile.data_link_port, extras)
-        assert not save_as_enabled(form_config, profile)
+        live = _live_assertion()
+        form_config = receiver_config_from_profile(profile, live)
+        assert not save_as_enabled(form_config, profile, live)
 
     def test_enabled_again_once_the_form_diverges_from_the_selected_profile(
         self,
     ) -> None:
         """The #66 fix: applying edits must not take Save-as away again."""
         profile = _full_profile()
-        matrix = profile_matrix_to_form_matrix(profile)
-        matrix[RtcmRowId.RTCM_1074][PortId.UART2] = False
-        extras = profile_to_form_extras(profile)
-        form_config = build_apply_config(matrix, profile.data_link_port, extras)
-        assert save_as_enabled(form_config, profile)
+        live = _live_assertion()
+        form_config = receiver_config_from_profile(profile, live)
+        diverged = form_config.model_copy(update={"meas_period_ms": 999})
+        assert save_as_enabled(diverged, profile, live)
 
 
 class TestDisplayLabel:
@@ -580,73 +566,43 @@ class TestBuildSavedProfile:
 
 
 class TestResolvePortsDisplay:
-    def test_falls_back_to_live_when_no_form_ports(self) -> None:
-        live = PortProtocolConfig(
-            in_protocols={PortId.UART1: [UbxProtocol.UBX]},
-            out_protocols={PortId.UART1: [UbxProtocol.RTCM3X]},
-        )
-        display = resolve_ports_display(live, None)
-        assert display[PortId.UART1] == (["UBX"], ["RTCM3X"])
-        assert display[PortId.UART2] == ([], [])
-
-    def test_form_ports_take_priority_over_live(self) -> None:
-        live = PortProtocolConfig(
-            in_protocols={PortId.UART1: [UbxProtocol.UBX]},
-        )
-        form_ports = {
-            PortId.UART1: PortProtocolSet(
-                **{"in": [UbxProtocol.UBX, UbxProtocol.NMEA], "out": []}
-            ),
+    def test_renders_the_forms_ports(self) -> None:
+        ports = {
+            PortId.UART1: PortProtocolSet(**{"in": ["UBX"], "out": ["RTCM3X"]}),
         }
-        display = resolve_ports_display(live, form_ports)
-        assert display[PortId.UART1] == (["UBX", "NMEA"], [])
-        # A port omitted from the profile's ports is untouched -> empty.
+        display = resolve_ports_display(ports)
+        assert display[PortId.UART1] == (["UBX"], ["RTCM3X"])
+        # A port absent from the map renders empty.
         assert display[PortId.UART2] == ([], [])
 
 
 class TestResolveGnssDisplay:
-    def test_falls_back_to_live_when_no_form_constellations(self) -> None:
-        live = GnssConfig(
-            systems=[
-                GnssSystemConfig(constellation=GnssConstellation.GPS, enabled=True),
-                GnssSystemConfig(constellation=GnssConstellation.SBAS, enabled=False),
-            ]
-        )
-        display = resolve_gnss_display(live, None)
+    def test_renders_the_forms_constellations(self) -> None:
+        display = resolve_gnss_display([GnssConstellation.GPS])
         assert display["gps"] is True
         assert display["sbas"] is False
 
-    def test_form_constellations_take_priority_over_live(self) -> None:
-        live = GnssConfig(
-            systems=[
-                GnssSystemConfig(constellation=GnssConstellation.GPS, enabled=False),
-            ]
-        )
-        display = resolve_gnss_display(live, [GnssConstellation.GLONASS])
-        assert display["gps"] is False
-        assert display["glonass"] is True
+    def test_empty_constellations_shows_nothing_enabled(self) -> None:
+        display = resolve_gnss_display([])
+        assert not any(display.values())
 
 
 class TestHwExtrasDisplay:
-    def test_default_extras_show_unchanged(self) -> None:
-        rows = {label: value for _cls, label, value in hw_extras_display(FormExtras())}
-        assert rows["Baud"] == "unchanged"
-        assert rows["Dynamics Model"] == "unchanged"
-        assert rows["BeiDou B2"] == "unchanged"
-        assert rows["Measurement Rate"] == "1 Hz"
-
-    def test_populated_extras_render_their_values(self) -> None:
-        extras = FormExtras(
-            baud=BaudConfig(uart1=57600),
+    def test_renders_every_field_concretely(self) -> None:
+        extras = ReceiverAssertion(
+            baud=BaudAssertion(uart1=57600, uart2=115200),
             meas_period_ms=500,
+            constellations=[],
+            ports={},
             dyn_model=DynModel.STATIONARY,
             tmode_mode=TmodeMode.FIXED,
             elevation_mask_deg=15,
             bds_b2_enabled=False,
             spi_enabled=True,
+            rtcm_stream=RtcmStreamConfig(matrix={}),
         )
         rows = {label: value for _cls, label, value in hw_extras_display(extras)}
-        assert rows["Baud"] == "UART1=57600"
+        assert rows["Baud"] == "UART1=57600, UART2=115200"
         assert rows["Measurement Rate"] == "2 Hz"
         assert rows["Dynamics Model"] == "stationary"
         assert rows["Time Mode"] == "fixed"

--- a/tests/unit/test_profile_models.py
+++ b/tests/unit/test_profile_models.py
@@ -10,12 +10,23 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
-from sp_rtk_base.models.device_models import GnssConstellation, PortId, RtcmRowId
+from sp_rtk_base.models.device_models import (
+    GnssConstellation,
+    PortId,
+    RtcmRowId,
+    UbxProtocol,
+)
 from sp_rtk_base.models.profile_models import (
+    BaudAssertion,
+    BaudConfig,
     DynModel,
+    PortProtocolSet,
     Profile,
+    ReceiverAssertion,
     ReceiverConfig,
+    RtcmStreamConfig,
     TmodeMode,
+    merge_profile_into_assertion,
 )
 
 
@@ -301,3 +312,188 @@ class TestProfile:
         data = profile.model_dump(mode="json")
         restored = Profile.model_validate(data)
         assert restored == profile
+
+
+# ---------------------------------------------------------------------------
+# ReceiverAssertion + merge_profile_into_assertion (issue #97)
+# ---------------------------------------------------------------------------
+
+
+def _live() -> ReceiverAssertion:
+    """A fully-populated live read-back, distinct from ``_full_profile()``'s
+    values so a merge's fallback-to-live is unambiguous in assertions."""
+    return ReceiverAssertion(
+        baud=BaudAssertion(uart1=9600, uart2=9600),
+        meas_period_ms=2000,
+        constellations=[GnssConstellation.BEIDOU],
+        ports={
+            PortId.UART1: PortProtocolSet(**{"in": [], "out": []}),
+            PortId.UART2: PortProtocolSet(**{"in": [], "out": []}),
+            PortId.USB: PortProtocolSet(
+                **{"in": ["UBX", "NMEA"], "out": ["UBX", "NMEA"]}
+            ),
+        },
+        dyn_model=DynModel.PORTABLE,
+        tmode_mode=TmodeMode.SURVEY_IN,
+        elevation_mask_deg=5,
+        bds_b2_enabled=True,
+        spi_enabled=False,
+        rtcm_stream=RtcmStreamConfig(
+            matrix={RtcmRowId.RTCM_1077: {PortId.UART1: True}}
+        ),
+    )
+
+
+def _full_profile() -> Profile:
+    """A profile with every field populated except ``tmode_mode`` and the
+    USB port entry — the two omissions the built-in profile actually
+    makes (see profiles/builtin/ublox-f9p-base-standard.yaml)."""
+    return Profile.model_validate(
+        {
+            "name": "full-profile",
+            "version": 1,
+            "hardware": "ZED-F9P",
+            "baud": {"uart1": 57600, "uart2": 115200},
+            "meas_period_ms": 500,
+            "constellations": ["gps", "glonass"],
+            "ports": {
+                "UART1": {"in": ["UBX", "NMEA", "RTCM3X"], "out": ["RTCM3X"]},
+                "UART2": {"in": ["UBX", "RTCM3X"], "out": ["RTCM3X"]},
+            },
+            "data_link_port": ["UART1", "UART2"],
+            "dyn_model": "stationary",
+            "elevation_mask_deg": 15,
+            "bds_b2_enabled": False,
+            "spi_enabled": True,
+            "rtcm_stream": {
+                "matrix": {
+                    "1005": {"UART1": True, "UART2": True},
+                    "1074": {"UART1": True, "UART2": True},
+                }
+            },
+        }
+    )
+
+
+class TestBaudAssertion:
+    def test_both_fields_required(self) -> None:
+        with pytest.raises(ValidationError):
+            BaudAssertion.model_validate({"uart1": 57600})
+
+    def test_out_of_range_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            BaudAssertion(uart1=1, uart2=9600)
+
+
+class TestReceiverAssertion:
+    def test_every_field_required(self) -> None:
+        with pytest.raises(ValidationError):
+            ReceiverAssertion.model_validate({})
+
+    def test_extra_field_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ReceiverAssertion(**_live().model_dump(), bogus_field="nope")
+
+    def test_fully_populated_instance_is_valid(self) -> None:
+        live = _live()
+        assert live.dyn_model == DynModel.PORTABLE
+        assert live.tmode_mode == TmodeMode.SURVEY_IN
+
+
+class TestMergeProfileIntoAssertion:
+    def test_profile_values_win_where_set(self) -> None:
+        merged = merge_profile_into_assertion(_full_profile(), _live())
+        assert merged.baud.uart1 == 57600
+        assert merged.baud.uart2 == 115200
+        assert merged.meas_period_ms == 500
+        assert merged.constellations == [
+            GnssConstellation.GPS,
+            GnssConstellation.GLONASS,
+        ]
+        assert merged.dyn_model == DynModel.STATIONARY
+        assert merged.elevation_mask_deg == 15
+        assert merged.bds_b2_enabled is False
+        assert merged.spi_enabled is True
+
+    def test_omitted_tmode_mode_falls_back_to_live(self) -> None:
+        """The built-in profile omits ``tmode_mode`` on purpose."""
+        live = _live()
+        merged = merge_profile_into_assertion(_full_profile(), live)
+        assert merged.tmode_mode == live.tmode_mode
+
+    def test_omitted_usb_port_falls_back_to_live(self) -> None:
+        """The built-in profile omits the USB port entry on purpose."""
+        live = _live()
+        merged = merge_profile_into_assertion(_full_profile(), live)
+        assert merged.ports[PortId.USB] == live.ports[PortId.USB]
+
+    def test_ports_the_profile_sets_are_not_overridden_by_live(self) -> None:
+        merged = merge_profile_into_assertion(_full_profile(), _live())
+        assert merged.ports[PortId.UART1].out == [UbxProtocol.RTCM3X]
+
+    def test_partial_baud_falls_back_to_live_per_field(self) -> None:
+        profile = _full_profile().model_copy(update={"baud": BaudConfig(uart1=57600)})
+        live = _live()
+        merged = merge_profile_into_assertion(profile, live)
+        assert merged.baud.uart1 == 57600
+        assert merged.baud.uart2 == live.baud.uart2
+
+    def test_matrix_is_taken_from_the_profile_not_live(self) -> None:
+        """``rtcm_stream`` is always assertive — never "leave alone"."""
+        merged = merge_profile_into_assertion(_full_profile(), _live())
+        assert merged.rtcm_stream.matrix[RtcmRowId.RTCM_1005][PortId.UART1] is True
+        # Live's matrix (RTCM_1077 on UART1) is not present in the profile
+        # and must not leak into the merged result.
+        assert merged.rtcm_stream.matrix[RtcmRowId.RTCM_1077][PortId.UART1] is False
+
+    def test_matrix_covers_every_catalog_row_and_matrix_port(self) -> None:
+        merged = merge_profile_into_assertion(_full_profile(), _live())
+        assert set(merged.rtcm_stream.matrix.keys()) == set(RtcmRowId)
+        for row in merged.rtcm_stream.matrix.values():
+            assert set(row.keys()) == {PortId.UART1, PortId.UART2, PortId.USB}
+
+    def test_bare_profile_falls_back_to_live_for_every_optional_field(self) -> None:
+        """A profile that sets nothing beyond identity + the minimal matrix
+        resolves to *live* for every field it left unset."""
+        bare = Profile.model_validate(
+            {
+                "name": "bare",
+                "version": 1,
+                "hardware": "ZED-F9P",
+                "data_link_port": ["UART1"],
+                "rtcm_stream": {"matrix": {"1005": {"UART1": True}}},
+            }
+        )
+        live = _live()
+        merged = merge_profile_into_assertion(bare, live)
+        assert merged.baud == live.baud
+        assert merged.constellations == live.constellations
+        assert merged.ports == live.ports
+        assert merged.dyn_model == live.dyn_model
+        assert merged.tmode_mode == live.tmode_mode
+        assert merged.elevation_mask_deg == live.elevation_mask_deg
+        assert merged.bds_b2_enabled == live.bds_b2_enabled
+        assert merged.spi_enabled == live.spi_enabled
+
+    def test_meas_period_ms_never_falls_back_to_live(self) -> None:
+        """The one documented exception: ``ReceiverConfig.meas_period_ms``
+        is a plain ``int`` defaulting to 1000, not ``int | None`` — a bare
+        profile that never mentions it is indistinguishable from one that
+        explicitly wants 1000, so it can't fall back to *live* the way
+        every other optional field does."""
+        bare = Profile.model_validate(
+            {
+                "name": "bare",
+                "version": 1,
+                "hardware": "ZED-F9P",
+                "data_link_port": ["UART1"],
+                "rtcm_stream": {"matrix": {"1005": {"UART1": True}}},
+            }
+        )
+        live = _live()
+        assert bare.meas_period_ms != live.meas_period_ms
+
+        merged = merge_profile_into_assertion(bare, live)
+
+        assert merged.meas_period_ms == bare.meas_period_ms
+        assert merged.meas_period_ms != live.meas_period_ms

--- a/tests/unit/test_ublox_driver.py
+++ b/tests/unit/test_ublox_driver.py
@@ -1911,6 +1911,84 @@ class TestGetUartBaudRates:
         assert result == {PortId.UART1: 57600, PortId.UART2: 115200}
 
 
+class TestGetReceiverScalars:
+    """Tests for ``UbloxDriver.get_receiver_scalars`` (issue #97)."""
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_reads_every_scalar_in_one_poll(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        read_back = SimpleNamespace(
+            identity="CFG-VALGET",
+            CFG_UART1_BAUDRATE=57600,
+            CFG_UART2_BAUDRATE=115200,
+            CFG_RATE_MEAS=250,
+            CFG_NAVSPG_DYNMODEL=2,
+            CFG_TMODE_MODE=2,
+            CFG_NAVSPG_INFIL_MINELEV=15,
+            CFG_SIGNAL_BDS_B2_ENA=0,
+            CFG_SPI_ENABLED=1,
+        )
+        driver, _reader = _connect_driver(
+            mock_serial_cls, mock_reader_cls, mock_ubx_msg, [read_back]
+        )
+
+        result = driver.get_receiver_scalars()
+
+        assert result.uart1_baud == 57600
+        assert result.uart2_baud == 115200
+        assert result.meas_period_ms == 250
+        assert result.dyn_model == DynModel.STATIONARY
+        assert result.tmode_mode == BaseMode.FIXED
+        assert result.elevation_mask_deg == 15
+        assert result.bds_b2_enabled is False
+        assert result.spi_enabled is True
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_polls_all_eight_keys_in_a_single_message(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        read_back = SimpleNamespace(
+            identity="CFG-VALGET",
+            CFG_UART1_BAUDRATE=9600,
+            CFG_UART2_BAUDRATE=9600,
+            CFG_RATE_MEAS=1000,
+            CFG_NAVSPG_DYNMODEL=0,
+            CFG_TMODE_MODE=0,
+            CFG_NAVSPG_INFIL_MINELEV=5,
+            CFG_SIGNAL_BDS_B2_ENA=1,
+            CFG_SPI_ENABLED=0,
+        )
+        driver, _reader = _connect_driver(
+            mock_serial_cls, mock_reader_cls, mock_ubx_msg, [read_back]
+        )
+
+        driver.get_receiver_scalars()
+
+        assert mock_ubx_msg.config_poll.call_count == 1
+        _layer, _reserved, poll_keys = mock_ubx_msg.config_poll.call_args[0]
+        assert set(poll_keys) == {
+            "CFG_UART1_BAUDRATE",
+            "CFG_UART2_BAUDRATE",
+            "CFG_RATE_MEAS",
+            "CFG_NAVSPG_DYNMODEL",
+            "CFG_TMODE_MODE",
+            "CFG_NAVSPG_INFIL_MINELEV",
+            "CFG_SIGNAL_BDS_B2_ENA",
+            "CFG_SPI_ENABLED",
+        }
+
+
 class TestReadCfgKeysLocked:
     """Tests for ``UbloxDriver._read_cfg_keys_locked`` (issue #94).
 


### PR DESCRIPTION
## Summary

- Introduces `ReceiverAssertion` — every receiver field required, no optionals — as the symmetric counterpart to `ReceiverConfig`'s "omitted means leave it alone" semantics, plus a new batched CFG-VALGET poll (`UbloxDriver.get_receiver_scalars`) that reads baud, measurement rate, dyn model, tmode mode, elevation mask, BeiDou B2 and SPI in one round trip — folding in the four fields (measurement rate, elevation mask, BeiDou B2, SPI) that previously had no getter at all.
- `DeviceService.get_receiver_assertion()` composes this with the existing RTCM matrix, port-protocol and GNSS reads into a single service call — three CFG-VALGET polls total rather than seven separate round trips.
- The Advanced GPS page's six parallel state variables collapse into a `form`/`live` `ReceiverAssertion` pair plus the data-link port selection. Loading a profile resolves its optional omissions against the live-seeded assertion via the pure, unit-tested `merge_profile_into_assertion` (module-level, not page-closure logic). Nav rate now displays the receiver's actual configured rate instead of a hardcoded default.
- Apply's behaviour (matrix + data-link ports only) and the out-of-sync badge (matrix-only comparison) are unchanged, per spec.

Closes #97

## Test plan

- [x] `uv run pytest` — 1400 unit tests pass, 93.5% coverage (gate: 90%)
- [x] `uv run pyright src/` — clean (strict mode)
- [x] `uv run mypy` — clean
- [x] `uv run ruff check` / `ruff format` — clean
- [x] Full GPS-page e2e suite against the fake driver (32 tests: apply, profile picker, save-as, config buttons, data flow, fixed-position card) — all pass
- [x] App boots (`init_app()`) with the refactored page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AcBmmcpcJtBBxvDE8M3C6p