### PR TITLE
Apply asserts the whole form + profile picker becomes a dropdown (#98, #105)

### DIFF
--- a/src/sp_rtk_base/api/device.py
+++ b/src/sp_rtk_base/api/device.py
@@ -17,7 +17,6 @@ from sp_rtk_base.models.config_models import (
     InputProfile,
 )
 from sp_rtk_base.models.device_models import (
-    ApplyConfigResult,
     BaseInvariantsCheck,
     CurrentBaseConfig,
     DeviceStatus,
@@ -30,7 +29,7 @@ from sp_rtk_base.models.device_models import (
     SurveyInConfig,
     SurveyInProgress,
 )
-from sp_rtk_base.models.profile_models import ReceiverConfig
+from sp_rtk_base.models.profile_models import ApplyConfigResult, ReceiverApplyRequest
 from sp_rtk_base.services import (
     get_config_service,
     get_device_service,
@@ -311,21 +310,31 @@ async def get_port_protocols(
 
 @router.post("/apply-config", response_model=ApplyConfigResult)
 async def apply_config(
-    config: ReceiverConfig,
+    request: ReceiverApplyRequest,
     svc: DeviceService = Depends(get_device_service),
 ) -> ApplyConfigResult:
-    """Apply a bare ``ReceiverConfig`` to the receiver, verified with a read-back.
+    """Apply the whole form to the receiver, verified with a per-leaf read-back diff.
+
+    *request* is the envelope Apply sends (issue #98): the full
+    asserted receiver state (``assertion``, a ``ReceiverAssertion`` —
+    every field, none omitted) plus ``data_link_port``, which has no
+    CFG key of its own and is only an input to ``ReceiverApplyRequest``'s
+    cross-field validators (never written, never part of the diff
+    below).
 
     An ordered series of layer=5 writes (see
-    ``DeviceService.apply_receiver_config`` for the exact sequence and
-    guards), followed by a read-back of the RTCM matrix. A read-back
-    mismatch still returns 200 with ``status: "failed"`` and a
-    per-cell diff — the writes are left in flash, nothing is rolled
-    back.
+    ``DeviceService.apply_receiver_config`` for the exact sequence,
+    the measurement-rate/baud unchanged-skip, and the guards), followed
+    by a full read-back diffed per-leaf, path-keyed against what was
+    sent. A read-back mismatch still returns 200 with
+    ``status: "failed"`` and the per-leaf diff — the writes are left in
+    flash, nothing is rolled back. ``read_back`` on the response is
+    always the fresh full assertion read, whichever ``status`` — the
+    caller syncs its live state from it either way.
 
     Status contract: 409 if not connected or the relay is running;
     422 for a schema violation (handled automatically by the
-    ``ReceiverConfig`` body validation); 400 for a business-rule
+    ``ReceiverApplyRequest`` body validation); 400 for a business-rule
     refusal, with the failed rule named and nothing written; 502 if a
     UART1 baud write lands but the console's own link can't be
     reopened at the new baud or the previous one (issue #62) — the
@@ -333,7 +342,7 @@ async def apply_config(
     needs a power-cycle or manual reconnect at the new baud rate.
     """
     try:
-        return await svc.apply_receiver_config(config)
+        return await svc.apply_receiver_config(request)
     except ApplyConfigLinkLostError as exc:
         raise HTTPException(status_code=502, detail=str(exc)) from exc
     except ApplyConfigRefusedError as exc:

--- a/src/sp_rtk_base/models/device_models.py
+++ b/src/sp_rtk_base/models/device_models.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import enum
 from datetime import datetime
-from typing import Literal
 
 from pydantic import BaseModel, Field
 
@@ -325,34 +324,13 @@ class UbxProtocol(str, enum.Enum):
 
 
 # ---------------------------------------------------------------------------
-# Apply-config read-back verify (issue #61)
+# Apply-config's read-back-verify diff/result types now live on
+# ``models.profile_models`` (``ApplyDiffEntry`` / ``ApplyConfigResult`` /
+# ``diff_receiver_assertions`` — issue #98), since they compare
+# ``ReceiverAssertion`` values and this module can't import that without
+# a circular dependency. The old matrix-only ``ApplyConfigCellDiff`` /
+# ``ApplyConfigResult`` pair that lived here is gone — no parallel type.
 # ---------------------------------------------------------------------------
-
-
-class ApplyConfigCellDiff(BaseModel):
-    """One mismatched cell from the post-apply RTCM matrix read-back."""
-
-    row_id: RtcmRowId
-    port: PortId
-    expected: bool
-    actual: bool
-
-
-class ApplyConfigResult(BaseModel):
-    """Response for ``POST /api/device/apply-config``.
-
-    ``status="failed"`` means the post-apply read-back of the RTCM
-    matrix didn't match what was written — the writes are left in
-    flash (nothing is rolled back); ``diff`` lists every mismatched
-    cell. ``warnings`` carries non-blocking advisories (e.g. the
-    estimated-throughput check) that never affect ``status``.
-    """
-
-    status: Literal["ok", "failed"]
-    diff: list[ApplyConfigCellDiff] = Field(
-        default_factory=lambda: list[ApplyConfigCellDiff]()
-    )
-    warnings: list[str] = Field(default_factory=lambda: list[str]())
 
 
 class PortProtocolConfig(BaseModel):

--- a/src/sp_rtk_base/models/profile_models.py
+++ b/src/sp_rtk_base/models/profile_models.py
@@ -22,6 +22,8 @@ coordinate guard are service-level and belong to the apply ticket.
 
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from sp_rtk_base.models.device_models import (
@@ -130,7 +132,16 @@ class RtcmStreamConfig(BaseModel):
 
 
 class ReceiverConfig(BaseModel):
-    """Everything writable to a receiver. No ``name`` — see ``Profile``."""
+    """Everything writable to a receiver. No ``name`` — see ``Profile``.
+
+    ``data_link_port`` deliberately isn't a field here (issue #98): it
+    has no CFG key and is re-inferred from the matrix on every load,
+    so there is no receiver-side counterpart a ``ReceiverConfig``
+    could ever be out of sync with. It lives on ``Profile`` (a saved
+    profile does want to remember which ports were the data-link
+    ports) and on ``ReceiverApplyRequest`` (Apply's envelope, where
+    it's purely an input to the cross-field validators below).
+    """
 
     model_config = ConfigDict(extra="forbid")
 
@@ -138,7 +149,6 @@ class ReceiverConfig(BaseModel):
     meas_period_ms: int = Field(default=1000, ge=100, le=60000)
     constellations: list[GnssConstellation] | None = Field(default=None)
     ports: dict[PortId, PortProtocolSet] | None = Field(default=None)
-    data_link_port: list[PortId] = Field(min_length=1)
     dyn_model: DynModel | None = Field(default=None)
     tmode_mode: TmodeMode | None = Field(default=None)
     elevation_mask_deg: int | None = Field(default=None, ge=0, le=90)
@@ -146,39 +156,50 @@ class ReceiverConfig(BaseModel):
     spi_enabled: bool | None = Field(default=None)
     rtcm_stream: RtcmStreamConfig = Field(default_factory=RtcmStreamConfig)
 
-    @model_validator(mode="after")
-    def _validate_data_link_ports_are_uart(self) -> ReceiverConfig:
-        invalid_ports = [
-            p for p in self.data_link_port if p not in _DATA_LINK_CANDIDATE_PORTS
-        ]
-        if invalid_ports:
-            raise ValueError(
-                f"data_link_port: {[p.value for p in invalid_ports]} cannot be a "
-                "data-link port — only UART1/UART2 are valid"
-            )
-        return self
 
-    @model_validator(mode="after")
-    def _validate_1005_on_a_data_link_port(self) -> ReceiverConfig:
-        rows_on_1005 = self.rtcm_stream.matrix.get(RtcmRowId.RTCM_1005, {})
-        if not any(rows_on_1005.get(port, False) for port in self.data_link_port):
-            raise ValueError(
-                "1005 (Station ARP) must be enabled on at least one data_link_port"
-            )
-        return self
+# ---------------------------------------------------------------------------
+# Shared data-link-port cross-field rules
+#
+# Three context-free rules that need both a ``data_link_port`` selection
+# and an RTCM matrix to check. Neither ``ReceiverConfig`` nor
+# ``ReceiverAssertion`` carries ``data_link_port`` (issue #98 — it has no
+# CFG key of its own), so these rules apply wherever the two are bundled
+# together: ``Profile`` (its own ``data_link_port`` field, alongside the
+# ``rtcm_stream`` it inherits from ``ReceiverConfig``) and
+# ``ReceiverApplyRequest`` (Apply's envelope). Extracted as free functions
+# so both call sites validate identically without one inheriting the
+# other's fields.
+# ---------------------------------------------------------------------------
 
-    @model_validator(mode="after")
-    def _validate_every_data_link_port_has_a_row_on(self) -> ReceiverConfig:
-        matrix = self.rtcm_stream.matrix
-        for port in self.data_link_port:
-            has_any_row_on = any(
-                ports_for_row.get(port, False) for ports_for_row in matrix.values()
-            )
-            if not has_any_row_on:
-                raise ValueError(
-                    f"data_link_port {port.value}: has zero RTCM rows enabled"
-                )
-        return self
+
+def _check_data_link_ports_are_uart(data_link_port: list[PortId]) -> None:
+    invalid_ports = [p for p in data_link_port if p not in _DATA_LINK_CANDIDATE_PORTS]
+    if invalid_ports:
+        raise ValueError(
+            f"data_link_port: {[p.value for p in invalid_ports]} cannot be a "
+            "data-link port — only UART1/UART2 are valid"
+        )
+
+
+def _check_1005_on_a_data_link_port(
+    data_link_port: list[PortId], matrix: dict[RtcmRowId, dict[PortId, bool]]
+) -> None:
+    rows_on_1005 = matrix.get(RtcmRowId.RTCM_1005, {})
+    if not any(rows_on_1005.get(port, False) for port in data_link_port):
+        raise ValueError(
+            "1005 (Station ARP) must be enabled on at least one data_link_port"
+        )
+
+
+def _check_every_data_link_port_has_a_row_on(
+    data_link_port: list[PortId], matrix: dict[RtcmRowId, dict[PortId, bool]]
+) -> None:
+    for port in data_link_port:
+        has_any_row_on = any(
+            ports_for_row.get(port, False) for ports_for_row in matrix.values()
+        )
+        if not has_any_row_on:
+            raise ValueError(f"data_link_port {port.value}: has zero RTCM rows enabled")
 
 
 # ---------------------------------------------------------------------------
@@ -187,13 +208,38 @@ class ReceiverConfig(BaseModel):
 
 
 class Profile(ReceiverConfig):
-    """A saved, named, hardware-tagged receiver configuration."""
+    """A saved, named, hardware-tagged receiver configuration.
 
+    Unlike ``ReceiverAssertion``, a saved profile *does* want to
+    remember which ports were the data-link ports — that's part of
+    what makes it worth saving — so ``data_link_port`` lives here as
+    ``Profile``'s own field rather than on ``ReceiverConfig`` (issue
+    #98).
+    """
+
+    data_link_port: list[PortId] = Field(min_length=1)
     name: str = Field(min_length=1)
     version: int
     hardware: str
     forked_from: str | None = Field(default=None)
     display_name: str | None = Field(default=None)
+
+    @model_validator(mode="after")
+    def _validate_data_link_ports_are_uart(self) -> Profile:
+        _check_data_link_ports_are_uart(self.data_link_port)
+        return self
+
+    @model_validator(mode="after")
+    def _validate_1005_on_a_data_link_port(self) -> Profile:
+        _check_1005_on_a_data_link_port(self.data_link_port, self.rtcm_stream.matrix)
+        return self
+
+    @model_validator(mode="after")
+    def _validate_every_data_link_port_has_a_row_on(self) -> Profile:
+        _check_every_data_link_port_has_a_row_on(
+            self.data_link_port, self.rtcm_stream.matrix
+        )
+        return self
 
     @model_validator(mode="after")
     def _validate_identity(self) -> Profile:
@@ -255,6 +301,254 @@ class ReceiverAssertion(BaseModel):
     bds_b2_enabled: bool
     spi_enabled: bool
     rtcm_stream: RtcmStreamConfig
+
+
+# ---------------------------------------------------------------------------
+# ReceiverApplyRequest — Apply's envelope (issue #98)
+# ---------------------------------------------------------------------------
+
+
+class ReceiverApplyRequest(BaseModel):
+    """The envelope Apply sends: the whole asserted receiver state plus
+    the data-link port selection.
+
+    ``data_link_port`` cannot live on ``ReceiverAssertion`` itself — it
+    has no CFG key and is re-inferred from the matrix on every load, so
+    there is no receiver-side counterpart it could ever be out of sync
+    with. Here it is purely an input to the three cross-field
+    validators below; it is never counted or marked in a diff (see
+    :func:`diff_receiver_assertions`, which never looks at it) — an
+    Apply where only the data-link port selection changed compares
+    equal on ``assertion`` and so correctly reports nothing to do.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    assertion: ReceiverAssertion
+    data_link_port: list[PortId] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def _validate_data_link_ports_are_uart(self) -> ReceiverApplyRequest:
+        _check_data_link_ports_are_uart(self.data_link_port)
+        return self
+
+    @model_validator(mode="after")
+    def _validate_1005_on_a_data_link_port(self) -> ReceiverApplyRequest:
+        _check_1005_on_a_data_link_port(
+            self.data_link_port, self.assertion.rtcm_stream.matrix
+        )
+        return self
+
+    @model_validator(mode="after")
+    def _validate_every_data_link_port_has_a_row_on(self) -> ReceiverApplyRequest:
+        _check_every_data_link_port_has_a_row_on(
+            self.data_link_port, self.assertion.rtcm_stream.matrix
+        )
+        return self
+
+
+# ---------------------------------------------------------------------------
+# Per-leaf, path-keyed diff — verify and sync collapse to one call (issue #98)
+# ---------------------------------------------------------------------------
+
+
+class ApplyDiffEntry(BaseModel):
+    """One leaf-level mismatch between two ``ReceiverAssertion`` values.
+
+    *path* identifies the exact widget a future inline marker would
+    highlight — a single matrix cell (``rtcm.1005.UART1``), one port's
+    one protocol direction (``ports.UART1.out.RTCM3X``), one
+    constellation (``constellations.gps``), or a plain scalar field
+    (``meas_period_ms``). Every leaf is a scalar, so *expected*/*actual*
+    stay simply typed rather than needing a union of composite shapes.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    path: str
+    expected: bool | int | str
+    actual: bool | int | str
+
+
+def diff_receiver_assertions(
+    expected: ReceiverAssertion, actual: ReceiverAssertion
+) -> list[ApplyDiffEntry]:
+    """Per-leaf, path-keyed differences between two ``ReceiverAssertion``s.
+
+    One entry per scalar leaf — matrix cells, per-port per-protocol
+    in/out membership, per-constellation membership, baud, and every
+    other scalar field — never a whole-field comparison: the per-cell
+    resolution is load-bearing for the UI (a single toggled cell must
+    render as exactly one diff line, not "the matrix differs"), every
+    leaf being a scalar keeps *expected*/*actual* simply typed, and
+    *path* is the join key a future inline marker will need to
+    highlight the mismatched widget.
+
+    This one expression is the comparison this app uses everywhere two
+    receiver states need diffing: Apply's post-write read-back verify
+    (sent vs. read-back) and the Advanced GPS page's "receiver out of
+    sync" indicator (form vs. live) both call this — verify and sync
+    collapse to the same call on the same type.
+
+    Deliberately never mentions ``data_link_port`` — neither operand is
+    a ``ReceiverApplyRequest`` — so the data-link port selection can
+    never appear as a difference.
+    """
+    diffs: list[ApplyDiffEntry] = []
+
+    if expected.baud.uart1 != actual.baud.uart1:
+        diffs.append(
+            ApplyDiffEntry(
+                path="baud.uart1",
+                expected=expected.baud.uart1,
+                actual=actual.baud.uart1,
+            )
+        )
+    if expected.baud.uart2 != actual.baud.uart2:
+        diffs.append(
+            ApplyDiffEntry(
+                path="baud.uart2",
+                expected=expected.baud.uart2,
+                actual=actual.baud.uart2,
+            )
+        )
+
+    if expected.meas_period_ms != actual.meas_period_ms:
+        diffs.append(
+            ApplyDiffEntry(
+                path="meas_period_ms",
+                expected=expected.meas_period_ms,
+                actual=actual.meas_period_ms,
+            )
+        )
+
+    expected_constellations = set(expected.constellations)
+    actual_constellations = set(actual.constellations)
+    for constellation in GnssConstellation:
+        exp_on = constellation in expected_constellations
+        act_on = constellation in actual_constellations
+        if exp_on != act_on:
+            diffs.append(
+                ApplyDiffEntry(
+                    path=f"constellations.{constellation.value}",
+                    expected=exp_on,
+                    actual=act_on,
+                )
+            )
+
+    empty_ports = PortProtocolSet()
+    for port in PortId:
+        expected_port = expected.ports.get(port, empty_ports)
+        actual_port = actual.ports.get(port, empty_ports)
+        expected_in = set(expected_port.in_)
+        actual_in = set(actual_port.in_)
+        expected_out = set(expected_port.out)
+        actual_out = set(actual_port.out)
+        for protocol in UbxProtocol:
+            exp_in_on = protocol in expected_in
+            act_in_on = protocol in actual_in
+            if exp_in_on != act_in_on:
+                diffs.append(
+                    ApplyDiffEntry(
+                        path=f"ports.{port.value}.in.{protocol.value}",
+                        expected=exp_in_on,
+                        actual=act_in_on,
+                    )
+                )
+            exp_out_on = protocol in expected_out
+            act_out_on = protocol in actual_out
+            if exp_out_on != act_out_on:
+                diffs.append(
+                    ApplyDiffEntry(
+                        path=f"ports.{port.value}.out.{protocol.value}",
+                        expected=exp_out_on,
+                        actual=act_out_on,
+                    )
+                )
+
+    if expected.dyn_model != actual.dyn_model:
+        diffs.append(
+            ApplyDiffEntry(
+                path="dyn_model",
+                expected=expected.dyn_model.value,
+                actual=actual.dyn_model.value,
+            )
+        )
+
+    if expected.tmode_mode != actual.tmode_mode:
+        diffs.append(
+            ApplyDiffEntry(
+                path="tmode_mode",
+                expected=expected.tmode_mode.value,
+                actual=actual.tmode_mode.value,
+            )
+        )
+
+    if expected.elevation_mask_deg != actual.elevation_mask_deg:
+        diffs.append(
+            ApplyDiffEntry(
+                path="elevation_mask_deg",
+                expected=expected.elevation_mask_deg,
+                actual=actual.elevation_mask_deg,
+            )
+        )
+
+    if expected.bds_b2_enabled != actual.bds_b2_enabled:
+        diffs.append(
+            ApplyDiffEntry(
+                path="bds_b2_enabled",
+                expected=expected.bds_b2_enabled,
+                actual=actual.bds_b2_enabled,
+            )
+        )
+
+    if expected.spi_enabled != actual.spi_enabled:
+        diffs.append(
+            ApplyDiffEntry(
+                path="spi_enabled",
+                expected=expected.spi_enabled,
+                actual=actual.spi_enabled,
+            )
+        )
+
+    for row_id in ALL_RTCM_MESSAGE_IDS:
+        expected_row = expected.rtcm_stream.matrix.get(row_id, {})
+        actual_row = actual.rtcm_stream.matrix.get(row_id, {})
+        for port in MATRIX_PORTS:
+            exp_on = expected_row.get(port, False)
+            act_on = actual_row.get(port, False)
+            if exp_on != act_on:
+                diffs.append(
+                    ApplyDiffEntry(
+                        path=f"rtcm.{row_id.value}.{port.value}",
+                        expected=exp_on,
+                        actual=act_on,
+                    )
+                )
+
+    return diffs
+
+
+class ApplyConfigResult(BaseModel):
+    """Response for ``POST /api/device/apply-config``.
+
+    ``status="failed"`` means the post-apply read-back didn't match
+    what was sent — the writes are left in flash (nothing is rolled
+    back); ``diff`` lists every mismatched leaf, path-keyed (see
+    :func:`diff_receiver_assertions`). ``read_back`` is the full
+    post-apply assertion read — callers (the Advanced GPS page) sync
+    their live state from it whether ``status`` is ``"ok"`` or
+    ``"failed"``, since the writes land either way. ``warnings``
+    carries non-blocking advisories (e.g. the estimated-throughput
+    check) that never affect ``status``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok", "failed"]
+    read_back: ReceiverAssertion
+    diff: list[ApplyDiffEntry] = Field(default_factory=lambda: list[ApplyDiffEntry]())
+    warnings: list[str] = Field(default_factory=lambda: list[str]())
 
 
 def _dense_matrix(

--- a/src/sp_rtk_base/services/device_service.py
+++ b/src/sp_rtk_base/services/device_service.py
@@ -16,8 +16,6 @@ from typing import NamedTuple, Protocol
 
 from sp_rtk_base.models.device_models import (
     ALL_RTCM_MESSAGE_IDS,
-    ApplyConfigCellDiff,
-    ApplyConfigResult,
     BaseInvariantsCheck,
     CurrentBaseConfig,
     DeviceCapability,
@@ -42,11 +40,14 @@ from sp_rtk_base.models.device_models import (
 )
 from sp_rtk_base.models.profile_models import (
     MATRIX_PORTS,
+    ApplyConfigResult,
     BaudAssertion,
     PortProtocolSet,
+    ReceiverApplyRequest,
     ReceiverAssertion,
-    ReceiverConfig,
     RtcmStreamConfig,
+    diff_receiver_assertions,
+    merge_profile_into_assertion,
 )
 from sp_rtk_base.profiles import BUILTIN_PROFILES
 from sp_rtk_base.services.drivers.base import GpsReceiverDriver
@@ -135,19 +136,21 @@ _BASE_INVARIANTS_PROFILE_NAME = "ublox-f9p-base-standard"
 
 
 def _throughput_warnings(
-    config: ReceiverConfig, baud_rates: dict[PortId, int]
+    assertion: ReceiverAssertion,
+    data_link_port: list[PortId],
+    baud_rates: dict[PortId, int],
 ) -> list[str]:
     """Non-blocking advisories when estimated RTCM output nears port capacity.
 
-    Takes the whole ``ReceiverConfig`` rather than its three relevant
-    fields individually — ``rtcm_stream.matrix``, ``data_link_port``
-    and ``meas_period_ms`` only ever travel together for this check,
-    and the config already bundles them.
+    Takes the whole ``ReceiverAssertion`` plus *data_link_port*
+    separately — ``data_link_port`` has no CFG key and isn't part of
+    the assertion (issue #98), but the check still needs it alongside
+    ``rtcm_stream.matrix`` and ``meas_period_ms``.
     """
-    matrix = config.rtcm_stream.matrix
-    hz = 1000.0 / config.meas_period_ms
+    matrix = assertion.rtcm_stream.matrix
+    hz = 1000.0 / assertion.meas_period_ms
     warnings: list[str] = []
-    for port in config.data_link_port:
+    for port in data_link_port:
         baud = baud_rates.get(port)
         if not baud:
             continue
@@ -532,22 +535,32 @@ class DeviceService:
         Reuses :meth:`apply_receiver_config` — the built-in profile
         (:data:`_BASE_INVARIANTS_PROFILE_NAME`) already specifies the
         port protocols, dynamics model and RTCM matrix that satisfy
-        :meth:`check_base_invariants`. ``baud`` is stripped from the
-        profile before applying: the two invariants this remedy exists
-        for (dynamics model, RTCM-on-data-link-port) never touch baud,
-        so a one-click warning fix should not risk stranding the
-        console's own link on a UART1 baud change the operator didn't
-        ask for.
+        :meth:`check_base_invariants`. The profile is merged onto a
+        fresh live read via :func:`merge_profile_into_assertion` (issue
+        #98 — ``apply_receiver_config`` now takes a whole
+        ``ReceiverApplyRequest`` rather than a bare, partially-optional
+        config), with ``baud`` stripped from the profile copy first: the
+        two invariants this remedy exists for (dynamics model,
+        RTCM-on-data-link-port) never touch baud, so a one-click warning
+        fix should not risk stranding the console's own link on a UART1
+        baud change the operator didn't ask for — stripping it means the
+        merge falls back to the live baud, which then compares equal in
+        ``apply_receiver_config``'s unchanged-baud skip.
 
         Raises:
             RuntimeError: If not connected or relay is running.
             ApplyConfigRefusedError: If a device-state guard rejects the
                 profile before any write.
         """
-        profile = BUILTIN_PROFILES[_BASE_INVARIANTS_PROFILE_NAME]
-        return await self.apply_receiver_config(
-            profile.model_copy(update={"baud": None})
+        profile = BUILTIN_PROFILES[_BASE_INVARIANTS_PROFILE_NAME].model_copy(
+            update={"baud": None}
         )
+        read = await self.get_receiver_assertion()
+        merged = merge_profile_into_assertion(profile, read.assertion)
+        request = ReceiverApplyRequest(
+            assertion=merged, data_link_port=list(profile.data_link_port)
+        )
+        return await self.apply_receiver_config(request)
 
     async def send_cfg_rst_diagnostic(
         self,
@@ -817,8 +830,17 @@ class DeviceService:
     # Apply-config — the profile one-shot (issue #61)
     # ------------------------------------------------------------------
 
-    async def apply_receiver_config(self, config: ReceiverConfig) -> ApplyConfigResult:
-        """Apply a bare ``ReceiverConfig`` as an ordered series of layer=5 writes.
+    async def apply_receiver_config(
+        self, request: ReceiverApplyRequest
+    ) -> ApplyConfigResult:
+        """Apply the whole form as an ordered series of layer=5 writes (issue #98).
+
+        *request* is the envelope Apply sends: a fully-populated
+        ``ReceiverAssertion`` (every receiver field, no "leave alone"
+        omissions) plus ``data_link_port`` — the port selection has no
+        CFG key of its own and is never written, only used by the
+        guards/warnings below and by ``ReceiverApplyRequest``'s own
+        cross-field validators.
 
         Sequence: guards -> measurement rate -> ports -> constellations
         -> optimisations -> role fields (dyn_model, then tmode_mode) ->
@@ -828,67 +850,85 @@ class DeviceService:
         in — a baud change is the one write that can move the console's
         own management link out from under this very request (issue #62).
 
+        Every field is sent on every Apply — this ticket's "whole form"
+        change — with two deliberate exceptions that skip their write
+        entirely when the live receiver already holds the value being
+        sent: **measurement rate** (this ticket fixes the 1 Hz bug by
+        construction — the caller always seeds it from the receiver
+        rather than a schema default, and this skip means an unchanged
+        rate is never rewritten either) and **baud** (skipping an
+        unchanged baud avoids the reopen-after-write dance below on
+        every single Apply, not just the ones that actually change it).
+        Both compare against one early ``get_receiver_scalars()`` poll.
+        No other field gets this treatment — ports, constellations,
+        optimisations, dyn_model, tmode_mode and the RTCM matrix are
+        always (re)written, matching "send every field".
+
         Guards run before any write and refuse with nothing written:
 
         - **UBX-in liveness.** This console always manages the receiver
           over its own USB connection — UART1/UART2 are reserved for
-          RTCM data-link output (``ReceiverConfig`` only allows those
-          two as ``data_link_port``). So "the connected port" is
-          always ``PortId.USB``; a submitted ``ports`` section that
-          would turn UBX off on USB IN is refused, since it would cut
-          the console's own control channel with nothing left to
-          write it back with.
+          RTCM data-link output. So "the connected port" is always
+          ``PortId.USB``; a submitted ``ports`` section that would turn
+          UBX off on USB IN is refused, since it would cut the
+          console's own control channel with nothing left to write it
+          back with.
         - **Coordinate guard.** ``tmode_mode: fixed`` is refused unless
           the receiver already holds a valid, non-zero position —
           otherwise a fresh receiver becomes a base broadcasting 1005
           from ECEF/LLH 0,0,0.
 
-        ``config.baud.uart1`` is treated as the port the console's own
-        management link is on, per the documented deployment (FTDI ->
-        UART1 at 57600, see docs/zed-f9p-base-station-config-reference.md)
-        — a separate, narrower premise from the UBX-in guard's "always
-        USB" one above; the two guard different concerns (which named
-        port must keep UBX in, vs. which physical serial link this
-        process itself has open) and issue #62 doesn't ask for them to
-        be reconciled. When ``uart1`` is set, this reopens the
-        connection at the new baud once the write lands, before
+        ``request.assertion.baud.uart1`` is treated as the port the
+        console's own management link is on, per the documented
+        deployment (FTDI -> UART1 at 57600, see
+        docs/zed-f9p-base-station-config-reference.md) — a separate,
+        narrower premise from the UBX-in guard's "always USB" one
+        above; the two guard different concerns (which named port must
+        keep UBX in, vs. which physical serial link this process
+        itself has open) and issue #62 doesn't ask for them to be
+        reconciled. When UART1's baud actually changes, this reopens
+        the connection at the new baud once the write lands, before
         anything else runs. Reopening is deterministic — the baud was
         just written — so one attempt normally suffices; a failure
         retries once at the previous baud purely to leave the caller
         with *some* link back, then raises ``ApplyConfigLinkLostError``
         regardless of that retry's outcome: the flash write stands
         either way (rolling it back would fight the write that just
-        landed, and retrying the old rate forever would hang).
-        ``config.baud.uart2`` never triggers a reopen — it isn't the
-        port this console is on.
+        landed, and retrying the old rate forever would hang). A
+        changed UART2 baud never triggers a reopen — it isn't the port
+        this console is on.
 
         After the writes land, a non-blocking throughput estimate
         checks each ``data_link_port`` against its live baud rate, and
-        a final read-back of the full RTCM matrix decides ``status``:
-        a mismatch returns ``status="failed"`` with a per-cell diff
-        (writes are left in flash, nothing is rolled back); a match
-        returns ``status="ok"``.
+        a fresh full read-back (:meth:`get_receiver_assertion`) is
+        diffed per-leaf against *request.assertion*
+        (:func:`profile_models.diff_receiver_assertions`) to decide
+        ``status``: any mismatch returns ``status="failed"`` with the
+        per-leaf, path-keyed diff (writes are left in flash, nothing is
+        rolled back); an empty diff returns ``status="ok"``. The
+        read-back is always attached as ``read_back``, whichever
+        ``status`` — the page's ``live`` state syncs from it either way.
 
         Raises:
             RuntimeError: If not connected or relay is running.
             ApplyConfigRefusedError: If a device-state guard rejects the
-                config before any write.
+                request before any write.
             ApplyConfigLinkLostError: If a UART1 baud write lands but
                 reopening the console's own link fails at both the new
                 and the previous baud.
         """
         driver = self._require_connected()
+        assertion = request.assertion
 
-        if config.ports is not None:
-            usb_ports = config.ports.get(PortId.USB)
-            if usb_ports is not None and UbxProtocol.UBX not in usb_ports.in_:
-                raise ApplyConfigRefusedError(
-                    "ubx_in_liveness",
-                    "ports.USB.in must keep UBX enabled — the console manages "
-                    "the receiver over its own USB connection",
-                )
+        usb_ports = assertion.ports.get(PortId.USB)
+        if usb_ports is not None and UbxProtocol.UBX not in usb_ports.in_:
+            raise ApplyConfigRefusedError(
+                "ubx_in_liveness",
+                "ports.USB.in must keep UBX enabled — the console manages "
+                "the receiver over its own USB connection",
+            )
 
-        if config.tmode_mode == TmodeMode.FIXED:
+        if assertion.tmode_mode == TmodeMode.FIXED:
             current_base = await asyncio.to_thread(driver.get_base_config)
             if (
                 current_base.latitude == 0.0
@@ -903,51 +943,57 @@ class DeviceService:
                 )
 
         self._state = DeviceConnectionState.CONFIGURING
+        new_uart1: int | None = None
         try:
-            await asyncio.to_thread(
-                driver.configure_measurement_rate, config.meas_period_ms
-            )
+            current_scalars = await asyncio.to_thread(driver.get_receiver_scalars)
 
-            if config.ports:
-                in_map = {port: cfg.in_ for port, cfg in config.ports.items()}
-                out_map = {port: cfg.out for port, cfg in config.ports.items()}
+            if current_scalars.meas_period_ms != assertion.meas_period_ms:
                 await asyncio.to_thread(
-                    driver.configure_port_protocols, in_map, out_map
+                    driver.configure_measurement_rate, assertion.meas_period_ms
                 )
 
-            if config.constellations is not None:
-                current_gnss = await asyncio.to_thread(driver.get_gnss_config)
-                wanted = set(config.constellations)
-                updated_gnss = GnssConfig(
-                    systems=[
-                        system.model_copy(
-                            update={"enabled": system.constellation in wanted}
-                        )
-                        for system in current_gnss.systems
-                    ]
-                )
-                await asyncio.to_thread(driver.configure_gnss, updated_gnss)
+            in_map = {port: cfg.in_ for port, cfg in assertion.ports.items()}
+            out_map = {port: cfg.out for port, cfg in assertion.ports.items()}
+            await asyncio.to_thread(driver.configure_port_protocols, in_map, out_map)
+
+            current_gnss = await asyncio.to_thread(driver.get_gnss_config)
+            wanted = set(assertion.constellations)
+            updated_gnss = GnssConfig(
+                systems=[
+                    system.model_copy(
+                        update={"enabled": system.constellation in wanted}
+                    )
+                    for system in current_gnss.systems
+                ]
+            )
+            await asyncio.to_thread(driver.configure_gnss, updated_gnss)
 
             await asyncio.to_thread(
                 driver.configure_optimisations,
-                config.elevation_mask_deg,
-                config.bds_b2_enabled,
-                config.spi_enabled,
+                assertion.elevation_mask_deg,
+                assertion.bds_b2_enabled,
+                assertion.spi_enabled,
             )
 
-            if config.dyn_model is not None:
-                await asyncio.to_thread(driver.configure_dyn_model, config.dyn_model)
-            if config.tmode_mode is not None:
-                await asyncio.to_thread(driver.configure_tmode_mode, config.tmode_mode)
+            await asyncio.to_thread(driver.configure_dyn_model, assertion.dyn_model)
+            await asyncio.to_thread(driver.configure_tmode_mode, assertion.tmode_mode)
 
-            await asyncio.to_thread(driver.apply_rtcm_matrix, config.rtcm_stream.matrix)
+            await asyncio.to_thread(
+                driver.apply_rtcm_matrix, assertion.rtcm_stream.matrix
+            )
 
-            if config.baud is not None and (
-                config.baud.uart1 is not None or config.baud.uart2 is not None
-            ):
-                await asyncio.to_thread(
-                    driver.configure_baud, config.baud.uart1, config.baud.uart2
-                )
+            new_uart1 = (
+                assertion.baud.uart1
+                if assertion.baud.uart1 != current_scalars.uart1_baud
+                else None
+            )
+            new_uart2 = (
+                assertion.baud.uart2
+                if assertion.baud.uart2 != current_scalars.uart2_baud
+                else None
+            )
+            if new_uart1 is not None or new_uart2 is not None:
+                await asyncio.to_thread(driver.configure_baud, new_uart1, new_uart2)
 
             self._state = DeviceConnectionState.CONNECTED
         except Exception as exc:
@@ -955,22 +1001,26 @@ class DeviceService:
             self._last_error = str(exc)
             raise
 
-        if config.baud is not None and config.baud.uart1 is not None:
-            await self._reopen_after_baud_write(driver, config.baud.uart1)
+        if new_uart1 is not None:
+            await self._reopen_after_baud_write(driver, new_uart1)
 
         baud_rates = await asyncio.to_thread(driver.get_uart_baud_rates)
-        warnings = _throughput_warnings(config, baud_rates)
+        warnings = _throughput_warnings(assertion, request.data_link_port, baud_rates)
 
-        actual_rtcm = await asyncio.to_thread(driver.get_rtcm_port_config)
-        diff = self._diff_rtcm_matrix(config.rtcm_stream.matrix, actual_rtcm)
+        read = await self.get_receiver_assertion()
+        diff = diff_receiver_assertions(assertion, read.assertion)
         if diff:
             logger.warning(
-                "apply-config read-back mismatch: %d cell(s) differ", len(diff)
+                "apply-config read-back mismatch: %d leaf(ves) differ", len(diff)
             )
-            return ApplyConfigResult(status="failed", diff=diff, warnings=warnings)
+            return ApplyConfigResult(
+                status="failed", read_back=read.assertion, diff=diff, warnings=warnings
+            )
 
         logger.info("apply-config applied and read-back verified")
-        return ApplyConfigResult(status="ok", warnings=warnings)
+        return ApplyConfigResult(
+            status="ok", read_back=read.assertion, warnings=warnings
+        )
 
     async def _reopen_after_baud_write(
         self, driver: GpsReceiverDriver, new_baud: int
@@ -1024,32 +1074,6 @@ class DeviceService:
         )
         logger.error(self._last_error)
         raise ApplyConfigLinkLostError(previous_baud, new_baud)
-
-    @staticmethod
-    def _diff_rtcm_matrix(
-        expected: dict[RtcmRowId, dict[PortId, bool]],
-        actual: RtcmPortConfig,
-    ) -> list[ApplyConfigCellDiff]:
-        """Diff the intended RTCM matrix against a live read-back.
-
-        Covers all 36 cells (12 rows x UART1/UART2/USB) — the same
-        scope ``apply_rtcm_matrix`` writes.
-        """
-        diffs: list[ApplyConfigCellDiff] = []
-        for row in RtcmRowId:
-            for port in (PortId.UART1, PortId.UART2, PortId.USB):
-                expected_on = expected.get(row, {}).get(port, False)
-                actual_on = actual.messages.get(row, {}).get(port.value, 0) > 0
-                if expected_on != actual_on:
-                    diffs.append(
-                        ApplyConfigCellDiff(
-                            row_id=row,
-                            port=port,
-                            expected=expected_on,
-                            actual=actual_on,
-                        )
-                    )
-        return diffs
 
     # ------------------------------------------------------------------
     # Status polling

--- a/src/sp_rtk_base/ui/pages/gps_config.py
+++ b/src/sp_rtk_base/ui/pages/gps_config.py
@@ -37,7 +37,14 @@ against; turning that into an editable grid is future work, same as
 # pyright: reportUnknownVariableType=false
 # pyright: reportOptionalMemberAccess=false
 # pyright: reportOptionalIterable=false
-# NiceGUI elements have partially unknown types.
+# pyright: reportPrivateUsage=false
+# NiceGUI elements have partially unknown types. reportPrivateUsage is
+# disabled because the profile-picker dropdown (issue #105) writes
+# directly to a raw ``q-select`` element's ``_props['options']`` — the
+# public ``ui.select``/``ChoiceElement`` options API rebuilds that prop
+# from a plain ``{value: label}`` mapping on every ``update()``, with
+# no room for the per-option disable/tooltip/highlight fields its
+# ``option`` scoped slot needs (see the comment beside ``picker_select``).
 
 from __future__ import annotations
 
@@ -644,7 +651,132 @@ def gps_config_page() -> None:
                 .style("border: 1px solid #5a4520; border-radius: 4px")
             )
             unconfirmed_banner.set_visibility(False)
-            picker_list = ui.column().classes("q-mt-sm gap-1 w-full")
+
+            # The dropdown (issue #105 — replaces the #64/#65/#66 card
+            # list). Built as a raw Quasar ``q-select`` via ``ui.element``
+            # rather than NiceGUI's ``ui.select`` wrapper: the wrapper's
+            # ``ChoiceElement`` maps options to plain ``{value, label}``
+            # pairs and rebuilds that list itself on every ``update()``,
+            # leaving nowhere to hang the extra per-option
+            # disable/tooltip/highlight fields the ``option`` scoped slot
+            # below needs. Working against the raw element keeps full
+            # control of the ``options`` prop's shape.
+            with ui.row().classes("items-center gap-2 q-mt-sm flex-wrap"):
+                picker_select = (
+                    ui.element("q-select")
+                    .props(
+                        "label='Select profile' emit-value map-options "
+                        "option-value=value option-label=label "
+                        "options-dense dense outlined behavior=menu"
+                    )
+                    .classes("profile-picker")
+                    .style("min-width: 320px")
+                )
+                # Custom ``option`` slot: Quasar's own ``option-disable``
+                # prop would set the native ``disable`` prop on the
+                # rendered ``q-item``, which sets ``pointer-events:none``
+                # and silently kills hover — exactly what the tooltip
+                # explaining *why* a profile is disabled needs. So
+                # selection is gated by hand (``props.opt.disable`` guards
+                # the click) instead, keeping the item hoverable.
+                #
+                # NB: NiceGUI's own slot-template wrapper (see
+                # ``renderRecursively`` in its bundled ``nicegui.js``)
+                # exposes the Quasar scoped-slot object as a template
+                # variable named ``props`` — *not* Quasar's own docs
+                # convention ``scope`` — regardless of which slot this
+                # is, so every reference below is ``props.*``.
+                picker_select.add_slot(
+                    "option",
+                    r"""
+                    <q-item
+                      v-bind:clickable="!props.opt.disable"
+                      v-bind:class="[
+                        'profile-option',
+                        'profile-option-' + props.opt.value,
+                        props.opt.disable ? 'profile-option-disabled' : '',
+                        props.opt.highlighted ? 'profile-option-suggested bg-primary-1' : '',
+                      ]"
+                      v-on:click="() => { if (!props.opt.disable) props.toggleOption(props.opt) }"
+                    >
+                      <q-item-section>
+                        <q-item-label v-bind:class="props.opt.disable ? 'text-grey-6' : ''">
+                          {{ props.opt.label }}
+                          <q-badge
+                            v-if="props.opt.highlighted"
+                            color="primary"
+                            class="profile-suggested-badge q-ml-sm"
+                          >Suggested</q-badge>
+                          <q-badge
+                            outline
+                            color="grey"
+                            class="profile-builtin-badge q-ml-sm"
+                          >{{ props.opt.builtin ? 'built-in' : 'custom' }}</q-badge>
+                        </q-item-label>
+                      </q-item-section>
+                      <q-tooltip
+                        v-if="props.opt.disable"
+                        class="profile-option-tooltip"
+                      >{{ props.opt.tooltip }}</q-tooltip>
+                    </q-item>
+                    """,
+                )
+                picker_select.on(
+                    "update:model-value",
+                    lambda e: _select_profile_by_name(e.args),
+                )
+
+                picker_rename_icon = (
+                    ui.icon("edit")
+                    .classes("profile-rename-icon text-grey-4 cursor-pointer")
+                    .tooltip("Rename")
+                )
+                picker_delete_icon = (
+                    ui.icon("delete")
+                    .classes("profile-delete-icon text-grey-4 cursor-pointer")
+                    .tooltip("Delete")
+                )
+                picker_export_icon = (
+                    ui.icon("download")
+                    .classes("profile-export-icon text-grey-4 cursor-pointer")
+                    .tooltip("Export")
+                )
+                picker_rename_icon.on(
+                    "click",
+                    lambda: (
+                        _open_rename_dialog(selected_profile)
+                        if selected_profile is not None
+                        else None
+                    ),
+                )
+                picker_delete_icon.on(
+                    "click",
+                    lambda: (
+                        _open_delete_dialog(selected_profile)
+                        if selected_profile is not None
+                        else None
+                    ),
+                )
+                picker_export_icon.on(
+                    "click",
+                    lambda: (
+                        _export_profile(selected_profile.name)
+                        if selected_profile is not None
+                        else None
+                    ),
+                )
+
+                # The profile-relation indicator (issue #105 — moved out
+                # of the action row, where it sat as a same-weight
+                # sibling of receiver status and used warning colour for
+                # "modified from X". It answers "should I save this?",
+                # never "something's wrong", so it renders here next to
+                # the control that resolves it, always in a neutral
+                # colour — see ``_render_modified_indicator``.
+                modified_badge = (
+                    ui.badge("").classes("modified-badge").props("color=grey-7 outline")
+                )
+                modified_badge.set_visibility(False)
 
         # ================================================================
         # Section C: Receiver configuration — read-only, seeded from the
@@ -707,10 +839,6 @@ def gps_config_page() -> None:
                     .classes("save-as-btn")
                     .props("color=secondary outline")
                 )
-                modified_badge = (
-                    ui.badge("").classes("modified-badge").props("color=warning")
-                )
-                modified_badge.set_visibility(False)
 
             apply_result_label = (
                 ui.label("")
@@ -906,7 +1034,16 @@ def gps_config_page() -> None:
                 pass  # Non-critical
 
         def _render_picker() -> None:
-            """Render the profile picker from the current device identity."""
+            """Render the profile picker dropdown from the current device identity.
+
+            Populates the raw ``q-select``'s ``options`` prop directly
+            (each entry a dict carrying ``value``/``label`` plus the
+            ``disable``/``tooltip``/``highlighted``/``builtin`` fields the
+            ``option`` scoped slot renders) rather than going through
+            NiceGUI's ``ui.select`` options API, which has no room for
+            those extra fields — see the comment where ``picker_select``
+            is built.
+            """
             identity = _current_identity()
             identity_label.text = (
                 f"Connected receiver hardware: {identity.target} "
@@ -920,78 +1057,48 @@ def gps_config_page() -> None:
                 profile_store.list_profiles(), profile_store, identity
             )
 
-            picker_list.clear()
-            with picker_list:
-                for entry in entries:
-                    is_selected = (
-                        selected_profile is not None
-                        and selected_profile.name == entry.profile.name
-                    )
-                    is_incompatible = (
-                        not entry.compatible and entry.incompatible_reason is not None
-                    )
-                    row_classes = f"profile-row profile-row-{entry.profile.name} items-center gap-2 q-py-xs justify-between"
-                    if is_selected:
-                        row_classes += " profile-row-selected"
-                    with ui.row().classes(row_classes) as row:
-                        name_classes = (
-                            "text-white" if entry.compatible else "text-grey-6"
-                        )
-                        # The clickable "select" target is its own inner
-                        # row so the rename/delete/export icons — siblings
-                        # inside the outer row, not descendants of this one
-                        # — never bubble a click into profile selection.
-                        select_classes = "items-center gap-2" + (
-                            " cursor-pointer" if entry.compatible else ""
-                        )
-                        with ui.row().classes(select_classes) as select_area:
-                            if entry.compatible:
-                                select_area.on(
-                                    "click",
-                                    lambda _, p=entry.profile: _select_profile(p),
-                                )
-                            if is_selected:
-                                ui.icon("check_circle").classes(
-                                    "profile-selected-icon text-primary"
-                                )
-                            ui.label(display_label(entry.profile)).classes(
-                                f"profile-name {name_classes}"
-                            )
-                            ui.badge(
-                                "built-in" if entry.is_builtin else "custom"
-                            ).props("outline color=grey")
-                            if entry.is_default:
-                                ui.badge("Suggested").classes(
-                                    "profile-suggested-badge"
-                                ).props("color=primary")
-                            if entry.incompatible_reason:
-                                ui.icon("info").classes(
-                                    "profile-incompatible-icon text-grey-5"
-                                ).tooltip(entry.incompatible_reason)
+            picker_select._props["options"] = [
+                {
+                    "value": entry.profile.name,
+                    "label": display_label(entry.profile),
+                    "disable": not entry.compatible,
+                    "tooltip": entry.incompatible_reason or "",
+                    "highlighted": entry.is_default,
+                    "builtin": entry.is_builtin,
+                }
+                for entry in entries
+            ]
+            picker_select._props["model-value"] = (
+                selected_profile.name if selected_profile is not None else None
+            )
+            picker_select.update()
 
-                        if is_incompatible:
-                            row.classes("opacity-60")
+            # Rename/delete/export act on whichever profile is currently
+            # selected (issue #105) — customs-only, same as before.
+            is_custom_selected = selected_profile is not None and not (
+                profile_store.is_builtin(selected_profile.name)
+            )
+            for icon in (
+                picker_rename_icon,
+                picker_delete_icon,
+                picker_export_icon,
+            ):
+                icon.set_visibility(is_custom_selected)
 
-                        if not entry.is_builtin:
-                            with ui.row().classes("gap-2 items-center"):
-                                ui.icon("edit").classes(
-                                    "profile-rename-icon text-grey-4 cursor-pointer"
-                                ).on(
-                                    "click",
-                                    lambda _, p=entry.profile: _open_rename_dialog(p),
-                                ).tooltip("Rename")
-                                ui.icon("delete").classes(
-                                    "profile-delete-icon text-grey-4 cursor-pointer"
-                                ).on(
-                                    "click",
-                                    lambda _, p=entry.profile: _open_delete_dialog(p),
-                                ).tooltip("Delete")
-                                ui.icon("download").classes(
-                                    "profile-export-icon text-grey-4 cursor-pointer"
-                                ).on(
-                                    "click",
-                                    lambda _, n=entry.profile.name: _export_profile(n),
-                                ).tooltip("Export")
+        def _select_profile_by_name(name: str | None) -> None:
+            """``update:model-value`` handler for the picker dropdown.
+
+            Looks the picked value back up as a :class:`Profile` and
+            delegates to :func:`_select_profile` — the dropdown emits the
+            profile's slug (``option-value=value``/``emit-value``), not
+            the object itself.
+            """
+            if not name:
+                return
+            profile = profile_store.get_profile(name)
+            if profile is None:
+                return
+            _select_profile(profile)
 
         def _select_profile(profile: Profile) -> None:
             """Pick a profile — pre-fills the whole form (issue #66).
@@ -1382,7 +1489,15 @@ def gps_config_page() -> None:
             """The second, independent indicator — form vs. *selected
             profile*, distinct from "out of sync" (form vs. live receiver).
             Hidden when no profile is selected: nothing to have diverged
-            from."""
+            from.
+
+            Renders in a neutral colour either way (issue #105) — this
+            answers "should I save this?", not "something's wrong", so
+            neither state ever borrows the warning/positive colours that
+            train an operator to read amber as trouble. "Modified from
+            X" and "Matches X" are told apart by an outline vs. filled
+            treatment of the same neutral grey, not by hue.
+            """
             form_config = _current_form_config()
             if selected_profile is None or form_config is None:
                 modified_badge.set_visibility(False)
@@ -1390,10 +1505,11 @@ def gps_config_page() -> None:
             modified_badge.set_visibility(True)
             if is_modified_from_profile(form_config, selected_profile, live):
                 modified_badge.text = f"Modified from {display_label(selected_profile)}"
-                modified_badge.props("color=warning")
+                modified_badge.props(remove="outline")
+                modified_badge.props("color=grey-7")
             else:
                 modified_badge.text = f"Matches {display_label(selected_profile)}"
-                modified_badge.props("color=positive")
+                modified_badge.props("color=grey-7 outline")
 
         def _render_save_as_gate() -> None:
             save_as_btn.set_enabled(

--- a/src/sp_rtk_base/ui/pages/gps_config.py
+++ b/src/sp_rtk_base/ui/pages/gps_config.py
@@ -18,19 +18,25 @@ and data-link port(s) editable, wired to
 plus the "receiver out of sync" indicator (form vs. live receiver,
 cleared only by a successful apply).
 
-Issue #66 (this revision) makes picking a profile actually write into
-the form — the whole ``ReceiverConfig`` shape (ports, GNSS,
-baud/measurement-rate, role fields, optimisations, plus the matrix and
-data-link ports), not just the matrix — and adds the second,
-independent "modified from X" indicator (form vs. *selected profile*,
-gating Save-as) alongside the existing "out of sync" one (form vs.
-*live receiver*, gating Apply). Save-as, rename, delete and export
-round out the custom-profile lifecycle. The ports/GNSS/baud/role
-section remains a read-only *display* of form state rather than a
-click-to-edit grid — the driver has no read-back for most of those
-fields (baud excepted), so there's nothing yet to reconcile an edit
-against; turning that into an editable grid is future work, same as
-#65 deferred it.
+Issue #66 makes picking a profile actually write into the form — the
+whole ``ReceiverAssertion`` shape (ports, GNSS, baud/measurement-rate,
+role fields, optimisations, plus the matrix and data-link ports), not
+just the matrix — and adds the second, independent "modified from X"
+indicator (form vs. *selected profile*, gating Save-as) alongside the
+existing "out of sync" one (form vs. *live receiver*, gating Apply).
+Save-as, rename, delete and export round out the custom-profile
+lifecycle. The ports/GNSS/baud/role section remains a read-only
+*display* of form state rather than a click-to-edit grid.
+
+Issue #98 (this revision) makes Apply push the *whole* form, not just
+the matrix and data-link ports — it now sends a ``ReceiverApplyRequest``
+(the whole ``form`` :class:`~sp_rtk_base.models.profile_models.ReceiverAssertion`
+plus ``form_data_link_ports``), and both "out of sync" and the post-apply
+verify go through the one shared
+:func:`~sp_rtk_base.models.profile_models.diff_receiver_assertions`
+per-leaf, path-keyed comparison. This also fixes a standing bug by
+construction: ``form`` is always live-seeded, so measurement rate can
+no longer silently default to 1 Hz on every Apply press.
 """
 
 # pyright: reportUnknownMemberType=false
@@ -52,7 +58,6 @@ from sp_rtk_base.models.config_models import DeviceProfile
 from sp_rtk_base.models.device_models import (
     ALL_RTCM_MESSAGE_IDS,
     RTCM_MESSAGE_GROUPS,
-    ApplyConfigCellDiff,
     CurrentBaseConfig,
     DeviceCapability,
     DeviceConnectionState,
@@ -80,13 +85,14 @@ from sp_rtk_base.models.hardware_identity import (
 )
 from sp_rtk_base.models.profile_models import (
     MATRIX_PORTS,
+    ApplyDiffEntry,
     BaudAssertion,
-    BaudConfig,
     PortProtocolSet,
     Profile,
+    ReceiverApplyRequest,
     ReceiverAssertion,
-    ReceiverConfig,
     RtcmStreamConfig,
+    diff_receiver_assertions,
     merge_profile_into_assertion,
 )
 from sp_rtk_base.services import (
@@ -253,98 +259,68 @@ def apply_blocked_reason(data_link_port: list[PortId]) -> str | None:
     return None
 
 
-def build_apply_config(
-    matrix: dict[RtcmRowId, dict[PortId, bool]],
-    data_link_port: list[PortId],
-    assertion: ReceiverAssertion | None = None,
-) -> ReceiverConfig:
-    """Build a ``ReceiverConfig`` from the form state.
+def build_apply_request(
+    form: ReceiverAssertion, data_link_port: list[PortId]
+) -> ReceiverApplyRequest:
+    """Build the whole-form Apply envelope (issue #98).
 
-    *assertion* defaults to ``None`` — nothing but the matrix and
-    data-link ports set. ``_apply()`` always uses that default (Apply
-    stays scoped to the matrix + data-link ports, per #65 — the other
-    fields have no live read-back to verify a write against). Save-as
-    and the "modified from X" comparison pass the current ``form``
-    :class:`ReceiverAssertion` through, since those only compare
-    in-form state and never touch the receiver. *matrix* is always
-    passed explicitly, even when it's the same value as
-    ``assertion.rtcm_stream.matrix`` — every caller that has an
-    *assertion* happens to derive *matrix* from it directly beforehand,
-    so the two never actually diverge in practice.
+    Apply now sends the entire form — the matrix-only default this
+    used to have (issue #65/#66) is gone; every caller (the actual
+    Apply call, Save-as, and the "modified from X" comparison) passes
+    the current ``form`` :class:`ReceiverAssertion` through.
 
     Raises:
-        pydantic.ValidationError: If the resulting config fails a
+        pydantic.ValidationError: If the resulting request fails a
             context-free rule (e.g. 1005 missing from every chosen
             data-link port) — a client-side pre-write refusal, nothing
             is sent to the receiver.
     """
-    if assertion is None:
-        return ReceiverConfig(
-            data_link_port=data_link_port,
-            rtcm_stream=RtcmStreamConfig(matrix=matrix),
-        )
-    return ReceiverConfig(
-        ports=assertion.ports,
-        constellations=assertion.constellations,
-        baud=BaudConfig(uart1=assertion.baud.uart1, uart2=assertion.baud.uart2),
-        meas_period_ms=assertion.meas_period_ms,
-        dyn_model=assertion.dyn_model,
-        tmode_mode=assertion.tmode_mode,
-        elevation_mask_deg=assertion.elevation_mask_deg,
-        bds_b2_enabled=assertion.bds_b2_enabled,
-        spi_enabled=assertion.spi_enabled,
-        data_link_port=data_link_port,
-        rtcm_stream=RtcmStreamConfig(matrix=matrix),
-    )
+    return ReceiverApplyRequest(assertion=form, data_link_port=data_link_port)
 
 
 def receiver_config_from_profile(
     profile: Profile, live: ReceiverAssertion
-) -> ReceiverConfig:
-    """The ``ReceiverConfig`` picking *profile* against *live* would produce,
-    with identity stripped.
+) -> ReceiverApplyRequest:
+    """The ``ReceiverApplyRequest`` picking *profile* against *live* would
+    produce.
 
     Used to compare "the form" against "the selected profile" as the
-    same type — a ``Profile`` is a ``ReceiverConfig`` plus identity
-    fields, and those must not participate in the "modified from X"
-    equality check.
-
-    Deliberately built through the same :func:`merge_profile_into_assertion`
-    resolution :func:`_select_profile` (in the page closure) uses to seed
-    the form from this same profile against the current *live* state —
-    a stored profile's matrix is *sparse* (absent cell = off) and its
-    optional fields mean "leave the live value alone", while the form
-    is always fully populated. Comparing a freshly-picked, untouched
-    form against a bare ``profile.model_dump()`` would almost always
-    report "modified" unless both sides go through the identical
-    resolution.
+    same type. Deliberately built through the same
+    :func:`merge_profile_into_assertion` resolution
+    :func:`_select_profile` (in the page closure) uses to seed the form
+    from this same profile against the current *live* state — a stored
+    profile's matrix is *sparse* (absent cell = off) and its optional
+    fields mean "leave the live value alone", while the form is always
+    fully populated. Comparing a freshly-picked, untouched form against
+    a bare ``profile.model_dump()`` would almost always report
+    "modified" unless both sides go through the identical resolution.
     """
     merged = merge_profile_into_assertion(profile, live)
-    return build_apply_config(
-        merged.rtcm_stream.matrix, list(profile.data_link_port), merged
-    )
+    return build_apply_request(merged, list(profile.data_link_port))
 
 
 def is_modified_from_profile(
-    form_config: ReceiverConfig, profile: Profile | None, live: ReceiverAssertion
+    form_request: ReceiverApplyRequest, profile: Profile | None, live: ReceiverAssertion
 ) -> bool:
-    """Whether *form_config* diverges from *profile* — the second, independent
-    indicator (form vs. selected profile), distinct from "out of sync" (form
-    vs. live receiver). ``False`` when no profile is selected — there is
-    nothing to have diverged from."""
+    """Whether *form_request* diverges from *profile* — the second,
+    independent indicator (form vs. selected profile), distinct from "out
+    of sync" (form vs. live receiver). ``False`` when no profile is
+    selected — there is nothing to have diverged from."""
     if profile is None:
         return False
-    return form_config != receiver_config_from_profile(profile, live)
+    return form_request != receiver_config_from_profile(profile, live)
 
 
 def save_as_enabled(
-    form_config: ReceiverConfig | None, profile: Profile | None, live: ReceiverAssertion
+    form_request: ReceiverApplyRequest | None,
+    profile: Profile | None,
+    live: ReceiverAssertion,
 ) -> bool:
     """Save-as is available whenever the form is valid, suppressed only when
     a *selected* profile still exactly equals the form."""
-    if form_config is None:
+    if form_request is None:
         return False
-    return profile is None or is_modified_from_profile(form_config, profile, live)
+    return profile is None or is_modified_from_profile(form_request, profile, live)
 
 
 def suggest_profile_name(profile: Profile | None, hardware_target: str) -> str:
@@ -385,13 +361,21 @@ def resolve_save_hardware(profile: Profile | None, identity: HardwareIdentity) -
 
 def build_saved_profile(
     name: str,
-    form_config: ReceiverConfig,
+    form_request: ReceiverApplyRequest,
     hardware: str,
     forked_from: str | None,
 ) -> Profile:
-    """Construct the ``Profile`` document Save-as persists."""
+    """Construct the ``Profile`` document Save-as persists.
+
+    Flattens *form_request*'s envelope — ``assertion``'s fields plus
+    ``data_link_port`` — onto ``Profile``'s own field layout (issue
+    #98: ``data_link_port`` moved off ``ReceiverConfig``, so it's no
+    longer part of ``assertion.model_dump()`` and must be passed
+    separately).
+    """
     return Profile(
-        **form_config.model_dump(),
+        **form_request.assertion.model_dump(),
+        data_link_port=form_request.data_link_port,
         name=name,
         version=1,
         hardware=hardware,
@@ -451,19 +435,6 @@ def hw_extras_display(assertion: ReceiverAssertion) -> list[tuple[str, str, str]
     ]
 
 
-def copy_matrix(
-    matrix: dict[RtcmRowId, dict[PortId, bool]],
-) -> dict[RtcmRowId, dict[PortId, bool]]:
-    """Deep-copy a row x port matrix so the copy can diverge independently.
-
-    A shallow ``dict(matrix)`` shares the per-row inner dicts with the
-    original — mutating one cell would silently mutate both the form
-    and the "last known live" snapshot, breaking the out-of-sync
-    comparison.
-    """
-    return {row: dict(ports) for row, ports in matrix.items()}
-
-
 def placeholder_assertion() -> ReceiverAssertion:
     """An empty ``ReceiverAssertion`` for the page's pre-connect state,
     before any live receiver read has happened."""
@@ -481,12 +452,22 @@ def placeholder_assertion() -> ReceiverAssertion:
     )
 
 
-def format_cell_diff(diff: ApplyConfigCellDiff) -> str:
-    """Render one post-apply read-back mismatch as a human-readable line."""
-    expected = "on" if diff.expected else "off"
-    actual = "on" if diff.actual else "off"
+def _format_diff_value(value: bool | int | str) -> str:
+    if isinstance(value, bool):
+        return "on" if value else "off"
+    return str(value)
+
+
+def format_leaf_diff(diff: ApplyDiffEntry) -> str:
+    """Render one post-apply read-back mismatch as a human-readable line.
+
+    *diff.path* already names the exact leaf (a matrix cell, a port's
+    protocol, a constellation, or a plain scalar field) — see
+    :func:`sp_rtk_base.models.profile_models.diff_receiver_assertions`.
+    """
     return (
-        f"{diff.row_id.value} on {diff.port.value}: expected {expected}, got {actual}"
+        f"{diff.path}: expected {_format_diff_value(diff.expected)}, "
+        f"got {_format_diff_value(diff.actual)}"
     )
 
 
@@ -1044,8 +1025,8 @@ def gps_config_page() -> None:
                 save_as_error_label.set_visibility(True)
                 return
 
-            form_config = _current_form_config()
-            if form_config is None:
+            form_request = _current_form_request()
+            if form_request is None:
                 save_as_error_label.text = (
                     "The form doesn't currently validate — fix the RTCM "
                     "matrix / data-link ports before saving."
@@ -1057,7 +1038,7 @@ def gps_config_page() -> None:
             forked_from = selected_profile.name if selected_profile else None
 
             try:
-                profile = build_saved_profile(name, form_config, hardware, forked_from)
+                profile = build_saved_profile(name, form_request, hardware, forked_from)
                 created = profile_store.create_profile(profile)
             except (ValidationError, ProfileStoreError) as exc:
                 save_as_error_label.text = str(exc)
@@ -1218,17 +1199,18 @@ def gps_config_page() -> None:
         delete_target_label: str = ""
 
         def _out_of_sync() -> bool:
-            """Matrix-only, matching what Apply actually pushes (#65/#66) —
-            the rest of ``form`` has no live read-back to verify against."""
-            return form.rtcm_stream.matrix != live.rtcm_stream.matrix
+            """Whole-form comparison (issue #98) — the same per-leaf
+            ``diff_receiver_assertions`` call Apply's read-back verify
+            uses, applied here to form vs. live. Never mentions
+            ``data_link_port`` (it isn't part of either operand), so a
+            data-link-port-only change never shows as out of sync."""
+            return bool(diff_receiver_assertions(form, live))
 
-        def _current_form_config() -> ReceiverConfig | None:
-            """The form as a ``ReceiverConfig``, or ``None`` if it doesn't
-            currently validate (e.g. no data-link port selected)."""
+        def _current_form_request() -> ReceiverApplyRequest | None:
+            """The form as a ``ReceiverApplyRequest``, or ``None`` if it
+            doesn't currently validate (e.g. no data-link port selected)."""
             try:
-                return build_apply_config(
-                    form.rtcm_stream.matrix, form_data_link_ports, form
-                )
+                return build_apply_request(form, form_data_link_ports)
             except ValidationError:
                 return None
 
@@ -1383,12 +1365,12 @@ def gps_config_page() -> None:
             profile*, distinct from "out of sync" (form vs. live receiver).
             Hidden when no profile is selected: nothing to have diverged
             from."""
-            form_config = _current_form_config()
-            if selected_profile is None or form_config is None:
+            form_request = _current_form_request()
+            if selected_profile is None or form_request is None:
                 modified_badge.set_visibility(False)
                 return
             modified_badge.set_visibility(True)
-            if is_modified_from_profile(form_config, selected_profile, live):
+            if is_modified_from_profile(form_request, selected_profile, live):
                 modified_badge.text = f"Modified from {display_label(selected_profile)}"
                 modified_badge.props("color=warning")
             else:
@@ -1397,7 +1379,7 @@ def gps_config_page() -> None:
 
         def _render_save_as_gate() -> None:
             save_as_btn.set_enabled(
-                save_as_enabled(_current_form_config(), selected_profile, live)
+                save_as_enabled(_current_form_request(), selected_profile, live)
             )
 
         def _on_form_changed() -> None:
@@ -1426,33 +1408,30 @@ def gps_config_page() -> None:
             apply_result_label.set_visibility(False)
             apply_diff_list.clear()
 
-        def _show_apply_diff(diff: list[ApplyConfigCellDiff]) -> None:
+        def _show_apply_diff(diff: list[ApplyDiffEntry]) -> None:
             apply_diff_list.clear()
             with apply_diff_list:
-                for cell in diff:
-                    ui.label(format_cell_diff(cell)).classes(
+                for leaf in diff:
+                    ui.label(format_leaf_diff(leaf)).classes(
                         "text-caption text-warning"
                     )
 
         async def _apply() -> None:
-            """Push the current form (matrix + data-link ports) to the receiver.
+            """Push the whole current form to the receiver (issue #98).
 
-            Deliberately excludes the rest of ``form`` (issue #66
-            review): those fields have no live read-back, so a
-            profile-populated value pushed through Apply could never be
-            verified by the read-back-diff below, unlike the matrix.
-            Extending Apply to the full hardware section is out of
-            #66's scope — it isn't in the acceptance criteria, and #65
-            deliberately scoped Apply to "only the RTCM matrix and the
-            data-link ports". The rest of ``form`` is still used for
-            Save-as/"modified from X", which compare in-form state and
-            never touch the receiver.
+            Apply now sends every receiver field, not just the RTCM
+            matrix — ``build_apply_request`` wraps the full ``form``
+            plus the data-link port selection into the envelope
+            ``svc.apply_receiver_config`` takes. ``live`` is replaced
+            wholesale from ``result.read_back`` — the fresh full
+            read-back the service always returns, whichever ``status``
+            — rather than patched field-by-field, so every display
+            (matrix, ports, GNSS, hardware section) stays honest after
+            both a clean apply and a partial-mismatch one.
             """
             nonlocal live
             try:
-                config = build_apply_config(
-                    form.rtcm_stream.matrix, form_data_link_ports
-                )
+                request = build_apply_request(form, form_data_link_ports)
             except ValidationError as exc:
                 _set_apply_result(
                     f"Apply refused: {exc.errors()[0]['msg']} — nothing was written.",
@@ -1461,7 +1440,7 @@ def gps_config_page() -> None:
                 return
 
             try:
-                result = await svc.apply_receiver_config(config)
+                result = await svc.apply_receiver_config(request)
             except ApplyConfigRefusedError as exc:
                 _set_apply_result(
                     f"Apply refused ({exc.rule}): {exc} — nothing was written.",
@@ -1476,26 +1455,12 @@ def gps_config_page() -> None:
                 logger.exception("apply-config failed")
                 return
 
+            live = result.read_back
+
             if result.status == "ok":
-                live = live.model_copy(
-                    update={
-                        "rtcm_stream": RtcmStreamConfig(
-                            matrix=copy_matrix(form.rtcm_stream.matrix)
-                        )
-                    }
-                )
                 _set_apply_result("Applied and verified ✓", ok=True)
                 ui.notify("Applied and verified ✓", type="positive")
             else:
-                # The writes landed but the read-back disagrees — reflect
-                # the receiver's *actual* state so "out of sync" stays
-                # honest even though only a successful apply clears it.
-                new_matrix = copy_matrix(live.rtcm_stream.matrix)
-                for cell in result.diff:
-                    new_matrix[cell.row_id][cell.port] = cell.actual
-                live = live.model_copy(
-                    update={"rtcm_stream": RtcmStreamConfig(matrix=new_matrix)}
-                )
                 _set_apply_result(
                     "Applied, but verification found mismatches — nothing "
                     "was rolled back.",

--- a/tests/e2e/test_gps_apply.py
+++ b/tests/e2e/test_gps_apply.py
@@ -115,8 +115,8 @@ def test_factory_receiver_blocks_apply_until_data_link_port_chosen(
     page.locator(".rtcm-cell-1005-UART1").click()
     page.locator(".data-link-checkbox-UART1").click()
 
-    expect(page.locator(".data-link-blocked")).not_to_be_visible()
-    expect(apply_btn).to_be_enabled()
+    expect(page.locator(".data-link-blocked")).not_to_be_visible(timeout=10_000)
+    expect(apply_btn).to_be_enabled(timeout=10_000)
 
     apply_btn.click()
     expect(page.locator(".apply-result")).to_contain_text(

--- a/tests/e2e/test_gps_profile_picker.py
+++ b/tests/e2e/test_gps_profile_picker.py
@@ -1,18 +1,20 @@
-"""E2E tests for the GPS page's profile picker + live-seeded form (issue #64).
+"""E2E tests for the GPS page's profile picker dropdown (issues #64, #105).
 
 Extends the existing GPS page suite (``test_gps_config_buttons.py``,
-``test_gps_data_flow.py``). This ticket is rendering-only — no Apply,
-no Save-as — so these tests cover:
+``test_gps_data_flow.py``). Issue #105 turned the picker's card list
+into a Quasar ``q-select`` dropdown, so these tests cover:
 
 - The form (ports, GNSS, RTCM matrix) seeds from the live receiver via
   ``connected_gps``, not from any profile.
-- The picker lists built-ins before customs, tagging compatibility and
-  greying incompatible entries with a tooltip.
-- The deterministic default is visibly suggested but never written
-  into the form.
-- The unconfirmed-hardware banner appears (and no default is
-  suggested) when the receiver's identity can't be confirmed — driven
-  through ``FakeGpsDriver``'s ``FAKE_UNKNOWN_HW_PORT`` sentinel.
+- The picker's dropdown lists built-ins before customs, tagging
+  compatibility: an incompatible option is disabled (unclickable) and
+  carries a tooltip explaining why.
+- The deterministic default is visibly highlighted/suggested in the
+  dropdown but never written into the form until picked.
+- The unconfirmed-hardware banner appears (and no option is
+  highlighted as suggested) when the receiver's identity can't be
+  confirmed — driven through ``FakeGpsDriver``'s ``FAKE_UNKNOWN_HW_PORT``
+  sentinel.
 - The matrix highlights the data-link columns and tags 1005 required.
 
 Locators target the stable ``profile-*`` / ``rtcm-*`` CSS class hooks
@@ -20,6 +22,11 @@ the page renders (see ``ui/pages/gps_config.py``) rather than text
 substrings — several page strings (e.g. the unconfirmed-hardware
 banner's "...no profile is suggested") share words with the things
 under test, which makes plain ``get_by_text`` matches ambiguous.
+
+The dropdown's option list only exists in the DOM while the popup is
+open (it's a Quasar ``q-menu``, mounted/unmounted on open/close), so
+every test that inspects an option opens the picker first via
+``.profile-picker`` before locating ``.profile-option-*``.
 """
 
 from __future__ import annotations
@@ -106,6 +113,12 @@ def _goto_gps_config(page: Page, base_url: str) -> None:
     )
 
 
+def _open_picker(page: Page) -> None:
+    """Open the profile dropdown — its options only mount while open."""
+    expect(page.locator(".profile-picker")).to_be_visible(timeout=10_000)
+    page.locator(".profile-picker").click()
+
+
 @pytest.mark.e2e
 def test_form_seeds_matrix_and_gnss_from_live_receiver(
     page: Page,
@@ -158,71 +171,128 @@ def test_matrix_tags_1005_required_and_highlights_data_link_columns(
 
 
 @pytest.mark.e2e
-def test_picker_lists_builtin_before_custom_and_greys_incompatible(
+def test_picker_is_a_dropdown_listing_builtin_before_custom(
     page: Page,
     base_url: str,
     connected_gps: None,
     custom_incompatible_profile: None,
 ) -> None:
-    """Built-in appears before the incompatible custom, which is greyed + tooltipped."""
+    """AC: "The picker renders as a dropdown rather than a card list."
+
+    The control itself is a ``q-select`` (queried via ``.profile-picker``,
+    a ``role=combobox``), and its options — only mounted once the
+    dropdown is opened — list the built-in before the custom.
+    """
     _goto_gps_config(page, base_url)
 
-    builtin_row = page.locator(f".profile-row-{BUILTIN_NAME}")
-    custom_name = CUSTOM_INCOMPATIBLE_PROFILE["name"]
-    custom_row = page.locator(f".profile-row-{custom_name}")
-    expect(builtin_row).to_be_visible(timeout=10_000)
-    expect(custom_row).to_be_visible(timeout=10_000)
+    picker = page.locator(".profile-picker")
+    expect(picker).to_be_visible(timeout=10_000)
+    expect(picker.locator('[role="combobox"]')).to_have_count(1)
 
-    builtin_box = builtin_row.bounding_box()
-    custom_box = custom_row.bounding_box()
+    _open_picker(page)
+    custom_name = CUSTOM_INCOMPATIBLE_PROFILE["name"]
+    builtin_option = page.locator(f".profile-option-{BUILTIN_NAME}")
+    custom_option = page.locator(f".profile-option-{custom_name}")
+    expect(builtin_option).to_be_visible(timeout=10_000)
+    expect(custom_option).to_be_visible(timeout=10_000)
+
+    builtin_box = builtin_option.bounding_box()
+    custom_box = custom_option.bounding_box()
     assert builtin_box is not None and custom_box is not None
     assert builtin_box["y"] < custom_box["y"], (
         "built-in profile should render above the custom profile"
     )
 
-    # Greyed + tooltip: the incompatible custom's row carries an info
-    # icon whose hover tooltip names the mismatched hardware.
-    info_icon = custom_row.locator(".profile-incompatible-icon")
-    expect(info_icon).to_be_visible()
-    info_icon.hover()
+
+@pytest.mark.e2e
+def test_incompatible_option_is_disabled_with_tooltip(
+    page: Page,
+    base_url: str,
+    connected_gps: None,
+    custom_incompatible_profile: None,
+) -> None:
+    """AC: "Profiles incompatible with the connected hardware are disabled
+    and carry a tooltip explaining why."
+
+    Covers both halves: the option carries the disabled CSS hook and a
+    hover tooltip naming the mismatched hardware, *and* clicking it is
+    a no-op — nothing gets selected (the "modified from X" indicator,
+    which only appears once a profile is picked, stays hidden).
+    """
+    _goto_gps_config(page, base_url)
+    _open_picker(page)
+
+    custom_name = CUSTOM_INCOMPATIBLE_PROFILE["name"]
+    builtin_option = page.locator(f".profile-option-{BUILTIN_NAME}")
+    custom_option = page.locator(f".profile-option-{custom_name}")
+    expect(builtin_option).to_be_visible(timeout=10_000)
+    expect(custom_option).to_be_visible(timeout=10_000)
+
+    expect(custom_option).to_have_class(re.compile("profile-option-disabled"))
+    expect(builtin_option).not_to_have_class(re.compile("profile-option-disabled"))
+
+    custom_option.hover()
     expect(page.get_by_text("not for this hardware (ZED-F9P)")).to_be_visible(
         timeout=5_000
     )
-    expect(builtin_row.locator(".profile-incompatible-icon")).to_have_count(0)
+
+    # Disabled options stay hoverable (that's how the tooltip above
+    # works) but a click must still be a no-op — force the click since
+    # the option isn't Quasar-"clickable" and Playwright's actionability
+    # check would otherwise refuse it.
+    custom_option.click(force=True)
+    page.wait_for_timeout(300)
+    expect(page.locator(".modified-badge")).to_be_hidden()
 
 
 @pytest.mark.e2e
-def test_default_is_suggested_but_not_written_to_form(
+def test_suggested_profile_is_highlighted_but_not_written_to_form(
     page: Page,
     base_url: str,
     connected_gps: None,
 ) -> None:
-    """The confirmed-compatible built-in is badged "Suggested"; the form stays live-seeded."""
-    _goto_gps_config(page, base_url)
+    """AC: "The suggested profile for the detected hardware is highlighted."
 
-    builtin_row = page.locator(f".profile-row-{BUILTIN_NAME}")
-    expect(builtin_row).to_be_visible(timeout=10_000)
-    expect(builtin_row.locator(".profile-suggested-badge")).to_be_visible()
+    The confirmed-compatible built-in carries the suggested badge and
+    highlight class in the dropdown; the form stays live-seeded until
+    actually picked.
+    """
+    _goto_gps_config(page, base_url)
+    _open_picker(page)
+
+    builtin_option = page.locator(f".profile-option-{BUILTIN_NAME}")
+    expect(builtin_option).to_be_visible(timeout=10_000)
+    expect(builtin_option).to_have_class(re.compile("profile-option-suggested"))
+    expect(builtin_option.locator(".profile-suggested-badge")).to_be_visible()
+
+    page.keyboard.press("Escape")
 
     # The built-in profile's matrix has UART2 enabled for 1077; the
     # fake driver's live read-back does not (UART1+USB only). If the
     # form had been written from the "suggested" profile, this cell
     # would show "on". It must instead reflect the live receiver.
     expect(page.locator(".rtcm-cell-1077-UART2")).to_have_text("-", timeout=10_000)
+    expect(page.locator(".modified-badge")).to_be_hidden()
 
 
 @pytest.mark.e2e
-def test_unconfirmed_hardware_banner_shown_with_no_default(
+def test_unconfirmed_hardware_banner_shown_with_no_suggestion(
     page: Page,
     base_url: str,
     connected_gps_unknown_hw: None,
 ) -> None:
-    """Unresolved hardware identity shows the banner and suggests nothing."""
+    """AC: "A banner appears when the hardware has not been confirmed."
+
+    Unresolved hardware identity shows the banner and highlights no
+    option as suggested.
+    """
     _goto_gps_config(page, base_url)
 
-    profile_card = page.locator(".q-card:has(.profile-row)").first
+    profile_card = page.locator(".q-card:has(.profile-picker)").first
     expect(profile_card).to_be_visible(timeout=10_000)
     expect(profile_card.get_by_text("Unconfirmed hardware")).to_be_visible(
         timeout=10_000
     )
-    expect(profile_card.locator(".profile-suggested-badge")).to_have_count(0)
+
+    _open_picker(page)
+    expect(page.locator(".profile-suggested-badge")).to_have_count(0)

--- a/tests/e2e/test_gps_profile_save_as.py
+++ b/tests/e2e/test_gps_profile_save_as.py
@@ -1,10 +1,10 @@
-"""E2E tests for profile pre-fill, Save-as, and the modified-from-profile
-indicator (issue #66).
+"""E2E tests for profile pre-fill, Save-as, and the profile-relation
+indicator (issues #66, #105).
 
 Extends the GPS page suite (``test_gps_profile_picker.py`` covers the
-read-only #64 shell, ``test_gps_apply.py`` covers #65's out-of-sync
-indicator + Apply). This ticket makes picking a profile actually write
-into the form and adds the *second*, independent indicator:
+picker dropdown itself, ``test_gps_apply.py`` covers #65's out-of-sync
+indicator + Apply). This suite covers picking a profile actually
+writing into the form, plus the *second*, independent indicator:
 
 - Selecting a compatible profile pre-fills the matrix, the data-link
   picker, and the "Hardware Section" display; the "modified from X"
@@ -21,10 +21,14 @@ into the form and adds the *second*, independent indicator:
 - Saving forks an independent custom profile carrying a
   ``forked_from`` provenance label; a name collision surfaces inline
   rather than silently overwriting.
-- Rename/delete/export are customs-only.
+- Rename/delete/export are customs-only, and act on whichever profile
+  is currently selected in the dropdown (issue #105 moved them from a
+  per-row icon set to a single icon trio beside the picker).
 
 Locators target the stable CSS class hooks the page renders (see
 ``ui/pages/gps_config.py``), matching the existing suite's convention.
+The dropdown's options only exist in the DOM while the popup is open,
+so selecting a profile always opens ``.profile-picker`` first.
 """
 
 from __future__ import annotations
@@ -37,8 +41,8 @@ from playwright.sync_api import Page, expect
 
 BUILTIN_NAME = "ublox-f9p-base-standard"
 #: The built-in's ``display_name`` (issue #95) — provenance labels
-#: (picker row, "Matches"/"Modified from", "Forked from") render this,
-#: not the slug ``BUILTIN_NAME``.
+#: (picker option, "Matches"/"Modified from", "Forked from") render
+#: this, not the slug ``BUILTIN_NAME``.
 BUILTIN_DISPLAY_NAME = "u-blox F9P — Base Station (Standard)"
 
 
@@ -81,8 +85,22 @@ def _goto_gps_config(page: Page, base_url: str) -> None:
     expect(page.locator(".rtcm-cell-1005-UART1")).to_have_text("✓", timeout=10_000)
 
 
+def _select_profile_option(page: Page, slug: str) -> None:
+    """Open the picker dropdown and click the option identified by *slug*.
+
+    The option list only mounts in the DOM while the dropdown is open
+    (it's a Quasar ``q-menu``), so every pick opens ``.profile-picker``
+    first.
+    """
+    expect(page.locator(".profile-picker")).to_be_visible(timeout=10_000)
+    page.locator(".profile-picker").click()
+    option = page.locator(f".profile-option-{slug}")
+    expect(option).to_be_visible(timeout=10_000)
+    option.click()
+
+
 def _select_builtin(page: Page) -> None:
-    """Click the built-in row and wait for the pick to fully settle.
+    """Pick the built-in profile and wait for the pick to fully settle.
 
     ``_select_profile`` re-renders several sections over the NiceGUI
     websocket round-trip; without waiting for the last of them
@@ -90,9 +108,7 @@ def _select_builtin(page: Page) -> None:
     a next action can land before the pick has actually taken effect
     client-side.
     """
-    builtin_row = page.locator(f".profile-row-{BUILTIN_NAME}")
-    expect(builtin_row).to_be_visible(timeout=10_000)
-    builtin_row.locator(".profile-name").click()
+    _select_profile_option(page, BUILTIN_NAME)
     expect(page.locator(".modified-badge")).to_contain_text(
         f"Matches {BUILTIN_DISPLAY_NAME}", timeout=10_000
     )
@@ -230,7 +246,8 @@ def test_save_as_forks_a_custom_profile_with_provenance(
     # The edited cell made it into the saved document.
     assert body["profile"]["rtcm_stream"]["matrix"]["1077"]["UART1"] is True
 
-    expect(page.locator(f".profile-row-{forked_name}")).to_be_visible(timeout=10_000)
+    page.locator(".profile-picker").click()
+    expect(page.locator(f".profile-option-{forked_name}")).to_be_visible(timeout=10_000)
 
 
 @pytest.mark.e2e
@@ -296,6 +313,9 @@ def test_rename_delete_export_are_customs_only(
     connected_gps: None,
     cleanup_profiles: list[str],
 ) -> None:
+    """Rename/delete/export (issue #105: a single icon trio beside the
+    picker, acting on whichever profile is currently selected) only
+    show up once a *custom* profile is the current selection."""
     custom = {
         "name": "e2e-custom-actions",
         "version": 1,
@@ -309,17 +329,20 @@ def test_rename_delete_export_are_customs_only(
 
     _goto_gps_config(page, base_url)
 
-    builtin_row = page.locator(f".profile-row-{BUILTIN_NAME}")
-    expect(builtin_row).to_be_visible(timeout=10_000)
-    expect(builtin_row.locator(".profile-rename-icon")).to_have_count(0)
-    expect(builtin_row.locator(".profile-delete-icon")).to_have_count(0)
-    expect(builtin_row.locator(".profile-export-icon")).to_have_count(0)
+    # Nothing selected yet — the icons stay hidden.
+    expect(page.locator(".profile-rename-icon")).to_be_hidden()
+    expect(page.locator(".profile-delete-icon")).to_be_hidden()
+    expect(page.locator(".profile-export-icon")).to_be_hidden()
 
-    custom_row = page.locator(".profile-row-e2e-custom-actions")
-    expect(custom_row).to_be_visible()
-    expect(custom_row.locator(".profile-rename-icon")).to_have_count(1)
-    expect(custom_row.locator(".profile-delete-icon")).to_have_count(1)
-    expect(custom_row.locator(".profile-export-icon")).to_have_count(1)
+    _select_profile_option(page, BUILTIN_NAME)
+    expect(page.locator(".profile-rename-icon")).to_be_hidden()
+    expect(page.locator(".profile-delete-icon")).to_be_hidden()
+    expect(page.locator(".profile-export-icon")).to_be_hidden()
+
+    _select_profile_option(page, "e2e-custom-actions")
+    expect(page.locator(".profile-rename-icon")).to_be_visible()
+    expect(page.locator(".profile-delete-icon")).to_be_visible()
+    expect(page.locator(".profile-export-icon")).to_be_visible()
 
 
 @pytest.mark.e2e
@@ -330,8 +353,8 @@ def test_rename_then_delete_custom_profile(
     connected_gps: None,
     cleanup_profiles: list[str],
 ) -> None:
-    """Rename edits the display name only — the slug (and so the row's
-    CSS identity, ``.profile-row-e2e-rename-me``) never changes; only
+    """Rename edits the display name only — the slug (and so the option's
+    CSS identity, ``.profile-option-e2e-rename-me``) never changes; only
     the rendered label updates."""
     custom = {
         "name": "e2e-rename-me",
@@ -346,19 +369,24 @@ def test_rename_then_delete_custom_profile(
 
     _goto_gps_config(page, base_url)
 
-    row = page.locator(".profile-row-e2e-rename-me")
-    expect(row).to_be_visible(timeout=10_000)
-    row.locator(".profile-rename-icon").click()
+    _select_profile_option(page, "e2e-rename-me")
+    page.locator(".profile-rename-icon").click()
 
     # No display_name set yet — the dialog falls back to the slug.
     expect(page.locator(".rename-name input")).to_have_value("e2e-rename-me")
     page.locator(".rename-name input").fill("e2e Renamed")
     page.locator(".rename-confirm-btn").click()
 
-    # Same row (same slug) — only the visible label changed.
-    expect(row).to_be_visible(timeout=10_000)
-    expect(row.locator(".profile-name")).to_have_text("e2e Renamed")
+    # Same option (same slug) — only the visible label changed.
+    page.locator(".profile-picker").click()
+    option = page.locator(".profile-option-e2e-rename-me")
+    expect(option).to_be_visible(timeout=10_000)
+    expect(option).to_contain_text("e2e Renamed")
+    page.keyboard.press("Escape")
 
-    row.locator(".profile-delete-icon").click()
+    page.locator(".profile-delete-icon").click()
     page.locator(".delete-confirm-btn").click()
-    expect(page.locator(".profile-row-e2e-rename-me")).to_have_count(0, timeout=10_000)
+    expect(page.locator(".profile-delete-icon")).to_be_hidden(timeout=10_000)
+
+    page.locator(".profile-picker").click()
+    expect(page.locator(".profile-option-e2e-rename-me")).to_have_count(0)

--- a/tests/unit/test_api_device.py
+++ b/tests/unit/test_api_device.py
@@ -548,24 +548,45 @@ class TestBaseConfig:
 # Apply-config — the profile one-shot (issue #61)
 # ---------------------------------------------------------------------------
 
-_MINIMAL_APPLY_BODY: dict[str, object] = {
-    "data_link_port": ["UART1"],
+_MINIMAL_ASSERTION_BODY: dict[str, object] = {
+    "baud": {"uart1": 57600, "uart2": 115200},
+    "meas_period_ms": 1000,
+    "constellations": [],
+    "ports": {},
+    "dyn_model": "portable",
+    "tmode_mode": "disabled",
+    "elevation_mask_deg": 0,
+    "bds_b2_enabled": False,
+    "spi_enabled": False,
     "rtcm_stream": {"matrix": {"1005": {"UART1": True}}},
 }
 
+_MINIMAL_APPLY_BODY: dict[str, object] = {
+    "assertion": _MINIMAL_ASSERTION_BODY,
+    "data_link_port": ["UART1"],
+}
+
+
+def _minimal_read_back() -> object:
+    """A ``ReceiverAssertion`` matching ``_MINIMAL_ASSERTION_BODY`` — the
+    read-back every mocked ``ApplyConfigResult`` in this section carries."""
+    from sp_rtk_base.models.profile_models import ReceiverAssertion
+
+    return ReceiverAssertion.model_validate(_MINIMAL_ASSERTION_BODY)
+
 
 class TestApplyConfig:
-    """Tests for POST /api/device/apply-config."""
+    """Tests for POST /api/device/apply-config (issue #98)."""
 
     def test_apply_config_ok(
         self,
         client: TestClient,
         mock_device_service: MagicMock,
     ) -> None:
-        from sp_rtk_base.models.device_models import ApplyConfigResult
+        from sp_rtk_base.models.profile_models import ApplyConfigResult
 
         mock_device_service.apply_receiver_config = AsyncMock(
-            return_value=ApplyConfigResult(status="ok")
+            return_value=ApplyConfigResult(status="ok", read_back=_minimal_read_back())
         )
         resp = client.post("/api/device/apply-config", json=_MINIMAL_APPLY_BODY)
         assert resp.status_code == 200
@@ -577,20 +598,15 @@ class TestApplyConfig:
         client: TestClient,
         mock_device_service: MagicMock,
     ) -> None:
-        from sp_rtk_base.models.device_models import (
-            ApplyConfigCellDiff,
-            ApplyConfigResult,
-            PortId,
-            RtcmRowId,
-        )
+        from sp_rtk_base.models.profile_models import ApplyConfigResult, ApplyDiffEntry
 
         mock_device_service.apply_receiver_config = AsyncMock(
             return_value=ApplyConfigResult(
                 status="failed",
+                read_back=_minimal_read_back(),
                 diff=[
-                    ApplyConfigCellDiff(
-                        row_id=RtcmRowId.RTCM_1005,
-                        port=PortId.UART1,
+                    ApplyDiffEntry(
+                        path="rtcm.1005.UART1",
                         expected=True,
                         actual=False,
                     )
@@ -604,8 +620,7 @@ class TestApplyConfig:
         assert body["status"] == "failed"
         assert body["diff"] == [
             {
-                "row_id": "1005",
-                "port": "UART1",
+                "path": "rtcm.1005.UART1",
                 "expected": True,
                 "actual": False,
             }
@@ -646,7 +661,7 @@ class TestApplyConfig:
         handled entirely by pydantic before the service is called."""
         resp = client.post(
             "/api/device/apply-config",
-            json={"rtcm_stream": {"matrix": {"1005": {"UART1": True}}}},
+            json={"assertion": _MINIMAL_ASSERTION_BODY},
         )
         assert resp.status_code == 422
 
@@ -727,10 +742,10 @@ class TestApplyBaseInvariants:
         client: TestClient,
         mock_device_service: MagicMock,
     ) -> None:
-        from sp_rtk_base.models.device_models import ApplyConfigResult
+        from sp_rtk_base.models.profile_models import ApplyConfigResult
 
         mock_device_service.apply_base_invariants = AsyncMock(
-            return_value=ApplyConfigResult(status="ok")
+            return_value=ApplyConfigResult(status="ok", read_back=_minimal_read_back())
         )
         resp = client.post("/api/device/apply-base-invariants")
         assert resp.status_code == 200

--- a/tests/unit/test_device_service.py
+++ b/tests/unit/test_device_service.py
@@ -28,9 +28,11 @@ from sp_rtk_base.models.device_models import (
     UbxProtocol,
 )
 from sp_rtk_base.models.profile_models import (
-    BaudConfig,
+    ApplyConfigResult,
+    BaudAssertion,
     PortProtocolSet,
-    ReceiverConfig,
+    ReceiverApplyRequest,
+    ReceiverAssertion,
     RtcmStreamConfig,
 )
 from sp_rtk_base.services.device_service import (
@@ -508,20 +510,99 @@ class TestGetReceiverAssertion:
 # ---------------------------------------------------------------------------
 
 
-def _minimal_config(**overrides: object) -> ReceiverConfig:
-    """A minimal valid ``ReceiverConfig`` — 1005 enabled on the one data-link port."""
+def _minimal_assertion(**overrides: object) -> ReceiverAssertion:
+    """A fully-populated, minimal-but-valid assertion — 1005 enabled on
+    UART1, everything else at an unambiguous, easy-to-assert-on default.
+
+    Matches ``TestApplyReceiverConfig.connected_svc``'s default driver
+    reads exactly (baud, meas rate, dyn model, tmode mode, optimisation
+    fields) — so a request built from this with no overrides round-trips
+    through a mocked apply as ``status="ok"`` with nothing rewritten,
+    and any single overridden field is the one and only thing that
+    differs from "the receiver's current state" for that test.
+    """
     defaults: dict[str, object] = {
-        "data_link_port": [PortId.UART1],
+        "baud": BaudAssertion(uart1=57600, uart2=115200),
+        "meas_period_ms": 1000,
+        "constellations": [],
+        "ports": {},
+        "dyn_model": DynModel.PORTABLE,
+        "tmode_mode": BaseMode.DISABLED,
+        "elevation_mask_deg": 0,
+        "bds_b2_enabled": False,
+        "spi_enabled": False,
         "rtcm_stream": RtcmStreamConfig(
             matrix={RtcmRowId.RTCM_1005: {PortId.UART1: True}}
         ),
     }
     defaults.update(overrides)
-    return ReceiverConfig(**defaults)  # type: ignore[arg-type]
+    return ReceiverAssertion(**defaults)  # type: ignore[arg-type]
+
+
+def _minimal_request(
+    *, data_link_port: list[PortId] | None = None, **assertion_overrides: object
+) -> ReceiverApplyRequest:
+    """The envelope ``apply_receiver_config`` takes — wraps
+    :func:`_minimal_assertion` with a one-UART data-link selection by
+    default."""
+    return ReceiverApplyRequest(
+        assertion=_minimal_assertion(**assertion_overrides),
+        data_link_port=(
+            data_link_port if data_link_port is not None else [PortId.UART1]
+        ),
+    )
+
+
+def _scalars_for(assertion: ReceiverAssertion) -> ReceiverScalarConfig:
+    """The ``ReceiverScalarConfig`` a driver read would need to return
+    for :func:`build_receiver_assertion` to reconstruct *assertion*'s
+    scalar fields exactly."""
+    return ReceiverScalarConfig(
+        uart1_baud=assertion.baud.uart1,
+        uart2_baud=assertion.baud.uart2,
+        meas_period_ms=assertion.meas_period_ms,
+        dyn_model=assertion.dyn_model,
+        tmode_mode=assertion.tmode_mode,
+        elevation_mask_deg=assertion.elevation_mask_deg,
+        bds_b2_enabled=assertion.bds_b2_enabled,
+        spi_enabled=assertion.spi_enabled,
+    )
+
+
+def _mock_read_back_matches(driver: MagicMock, assertion: ReceiverAssertion) -> None:
+    """Point every read-back driver method at values that reconstruct
+    exactly *assertion* via ``build_receiver_assertion`` — used by tests
+    that apply a request and then assert ``status == "ok"`` even though
+    the request deliberately diverges from the fixture's defaults.
+
+    Sets ``get_receiver_scalars.return_value`` too — fine for tests
+    that don't care whether the pre-write skip-decision "current"
+    reads the new or old scalars, but tests exercising the meas-rate/
+    baud unchanged-skip explicitly override ``.side_effect`` afterwards
+    (this function's `.return_value`` is then ignored).
+    """
+    driver.get_rtcm_port_config.return_value = RtcmPortConfig(
+        messages={
+            row: {port.value: int(on) for port, on in ports.items()}
+            for row, ports in assertion.rtcm_stream.matrix.items()
+        }
+    )
+    driver.get_port_protocols.return_value = PortProtocolConfig(
+        in_protocols={port: cfg.in_ for port, cfg in assertion.ports.items()},
+        out_protocols={port: cfg.out for port, cfg in assertion.ports.items()},
+    )
+    wanted = set(assertion.constellations)
+    driver.get_gnss_config.return_value = GnssConfig(
+        systems=[
+            GnssSystemConfig(constellation=c, enabled=c in wanted)
+            for c in GnssConstellation
+        ]
+    )
+    driver.get_receiver_scalars.return_value = _scalars_for(assertion)
 
 
 class TestApplyReceiverConfig:
-    """Tests for ``DeviceService.apply_receiver_config`` (issue #61)."""
+    """Tests for ``DeviceService.apply_receiver_config`` (issue #98)."""
 
     @pytest.fixture()
     def connected_svc(self) -> DeviceService:
@@ -529,11 +610,15 @@ class TestApplyReceiverConfig:
         driver = _make_mock_driver()
         driver.get_base_config.return_value = CurrentBaseConfig(mode=BaseMode.DISABLED)
         driver.get_gnss_config.return_value = GnssConfig(systems=[])
-        # Matches ``_minimal_config()``'s matrix by default so tests that
-        # don't care about the read-back diff see status="ok".
+        # Matches ``_minimal_assertion()`` exactly by default, so tests
+        # that don't care about the read-back diff see status="ok" and
+        # the meas-rate/baud unchanged-skip fires for anything that
+        # doesn't deliberately override those fields.
         driver.get_rtcm_port_config.return_value = RtcmPortConfig(
             messages={RtcmRowId.RTCM_1005: {"UART1": 1}}
         )
+        driver.get_port_protocols.return_value = PortProtocolConfig()
+        driver.get_receiver_scalars.return_value = _scalars_for(_minimal_assertion())
         driver.get_uart_baud_rates.return_value = {
             PortId.UART1: 57600,
             PortId.UART2: 115200,
@@ -549,14 +634,38 @@ class TestApplyReceiverConfig:
         svc = DeviceService()
         svc.set_driver(_make_mock_driver())
         with pytest.raises(RuntimeError, match="Device not connected"):
-            await svc.apply_receiver_config(_minimal_config())
+            await svc.apply_receiver_config(_minimal_request())
 
     @pytest.mark.asyncio()
-    async def test_baud_omitted_is_allowed(self, connected_svc: DeviceService) -> None:
-        result = await connected_svc.apply_receiver_config(
-            _minimal_config(baud=BaudConfig())
+    async def test_meas_period_ms_unchanged_is_not_rewritten(
+        self, connected_svc: DeviceService
+    ) -> None:
+        """Issue #98 acceptance criterion: applying with an unchanged
+        measurement rate no longer rewrites it."""
+        assert connected_svc.driver is not None
+        await connected_svc.apply_receiver_config(_minimal_request())
+        connected_svc.driver.configure_measurement_rate.assert_not_called()  # type: ignore[union-attr]
+
+    @pytest.mark.asyncio()
+    async def test_meas_period_ms_changed_is_rewritten(
+        self, connected_svc: DeviceService
+    ) -> None:
+        assert connected_svc.driver is not None
+        await connected_svc.apply_receiver_config(_minimal_request(meas_period_ms=333))
+        connected_svc.driver.configure_measurement_rate.assert_called_once_with(  # type: ignore[union-attr]
+            333
         )
+
+    @pytest.mark.asyncio()
+    async def test_baud_unchanged_is_not_rewritten(
+        self, connected_svc: DeviceService
+    ) -> None:
+        driver = connected_svc.driver
+        assert driver is not None
+        result = await connected_svc.apply_receiver_config(_minimal_request())
         assert result.status == "ok"
+        driver.configure_baud.assert_not_called()  # type: ignore[union-attr]
+        driver.reconnect_at_baud.assert_not_called()  # type: ignore[union-attr]
 
     @pytest.mark.asyncio()
     async def test_baud_written_last_after_every_other_key(
@@ -567,13 +676,9 @@ class TestApplyReceiverConfig:
         driver.reconnect_at_baud.return_value = DeviceInfo(  # type: ignore[union-attr]
             vendor="MockVendor", model="MockModel"
         )
-        config = _minimal_config(
-            baud=BaudConfig(uart1=115200),
-            dyn_model=DynModel.STATIONARY,
-            tmode_mode=BaseMode.DISABLED,
-        )
+        request = _minimal_request(baud=BaudAssertion(uart1=115200, uart2=115200))
 
-        await connected_svc.apply_receiver_config(config)
+        await connected_svc.apply_receiver_config(request)
 
         write_methods = {
             "configure_measurement_rate",
@@ -600,9 +705,9 @@ class TestApplyReceiverConfig:
         driver.reconnect_at_baud.return_value = DeviceInfo(  # type: ignore[union-attr]
             vendor="MockVendor", model="MockModel"
         )
-        config = _minimal_config(baud=BaudConfig(uart1=115200, uart2=38400))
+        request = _minimal_request(baud=BaudAssertion(uart1=115200, uart2=38400))
 
-        await connected_svc.apply_receiver_config(config)
+        await connected_svc.apply_receiver_config(request)
 
         driver.configure_baud.assert_called_once_with(115200, 38400)  # type: ignore[union-attr]
 
@@ -613,9 +718,14 @@ class TestApplyReceiverConfig:
         """UART2 isn't the port this console's own link is on — no reopen."""
         driver = connected_svc.driver
         assert driver is not None
-        config = _minimal_config(baud=BaudConfig(uart2=38400))
+        request = _minimal_request(baud=BaudAssertion(uart1=57600, uart2=38400))
+        _mock_read_back_matches(driver, request.assertion)
+        driver.get_receiver_scalars.side_effect = [
+            _scalars_for(_minimal_assertion()),
+            _scalars_for(request.assertion),
+        ]
 
-        result = await connected_svc.apply_receiver_config(config)
+        result = await connected_svc.apply_receiver_config(request)
 
         assert result.status == "ok"
         driver.configure_baud.assert_called_once_with(None, 38400)  # type: ignore[union-attr]
@@ -630,9 +740,14 @@ class TestApplyReceiverConfig:
         driver.reconnect_at_baud.return_value = DeviceInfo(  # type: ignore[union-attr]
             vendor="MockVendor", model="MockModel"
         )
-        config = _minimal_config(baud=BaudConfig(uart1=115200))
+        request = _minimal_request(baud=BaudAssertion(uart1=115200, uart2=115200))
+        _mock_read_back_matches(driver, request.assertion)
+        driver.get_receiver_scalars.side_effect = [
+            _scalars_for(_minimal_assertion()),
+            _scalars_for(request.assertion),
+        ]
 
-        result = await connected_svc.apply_receiver_config(config)
+        result = await connected_svc.apply_receiver_config(request)
 
         assert result.status == "ok"
         driver.reconnect_at_baud.assert_called_once_with(115200)  # type: ignore[union-attr]
@@ -653,9 +768,9 @@ class TestApplyReceiverConfig:
         driver.reconnect_at_baud.return_value = DeviceInfo(  # type: ignore[union-attr]
             vendor="MockVendor", model="MockModel"
         )
-        config = _minimal_config(baud=BaudConfig(uart1=115200))
+        request = _minimal_request(baud=BaudAssertion(uart1=115200, uart2=115200))
 
-        await connected_svc.apply_receiver_config(config)
+        await connected_svc.apply_receiver_config(request)
 
         assert connected_svc._baud_rate == 115200  # pyright: ignore[reportPrivateUsage]
 
@@ -669,10 +784,10 @@ class TestApplyReceiverConfig:
         driver.reconnect_at_baud.side_effect = ConnectionError(  # type: ignore[union-attr]
             "no response"
         )
-        config = _minimal_config(baud=BaudConfig(uart1=115200))
+        request = _minimal_request(baud=BaudAssertion(uart1=115200, uart2=115200))
 
         with pytest.raises(ApplyConfigLinkLostError) as exc_info:
-            await connected_svc.apply_receiver_config(config)
+            await connected_svc.apply_receiver_config(request)
 
         assert exc_info.value.previous_baud == 57600
         assert exc_info.value.new_baud == 115200
@@ -696,10 +811,10 @@ class TestApplyReceiverConfig:
             ConnectionError("no response at new baud"),
             DeviceInfo(vendor="MockVendor", model="MockModel"),
         ]
-        config = _minimal_config(baud=BaudConfig(uart1=115200))
+        request = _minimal_request(baud=BaudAssertion(uart1=115200, uart2=115200))
 
         with pytest.raises(ApplyConfigLinkLostError):
-            await connected_svc.apply_receiver_config(config)
+            await connected_svc.apply_receiver_config(request)
 
         assert connected_svc.state == DeviceConnectionState.CONNECTED
         assert connected_svc._baud_rate == 57600  # pyright: ignore[reportPrivateUsage]
@@ -710,12 +825,12 @@ class TestApplyReceiverConfig:
         self, connected_svc: DeviceService
     ) -> None:
         assert connected_svc.driver is not None
-        config = _minimal_config(
+        request = _minimal_request(
             ports={PortId.USB: PortProtocolSet(**{"in": [UbxProtocol.NMEA], "out": []})}
         )
 
         with pytest.raises(ApplyConfigRefusedError) as exc_info:
-            await connected_svc.apply_receiver_config(config)
+            await connected_svc.apply_receiver_config(request)
 
         assert exc_info.value.rule == "ubx_in_liveness"
         connected_svc.driver.configure_measurement_rate.assert_not_called()  # type: ignore[union-attr]
@@ -725,14 +840,18 @@ class TestApplyReceiverConfig:
     async def test_ubx_in_present_on_usb_is_allowed(
         self, connected_svc: DeviceService
     ) -> None:
-        config = _minimal_config(
+        driver = connected_svc.driver
+        assert driver is not None
+        request = _minimal_request(
             ports={
                 PortId.USB: PortProtocolSet(
                     **{"in": [UbxProtocol.UBX], "out": [UbxProtocol.NMEA]}
                 )
             }
         )
-        result = await connected_svc.apply_receiver_config(config)
+        _mock_read_back_matches(driver, request.assertion)
+
+        result = await connected_svc.apply_receiver_config(request)
         assert result.status == "ok"
 
     @pytest.mark.asyncio()
@@ -743,10 +862,10 @@ class TestApplyReceiverConfig:
         connected_svc.driver.get_base_config.return_value = CurrentBaseConfig(  # type: ignore[union-attr]
             mode=BaseMode.DISABLED, latitude=0.0, longitude=0.0, altitude_m=0.0
         )
-        config = _minimal_config(tmode_mode=BaseMode.FIXED)
+        request = _minimal_request(tmode_mode=BaseMode.FIXED)
 
         with pytest.raises(ApplyConfigRefusedError) as exc_info:
-            await connected_svc.apply_receiver_config(config)
+            await connected_svc.apply_receiver_config(request)
 
         assert exc_info.value.rule == "tmode_fixed_requires_coordinates"
         connected_svc.driver.configure_measurement_rate.assert_not_called()  # type: ignore[union-attr]
@@ -755,25 +874,25 @@ class TestApplyReceiverConfig:
     async def test_tmode_fixed_with_coordinates_succeeds(
         self, connected_svc: DeviceService
     ) -> None:
-        assert connected_svc.driver is not None
-        connected_svc.driver.get_base_config.return_value = CurrentBaseConfig(  # type: ignore[union-attr]
+        driver = connected_svc.driver
+        assert driver is not None
+        driver.get_base_config.return_value = CurrentBaseConfig(
             mode=BaseMode.FIXED, latitude=47.0, longitude=8.0, altitude_m=400.0
         )
-        config = _minimal_config(tmode_mode=BaseMode.FIXED)
+        request = _minimal_request(tmode_mode=BaseMode.FIXED)
+        _mock_read_back_matches(driver, request.assertion)
 
-        result = await connected_svc.apply_receiver_config(config)
+        result = await connected_svc.apply_receiver_config(request)
 
         assert result.status == "ok"
-        connected_svc.driver.configure_tmode_mode.assert_called_once_with(  # type: ignore[union-attr]
-            BaseMode.FIXED
-        )
+        driver.configure_tmode_mode.assert_called_once_with(BaseMode.FIXED)
 
     @pytest.mark.asyncio()
     async def test_write_order_matches_the_specified_sequence(
         self, connected_svc: DeviceService
     ) -> None:
         assert connected_svc.driver is not None
-        config = _minimal_config(
+        request = _minimal_request(
             ports={
                 PortId.UART1: PortProtocolSet(
                     **{"in": [UbxProtocol.UBX], "out": [UbxProtocol.RTCM3X]}
@@ -783,9 +902,13 @@ class TestApplyReceiverConfig:
             elevation_mask_deg=10,
             dyn_model=DynModel.STATIONARY,
             tmode_mode=BaseMode.DISABLED,
+            # Differs from the fixture's default current scalars so
+            # ``configure_measurement_rate`` actually fires and can be
+            # asserted first in the order below.
+            meas_period_ms=333,
         )
 
-        await connected_svc.apply_receiver_config(config)
+        await connected_svc.apply_receiver_config(request)
 
         write_methods = {
             "configure_measurement_rate",
@@ -812,12 +935,12 @@ class TestApplyReceiverConfig:
         ]
 
     @pytest.mark.asyncio()
-    async def test_ports_not_written_when_omitted(
-        self, connected_svc: DeviceService
-    ) -> None:
+    async def test_ports_always_written(self, connected_svc: DeviceService) -> None:
+        """Issue #98: every field is sent on every Apply — ``ports`` is no
+        longer conditionally omitted."""
         assert connected_svc.driver is not None
-        await connected_svc.apply_receiver_config(_minimal_config())
-        connected_svc.driver.configure_port_protocols.assert_not_called()  # type: ignore[union-attr]
+        await connected_svc.apply_receiver_config(_minimal_request())
+        connected_svc.driver.configure_port_protocols.assert_called_once()  # type: ignore[union-attr]
 
     @pytest.mark.asyncio()
     async def test_constellations_flip_enabled_and_preserve_channels(
@@ -841,9 +964,9 @@ class TestApplyReceiverConfig:
                 ),
             ]
         )
-        config = _minimal_config(constellations=[GnssConstellation.GALILEO])
+        request = _minimal_request(constellations=[GnssConstellation.GALILEO])
 
-        await connected_svc.apply_receiver_config(config)
+        await connected_svc.apply_receiver_config(request)
 
         written: GnssConfig = driver.configure_gnss.call_args[0][0]
         by_constellation: dict[GnssConstellation, GnssSystemConfig] = {
@@ -856,34 +979,30 @@ class TestApplyReceiverConfig:
         assert by_constellation[GnssConstellation.GALILEO].max_channels == 12
 
     @pytest.mark.asyncio()
-    async def test_dyn_model_and_tmode_mode_omitted_write_neither_key(
+    async def test_dyn_model_and_tmode_mode_always_written(
         self, connected_svc: DeviceService
     ) -> None:
+        """Issue #98: every field is sent on every Apply — ``dyn_model``/
+        ``tmode_mode`` are no longer conditionally omitted. Plain
+        reassertion of the same value is safe here (not the edge-
+        triggered survey-in path — see ``UbloxDriver.configure_tmode_mode``)."""
         assert connected_svc.driver is not None
-        await connected_svc.apply_receiver_config(_minimal_config())
-        connected_svc.driver.configure_dyn_model.assert_not_called()  # type: ignore[union-attr]
-        connected_svc.driver.configure_tmode_mode.assert_not_called()  # type: ignore[union-attr]
+        await connected_svc.apply_receiver_config(_minimal_request())
+        connected_svc.driver.configure_dyn_model.assert_called_once_with(  # type: ignore[union-attr]
+            DynModel.PORTABLE
+        )
+        connected_svc.driver.configure_tmode_mode.assert_called_once_with(  # type: ignore[union-attr]
+            BaseMode.DISABLED
+        )
 
     @pytest.mark.asyncio()
     async def test_optimisations_always_invoked(
         self, connected_svc: DeviceService
     ) -> None:
-        """The driver call always happens; per-field omission is the
-        driver's job (each ``None`` there means leave untouched)."""
         assert connected_svc.driver is not None
-        await connected_svc.apply_receiver_config(_minimal_config())
+        await connected_svc.apply_receiver_config(_minimal_request())
         connected_svc.driver.configure_optimisations.assert_called_once_with(  # type: ignore[union-attr]
-            None, None, None
-        )
-
-    @pytest.mark.asyncio()
-    async def test_meas_period_ms_passed_through_unconverted(
-        self, connected_svc: DeviceService
-    ) -> None:
-        assert connected_svc.driver is not None
-        await connected_svc.apply_receiver_config(_minimal_config(meas_period_ms=333))
-        connected_svc.driver.configure_measurement_rate.assert_called_once_with(  # type: ignore[union-attr]
-            333
+            0, False, False
         )
 
     @pytest.mark.asyncio()
@@ -891,12 +1010,12 @@ class TestApplyReceiverConfig:
         self, connected_svc: DeviceService
     ) -> None:
         assert connected_svc.driver is not None
-        connected_svc.driver.get_rtcm_port_config.return_value = RtcmPortConfig(  # type: ignore[union-attr]
-            messages={RtcmRowId.RTCM_1005: {"UART1": 1}}
-        )
-        result = await connected_svc.apply_receiver_config(_minimal_config())
+        result = await connected_svc.apply_receiver_config(_minimal_request())
         assert result.status == "ok"
         assert result.diff == []
+        from sp_rtk_base.models.profile_models import diff_receiver_assertions
+
+        assert diff_receiver_assertions(result.read_back, _minimal_assertion()) == []
 
     @pytest.mark.asyncio()
     async def test_read_back_mismatch_returns_failed_with_diff(
@@ -908,15 +1027,14 @@ class TestApplyReceiverConfig:
         connected_svc.driver.get_rtcm_port_config.return_value = RtcmPortConfig(  # type: ignore[union-attr]
             messages={RtcmRowId.RTCM_1005: {"UART1": 0}}
         )
-        result = await connected_svc.apply_receiver_config(_minimal_config())
+        result = await connected_svc.apply_receiver_config(_minimal_request())
 
         assert result.status == "failed"
         assert len(result.diff) == 1
-        cell = result.diff[0]
-        assert cell.row_id == RtcmRowId.RTCM_1005
-        assert cell.port == PortId.UART1
-        assert cell.expected is True
-        assert cell.actual is False
+        leaf = result.diff[0]
+        assert leaf.path == "rtcm.1005.UART1"
+        assert leaf.expected is True
+        assert leaf.actual is False
 
     @pytest.mark.asyncio()
     async def test_throughput_warning_when_over_threshold(
@@ -941,9 +1059,9 @@ class TestApplyReceiverConfig:
                 for row, ports in heavy_matrix.matrix.items()
             }
         )
-        config = _minimal_config(rtcm_stream=heavy_matrix)
+        request = _minimal_request(rtcm_stream=heavy_matrix)
 
-        result = await connected_svc.apply_receiver_config(config)
+        result = await connected_svc.apply_receiver_config(request)
 
         assert result.status == "ok"
         assert len(result.warnings) == 1
@@ -958,7 +1076,7 @@ class TestApplyReceiverConfig:
             PortId.UART1: 115200,
             PortId.UART2: 115200,
         }
-        result = await connected_svc.apply_receiver_config(_minimal_config())
+        result = await connected_svc.apply_receiver_config(_minimal_request())
         assert result.warnings == []
 
 
@@ -984,25 +1102,37 @@ class TestSurveyInPreservesAppliedProfile:
         svc._state = DeviceConnectionState.CONNECTED
         svc._info = DeviceInfo(vendor="Fake", model="FAKE-F9P")
 
-        # Deliberately not the built-in profile's values, so a
-        # regression that force-re-applies the built-in's stationary
-        # dyn model / RTCM-only ports would be caught.
-        applied = _minimal_config(
-            data_link_port=[PortId.UART1, PortId.UART2],
-            ports={
-                PortId.UART1: PortProtocolSet(
-                    in_=[UbxProtocol.UBX], out=[UbxProtocol.RTCM3X, UbxProtocol.NMEA]
+        # Live-seed the whole envelope (issue #98: Apply sends the whole
+        # form), then override only the fields this regression cares
+        # about — mirroring how the real UI builds ``form`` from
+        # ``live`` and mutates specific fields. Deliberately keeps
+        # ``dyn_model: portable`` (the fake driver's own live default),
+        # not the built-in profile's ``stationary``, so a regression
+        # that force-re-applies the built-in's dynamics model would be
+        # caught.
+        live = (await svc.get_receiver_assertion()).assertion
+        applied_assertion = live.model_copy(
+            update={
+                "dyn_model": DynModel.PORTABLE,
+                "ports": {
+                    **live.ports,
+                    PortId.UART1: PortProtocolSet(
+                        in_=[UbxProtocol.UBX],
+                        out=[UbxProtocol.RTCM3X, UbxProtocol.NMEA],
+                    ),
+                    PortId.UART2: PortProtocolSet(
+                        in_=[UbxProtocol.UBX], out=[UbxProtocol.RTCM3X]
+                    ),
+                },
+                "rtcm_stream": RtcmStreamConfig(
+                    matrix={
+                        RtcmRowId.RTCM_1005: {PortId.UART1: True, PortId.UART2: True},
+                    }
                 ),
-                PortId.UART2: PortProtocolSet(
-                    in_=[UbxProtocol.UBX], out=[UbxProtocol.RTCM3X]
-                ),
-            },
-            dyn_model=DynModel.PORTABLE,
-            rtcm_stream=RtcmStreamConfig(
-                matrix={
-                    RtcmRowId.RTCM_1005: {PortId.UART1: True, PortId.UART2: True},
-                }
-            ),
+            }
+        )
+        applied = ReceiverApplyRequest(
+            assertion=applied_assertion, data_link_port=[PortId.UART1, PortId.UART2]
         )
         apply_result = await svc.apply_receiver_config(applied)
         assert apply_result.status == "ok"
@@ -1035,6 +1165,24 @@ class TestBaseInvariants:
         driver.get_dyn_model.return_value = DynModel.STATIONARY
         driver.get_rtcm_port_config.return_value = RtcmPortConfig(
             messages={RtcmRowId.RTCM_1005: {"UART1": 1, "UART2": 1}}
+        )
+        # ``apply_base_invariants`` now reads a full live assertion via
+        # ``get_receiver_assertion()`` before merging the built-in
+        # profile onto it (issue #98) — deliberately distinct from the
+        # built-in's own values wherever it sets one explicitly, so a
+        # regression that used the built-in's value instead of live (or
+        # vice versa) is caught by ``test_apply_delegates_...`` below.
+        driver.get_port_protocols.return_value = PortProtocolConfig()
+        driver.get_gnss_config.return_value = GnssConfig(systems=[])
+        driver.get_receiver_scalars.return_value = ReceiverScalarConfig(
+            uart1_baud=9600,
+            uart2_baud=9600,
+            meas_period_ms=250,
+            dyn_model=DynModel.PORTABLE,
+            tmode_mode=BaseMode.SURVEY_IN,
+            elevation_mask_deg=45,
+            bds_b2_enabled=True,
+            spi_enabled=False,
         )
         svc.set_driver(driver)
         svc._state = DeviceConnectionState.CONNECTED
@@ -1086,21 +1234,44 @@ class TestBaseInvariants:
     ) -> None:
         from unittest.mock import AsyncMock
 
-        from sp_rtk_base.models.device_models import ApplyConfigResult
         from sp_rtk_base.profiles import BUILTIN_PROFILES
 
-        mock_apply = AsyncMock(return_value=ApplyConfigResult(status="ok"))
+        mock_apply = AsyncMock(
+            return_value=ApplyConfigResult(status="ok", read_back=_minimal_assertion())
+        )
         monkeypatch.setattr(connected_svc, "apply_receiver_config", mock_apply)
 
         result = await connected_svc.apply_base_invariants()
 
-        applied_config = mock_apply.call_args[0][0]
+        applied_request: ReceiverApplyRequest = mock_apply.call_args[0][0]
         builtin = BUILTIN_PROFILES["ublox-f9p-base-standard"]
-        # Everything except baud must match the built-in profile
-        # verbatim — baud is deliberately stripped so this one-click
-        # remedy can never strand the console's own link.
-        assert applied_config == builtin.model_copy(update={"baud": None})
-        assert applied_config.baud is None
+
+        # data_link_port comes straight from the built-in profile.
+        assert applied_request.data_link_port == list(builtin.data_link_port)
+
+        # Fields the built-in profile sets explicitly win over live —
+        # proven by the fixture's live scalars deliberately disagreeing
+        # with every one of them.
+        assert applied_request.assertion.dyn_model == builtin.dyn_model
+        assert applied_request.assertion.elevation_mask_deg == (
+            builtin.elevation_mask_deg
+        )
+        assert applied_request.assertion.bds_b2_enabled == builtin.bds_b2_enabled
+        assert applied_request.assertion.spi_enabled == builtin.spi_enabled
+        assert applied_request.assertion.constellations == builtin.constellations
+        assert applied_request.assertion.ports[PortId.UART1].out == [UbxProtocol.RTCM3X]
+
+        # baud is deliberately stripped from the profile copy before
+        # merging, so this one-click remedy can never strand the
+        # console's own link on a baud change the operator didn't ask
+        # for — it falls back to the live baud (9600/9600 in the
+        # fixture), not the built-in's own 57600/115200.
+        assert applied_request.assertion.baud == BaudAssertion(uart1=9600, uart2=9600)
+
+        # tmode_mode is omitted by the built-in profile — falls back to
+        # live (survey_in in the fixture).
+        assert applied_request.assertion.tmode_mode == BaseMode.SURVEY_IN
+
         assert result.status == "ok"
 
 

--- a/tests/unit/test_gps_config_helpers.py
+++ b/tests/unit/test_gps_config_helpers.py
@@ -14,7 +14,9 @@ from pathlib import Path
 import pytest
 
 from sp_rtk_base.models.device_models import (
-    ApplyConfigCellDiff,
+    BaseMode as TmodeMode,
+)
+from sp_rtk_base.models.device_models import (
     CurrentBaseConfig,
     DynModel,
     GnssConstellation,
@@ -24,9 +26,6 @@ from sp_rtk_base.models.device_models import (
     RtcmRowId,
     SurveyInProgress,
 )
-from sp_rtk_base.models.device_models import (
-    BaseMode as TmodeMode,
-)
 from sp_rtk_base.models.hardware_identity import (
     HARDWARE_ANY,
     HARDWARE_UNKNOWN,
@@ -34,10 +33,11 @@ from sp_rtk_base.models.hardware_identity import (
     identity_from_target,
 )
 from sp_rtk_base.models.profile_models import (
+    ApplyDiffEntry,
     BaudAssertion,
-    BaudConfig,
     PortProtocolSet,
     Profile,
+    ReceiverApplyRequest,
     ReceiverAssertion,
     RtcmStreamConfig,
     merge_profile_into_assertion,
@@ -47,12 +47,12 @@ from sp_rtk_base.ui.pages.gps_config import (
     MATRIX_PORTS,
     REQUIRED_RTCM_ROW,
     apply_blocked_reason,
-    build_apply_config,
+    build_apply_request,
     build_picker_entries,
     build_saved_profile,
     display_label,
     fixed_position_step_state,
-    format_cell_diff,
+    format_leaf_diff,
     hw_extras_display,
     i2c_spi_advisory_rows,
     infer_data_link_ports,
@@ -293,40 +293,61 @@ class TestApplyBlockedReason:
         assert apply_blocked_reason([PortId.UART1]) is None
 
 
-class TestBuildApplyConfig:
-    def test_builds_a_valid_receiver_config(self) -> None:
-        matrix = rtcm_config_to_matrix(
-            RtcmPortConfig(messages={RtcmRowId.RTCM_1005: {"UART1": 1}})
-        )
-        config = build_apply_config(matrix, [PortId.UART1])
-        assert config.data_link_port == [PortId.UART1]
-        assert config.rtcm_stream.matrix[RtcmRowId.RTCM_1005][PortId.UART1] is True
-        # Fields this page doesn't make editable are left untouched.
-        assert config.ports is None
-        assert config.constellations is None
-        assert config.dyn_model is None
-        assert config.tmode_mode is None
-        assert config.baud is None
+def _minimal_form() -> ReceiverAssertion:
+    """A minimal, fully-populated form — used wherever a test only cares
+    about the matrix + data-link ports and doesn't need the rest of the
+    hardware section populated meaningfully (issue #98: ``build_apply_request``
+    always takes the whole form, unlike the old matrix-only default)."""
+    return ReceiverAssertion(
+        baud=BaudAssertion(uart1=57600, uart2=115200),
+        meas_period_ms=1000,
+        constellations=[],
+        ports={},
+        dyn_model=DynModel.PORTABLE,
+        tmode_mode=TmodeMode.DISABLED,
+        elevation_mask_deg=0,
+        bds_b2_enabled=False,
+        spi_enabled=False,
+        rtcm_stream=RtcmStreamConfig(
+            matrix=rtcm_config_to_matrix(
+                RtcmPortConfig(messages={RtcmRowId.RTCM_1005: {"UART1": 1}})
+            )
+        ),
+    )
+
+
+class TestBuildApplyRequest:
+    def test_builds_a_valid_request(self) -> None:
+        form = _minimal_form()
+        request = build_apply_request(form, [PortId.UART1])
+        assert request.data_link_port == [PortId.UART1]
+        assert request.assertion == form
 
     def test_raises_when_1005_missing_from_every_data_link_port(self) -> None:
-        matrix = rtcm_config_to_matrix(RtcmPortConfig(messages={}))
-        with pytest.raises(ValueError, match="1005"):
-            build_apply_config(matrix, [PortId.UART1])
-
-
-class TestFormatCellDiff:
-    def test_names_row_port_and_the_mismatch(self) -> None:
-        diff = ApplyConfigCellDiff(
-            row_id=RtcmRowId.RTCM_1005,
-            port=PortId.UART1,
-            expected=True,
-            actual=False,
+        form = _minimal_form().model_copy(
+            update={
+                "rtcm_stream": RtcmStreamConfig(
+                    matrix=rtcm_config_to_matrix(RtcmPortConfig(messages={}))
+                )
+            }
         )
-        text = format_cell_diff(diff)
-        assert "1005" in text
-        assert "UART1" in text
+        with pytest.raises(ValueError, match="1005"):
+            build_apply_request(form, [PortId.UART1])
+
+
+class TestFormatLeafDiff:
+    def test_names_the_path_and_the_mismatch(self) -> None:
+        diff = ApplyDiffEntry(path="rtcm.1005.UART1", expected=True, actual=False)
+        text = format_leaf_diff(diff)
+        assert "rtcm.1005.UART1" in text
         assert "on" in text
         assert "off" in text
+
+    def test_non_bool_values_render_as_themselves(self) -> None:
+        diff = ApplyDiffEntry(path="meas_period_ms", expected=1000, actual=333)
+        text = format_leaf_diff(diff)
+        assert "1000" in text
+        assert "333" in text
 
 
 def _full_profile(name: str = "full-profile") -> Profile:
@@ -383,81 +404,50 @@ def _live_assertion() -> ReceiverAssertion:
     )
 
 
-class TestBuildApplyConfigWithExtras:
-    def test_extras_flow_into_the_config(self) -> None:
-        matrix = rtcm_config_to_matrix(
-            RtcmPortConfig(messages={RtcmRowId.RTCM_1005: {"UART1": 1}})
-        )
-        extras = ReceiverAssertion(
-            baud=BaudAssertion(uart1=57600, uart2=115200),
-            meas_period_ms=200,
-            constellations=[GnssConstellation.GPS],
-            ports={},
-            dyn_model=DynModel.STATIONARY,
-            tmode_mode=TmodeMode.DISABLED,
-            elevation_mask_deg=15,
-            bds_b2_enabled=False,
-            spi_enabled=True,
-            rtcm_stream=RtcmStreamConfig(matrix=matrix),
-        )
-        config = build_apply_config(matrix, [PortId.UART1], extras)
-        assert config.baud == BaudConfig(uart1=57600, uart2=115200)
-        assert config.meas_period_ms == 200
-        assert config.constellations == [GnssConstellation.GPS]
-        assert config.dyn_model == DynModel.STATIONARY
-        assert config.tmode_mode == TmodeMode.DISABLED
-        assert config.elevation_mask_deg == 15
-        assert config.bds_b2_enabled is False
-        assert config.spi_enabled is True
-
-
 class TestReceiverConfigFromProfile:
-    def test_strips_identity_fields(self) -> None:
-        config = receiver_config_from_profile(_full_profile(), _live_assertion())
-        assert not hasattr(config, "name")
-        assert not hasattr(config, "hardware")
-        assert not hasattr(config, "forked_from")
-        assert config.meas_period_ms == 500
+    def test_returns_the_apply_envelope(self) -> None:
+        request = receiver_config_from_profile(_full_profile(), _live_assertion())
+        assert isinstance(request, ReceiverApplyRequest)
+        assert request.assertion.meas_period_ms == 500
+        assert request.data_link_port == [PortId.UART1, PortId.UART2]
 
     def test_falls_back_to_live_for_fields_the_profile_omits(self) -> None:
         """``_full_profile()`` omits ``tmode_mode`` and USB ports on purpose."""
         live = _live_assertion()
-        config = receiver_config_from_profile(_full_profile(), live)
-        assert config.tmode_mode == live.tmode_mode
-        assert config.ports is not None
-        assert config.ports[PortId.USB] == live.ports[PortId.USB]
+        request = receiver_config_from_profile(_full_profile(), live)
+        assert request.assertion.tmode_mode == live.tmode_mode
+        assert request.assertion.ports[PortId.USB] == live.ports[PortId.USB]
 
     def test_equals_the_form_built_from_the_same_profile(self) -> None:
         profile = _full_profile()
         live = _live_assertion()
         merged = merge_profile_into_assertion(profile, live)
-        form_config = build_apply_config(
-            merged.rtcm_stream.matrix, profile.data_link_port, merged
-        )
-        assert form_config == receiver_config_from_profile(profile, live)
+        form_request = build_apply_request(merged, list(profile.data_link_port))
+        assert form_request == receiver_config_from_profile(profile, live)
 
 
 class TestIsModifiedFromProfile:
     def test_false_when_no_profile_selected(self) -> None:
-        config = build_apply_config(
-            rtcm_config_to_matrix(
-                RtcmPortConfig(messages={RtcmRowId.RTCM_1005: {"UART1": 1}})
-            ),
-            [PortId.UART1],
-        )
-        assert not is_modified_from_profile(config, None, _live_assertion())
+        request = build_apply_request(_minimal_form(), [PortId.UART1])
+        assert not is_modified_from_profile(request, None, _live_assertion())
 
     def test_false_when_form_exactly_equals_the_profile(self) -> None:
         profile = _full_profile()
         live = _live_assertion()
-        form_config = receiver_config_from_profile(profile, live)
-        assert not is_modified_from_profile(form_config, profile, live)
+        form_request = receiver_config_from_profile(profile, live)
+        assert not is_modified_from_profile(form_request, profile, live)
 
     def test_true_once_the_form_diverges(self) -> None:
         profile = _full_profile()
         live = _live_assertion()
-        form_config = receiver_config_from_profile(profile, live)
-        diverged = form_config.model_copy(update={"meas_period_ms": 999})
+        form_request = receiver_config_from_profile(profile, live)
+        diverged = form_request.model_copy(
+            update={
+                "assertion": form_request.assertion.model_copy(
+                    update={"meas_period_ms": 999}
+                )
+            }
+        )
         assert is_modified_from_profile(diverged, profile, live)
 
 
@@ -466,19 +456,14 @@ class TestSaveAsEnabled:
         assert not save_as_enabled(None, None, _live_assertion())
 
     def test_enabled_with_no_profile_selected(self) -> None:
-        config = build_apply_config(
-            rtcm_config_to_matrix(
-                RtcmPortConfig(messages={RtcmRowId.RTCM_1005: {"UART1": 1}})
-            ),
-            [PortId.UART1],
-        )
-        assert save_as_enabled(config, None, _live_assertion())
+        request = build_apply_request(_minimal_form(), [PortId.UART1])
+        assert save_as_enabled(request, None, _live_assertion())
 
     def test_suppressed_when_selected_profile_exactly_equals_the_form(self) -> None:
         profile = _full_profile()
         live = _live_assertion()
-        form_config = receiver_config_from_profile(profile, live)
-        assert not save_as_enabled(form_config, profile, live)
+        form_request = receiver_config_from_profile(profile, live)
+        assert not save_as_enabled(form_request, profile, live)
 
     def test_enabled_again_once_the_form_diverges_from_the_selected_profile(
         self,
@@ -486,8 +471,14 @@ class TestSaveAsEnabled:
         """The #66 fix: applying edits must not take Save-as away again."""
         profile = _full_profile()
         live = _live_assertion()
-        form_config = receiver_config_from_profile(profile, live)
-        diverged = form_config.model_copy(update={"meas_period_ms": 999})
+        form_request = receiver_config_from_profile(profile, live)
+        diverged = form_request.model_copy(
+            update={
+                "assertion": form_request.assertion.model_copy(
+                    update={"meas_period_ms": 999}
+                )
+            }
+        )
         assert save_as_enabled(diverged, profile, live)
 
 
@@ -541,13 +532,8 @@ class TestResolveSaveHardware:
 
 class TestBuildSavedProfile:
     def test_builds_a_valid_profile_with_identity_fields(self) -> None:
-        config = build_apply_config(
-            rtcm_config_to_matrix(
-                RtcmPortConfig(messages={RtcmRowId.RTCM_1005: {"UART1": 1}})
-            ),
-            [PortId.UART1],
-        )
-        profile = build_saved_profile("my-base", config, "ZED-F9P", "source-profile")
+        request = build_apply_request(_minimal_form(), [PortId.UART1])
+        profile = build_saved_profile("my-base", request, "ZED-F9P", "source-profile")
         assert profile.name == "my-base"
         assert profile.version == 1
         assert profile.hardware == "ZED-F9P"
@@ -555,13 +541,8 @@ class TestBuildSavedProfile:
         assert profile.data_link_port == [PortId.UART1]
 
     def test_bare_capture_has_no_forked_from(self) -> None:
-        config = build_apply_config(
-            rtcm_config_to_matrix(
-                RtcmPortConfig(messages={RtcmRowId.RTCM_1005: {"UART1": 1}})
-            ),
-            [PortId.UART1],
-        )
-        profile = build_saved_profile("captured", config, "ZED-F9P", None)
+        request = build_apply_request(_minimal_form(), [PortId.UART1])
+        profile = build_saved_profile("captured", request, "ZED-F9P", None)
         assert profile.forked_from is None
 
 

--- a/tests/unit/test_profile_models.py
+++ b/tests/unit/test_profile_models.py
@@ -1,4 +1,5 @@
-"""Tests for the GPS receiver profile schema (ReceiverConfig + Profile).
+"""Tests for the GPS receiver profile schema (ReceiverConfig + Profile) and
+the Apply envelope / per-leaf diff introduced by issue #98.
 
 Covers only context-free validation — rules that need no live device
 state. The UBX-in liveness guard and the tmode_mode=fixed coordinate
@@ -17,15 +18,19 @@ from sp_rtk_base.models.device_models import (
     UbxProtocol,
 )
 from sp_rtk_base.models.profile_models import (
+    ApplyConfigResult,
+    ApplyDiffEntry,
     BaudAssertion,
     BaudConfig,
     DynModel,
     PortProtocolSet,
     Profile,
+    ReceiverApplyRequest,
     ReceiverAssertion,
     ReceiverConfig,
     RtcmStreamConfig,
     TmodeMode,
+    diff_receiver_assertions,
     merge_profile_into_assertion,
 )
 
@@ -40,17 +45,20 @@ def _matrix_ok() -> dict[RtcmRowId, dict[PortId, bool]]:
 def _base_kwargs() -> dict[str, object]:
     """Minimal kwargs for a valid ReceiverConfig."""
     return {
-        "data_link_port": [PortId.UART1],
         "rtcm_stream": {"matrix": _matrix_ok()},
     }
 
 
 class TestReceiverConfig:
-    """ReceiverConfig is what Apply takes — no name field."""
+    """ReceiverConfig is what Apply's envelope wraps — no name field, and
+    (issue #98) no ``data_link_port`` either: that field has no CFG key
+    and lives on ``Profile``/``ReceiverApplyRequest`` instead."""
+
+    def test_has_no_data_link_port_field(self) -> None:
+        assert "data_link_port" not in ReceiverConfig.model_fields
 
     def test_minimal_valid_config(self) -> None:
         config = ReceiverConfig.model_validate(_base_kwargs())
-        assert config.data_link_port == [PortId.UART1]
         assert config.meas_period_ms == 1000
 
     def test_has_no_name_field(self) -> None:
@@ -68,50 +76,6 @@ class TestReceiverConfig:
         config = ReceiverConfig.model_validate(kwargs)
         assert config.dyn_model == DynModel.STATIONARY
         assert config.tmode_mode == TmodeMode.FIXED
-
-    def test_missing_data_link_port_rejected(self) -> None:
-        kwargs = _base_kwargs()
-        del kwargs["data_link_port"]
-        with pytest.raises(ValidationError, match="data_link_port"):
-            ReceiverConfig.model_validate(kwargs)
-
-    def test_empty_data_link_port_rejected(self) -> None:
-        kwargs = _base_kwargs()
-        kwargs["data_link_port"] = []
-        with pytest.raises(ValidationError, match="data_link_port"):
-            ReceiverConfig.model_validate(kwargs)
-
-    def test_data_link_port_usb_rejected(self) -> None:
-        kwargs = _base_kwargs()
-        kwargs["data_link_port"] = [PortId.USB]
-        with pytest.raises(ValidationError):
-            ReceiverConfig.model_validate(kwargs)
-
-    def test_1005_not_on_any_data_link_port_rejected(self) -> None:
-        kwargs = _base_kwargs()
-        kwargs["rtcm_stream"] = {"matrix": {RtcmRowId.RTCM_1074: {PortId.UART1: True}}}
-        with pytest.raises(ValidationError, match="1005"):
-            ReceiverConfig.model_validate(kwargs)
-
-    def test_1005_on_a_non_data_link_port_is_not_enough(self) -> None:
-        kwargs = _base_kwargs()
-        kwargs["data_link_port"] = [PortId.UART1, PortId.UART2]
-        kwargs["rtcm_stream"] = {
-            "matrix": {
-                RtcmRowId.RTCM_1005: {PortId.UART2: False, PortId.UART1: False},
-                RtcmRowId.RTCM_1074: {PortId.UART1: True, PortId.UART2: True},
-            }
-        }
-        with pytest.raises(ValidationError, match="1005"):
-            ReceiverConfig.model_validate(kwargs)
-
-    def test_data_link_port_with_zero_rows_on_rejected(self) -> None:
-        kwargs = _base_kwargs()
-        kwargs["data_link_port"] = [PortId.UART1, PortId.UART2]
-        # UART2 is a data-link port but has nothing routed to it.
-        kwargs["rtcm_stream"] = {"matrix": {RtcmRowId.RTCM_1005: {PortId.UART1: True}}}
-        with pytest.raises(ValidationError, match="UART2"):
-            ReceiverConfig.model_validate(kwargs)
 
     @pytest.mark.parametrize("meas_period_ms", [99, 60001])
     def test_meas_period_ms_out_of_range_rejected(self, meas_period_ms: int) -> None:
@@ -208,14 +172,60 @@ class TestReceiverConfig:
 
 
 class TestProfile:
-    """Profile = ReceiverConfig + name, version, hardware, forked_from."""
+    """Profile = ReceiverConfig + its own ``data_link_port`` (issue #98) +
+    name, version, hardware, forked_from."""
 
     def _profile_kwargs(self) -> dict[str, object]:
         kwargs = _base_kwargs()
+        kwargs["data_link_port"] = [PortId.UART1]
         kwargs["name"] = "custom-test-profile"
         kwargs["version"] = 1
         kwargs["hardware"] = "ZED-F9P"
         return kwargs
+
+    def test_missing_data_link_port_rejected(self) -> None:
+        kwargs = self._profile_kwargs()
+        del kwargs["data_link_port"]
+        with pytest.raises(ValidationError, match="data_link_port"):
+            Profile.model_validate(kwargs)
+
+    def test_empty_data_link_port_rejected(self) -> None:
+        kwargs = self._profile_kwargs()
+        kwargs["data_link_port"] = []
+        with pytest.raises(ValidationError, match="data_link_port"):
+            Profile.model_validate(kwargs)
+
+    def test_data_link_port_usb_rejected(self) -> None:
+        kwargs = self._profile_kwargs()
+        kwargs["data_link_port"] = [PortId.USB]
+        with pytest.raises(ValidationError):
+            Profile.model_validate(kwargs)
+
+    def test_1005_not_on_any_data_link_port_rejected(self) -> None:
+        kwargs = self._profile_kwargs()
+        kwargs["rtcm_stream"] = {"matrix": {RtcmRowId.RTCM_1074: {PortId.UART1: True}}}
+        with pytest.raises(ValidationError, match="1005"):
+            Profile.model_validate(kwargs)
+
+    def test_1005_on_a_non_data_link_port_is_not_enough(self) -> None:
+        kwargs = self._profile_kwargs()
+        kwargs["data_link_port"] = [PortId.UART1, PortId.UART2]
+        kwargs["rtcm_stream"] = {
+            "matrix": {
+                RtcmRowId.RTCM_1005: {PortId.UART2: False, PortId.UART1: False},
+                RtcmRowId.RTCM_1074: {PortId.UART1: True, PortId.UART2: True},
+            }
+        }
+        with pytest.raises(ValidationError, match="1005"):
+            Profile.model_validate(kwargs)
+
+    def test_data_link_port_with_zero_rows_on_rejected(self) -> None:
+        kwargs = self._profile_kwargs()
+        kwargs["data_link_port"] = [PortId.UART1, PortId.UART2]
+        # UART2 is a data-link port but has nothing routed to it.
+        kwargs["rtcm_stream"] = {"matrix": {RtcmRowId.RTCM_1005: {PortId.UART1: True}}}
+        with pytest.raises(ValidationError, match="UART2"):
+            Profile.model_validate(kwargs)
 
     def test_minimal_valid_profile(self) -> None:
         profile = Profile.model_validate(self._profile_kwargs())
@@ -497,3 +507,225 @@ class TestMergeProfileIntoAssertion:
 
         assert merged.meas_period_ms == bare.meas_period_ms
         assert merged.meas_period_ms != live.meas_period_ms
+
+
+# ---------------------------------------------------------------------------
+# ReceiverApplyRequest — Apply's envelope (issue #98)
+# ---------------------------------------------------------------------------
+
+
+def _base_assertion() -> ReceiverAssertion:
+    """A fully-populated, minimal-but-valid assertion for envelope/diff tests."""
+    return ReceiverAssertion(
+        baud=BaudAssertion(uart1=57600, uart2=115200),
+        meas_period_ms=1000,
+        constellations=[GnssConstellation.GPS],
+        ports={
+            PortId.UART1: PortProtocolSet(**{"in": ["UBX"], "out": ["RTCM3X"]}),
+            PortId.UART2: PortProtocolSet(**{"in": ["UBX"], "out": []}),
+            PortId.USB: PortProtocolSet(
+                **{"in": ["UBX", "NMEA"], "out": ["UBX", "NMEA"]}
+            ),
+        },
+        dyn_model=DynModel.STATIONARY,
+        tmode_mode=TmodeMode.DISABLED,
+        elevation_mask_deg=10,
+        bds_b2_enabled=False,
+        spi_enabled=False,
+        rtcm_stream=RtcmStreamConfig(
+            matrix={RtcmRowId.RTCM_1005: {PortId.UART1: True}}
+        ),
+    )
+
+
+class TestReceiverApplyRequest:
+    """Apply's envelope (issue #98): the whole asserted state plus the
+    data-link port selection, with the three cross-field validators that
+    used to live on ``ReceiverConfig``."""
+
+    def test_minimal_valid_request(self) -> None:
+        request = ReceiverApplyRequest(
+            assertion=_base_assertion(), data_link_port=[PortId.UART1]
+        )
+        assert request.data_link_port == [PortId.UART1]
+
+    def test_missing_data_link_port_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="data_link_port"):
+            ReceiverApplyRequest.model_validate({"assertion": _base_assertion()})
+
+    def test_empty_data_link_port_rejected(self) -> None:
+        with pytest.raises(ValidationError, match="data_link_port"):
+            ReceiverApplyRequest(assertion=_base_assertion(), data_link_port=[])
+
+    def test_data_link_port_usb_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ReceiverApplyRequest(
+                assertion=_base_assertion(), data_link_port=[PortId.USB]
+            )
+
+    def test_1005_not_on_any_data_link_port_rejected(self) -> None:
+        assertion = _base_assertion().model_copy(
+            update={
+                "rtcm_stream": RtcmStreamConfig(
+                    matrix={RtcmRowId.RTCM_1074: {PortId.UART1: True}}
+                )
+            }
+        )
+        with pytest.raises(ValidationError, match="1005"):
+            ReceiverApplyRequest(assertion=assertion, data_link_port=[PortId.UART1])
+
+    def test_data_link_port_with_zero_rows_on_rejected(self) -> None:
+        # UART2 is a chosen data-link port but has nothing routed to it.
+        with pytest.raises(ValidationError, match="UART2"):
+            ReceiverApplyRequest(
+                assertion=_base_assertion(),
+                data_link_port=[PortId.UART1, PortId.UART2],
+            )
+
+    def test_extra_field_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ReceiverApplyRequest(
+                assertion=_base_assertion(),
+                data_link_port=[PortId.UART1],
+                bogus_field="nope",
+            )
+
+
+# ---------------------------------------------------------------------------
+# diff_receiver_assertions — per-leaf, path-keyed diff (issue #98)
+# ---------------------------------------------------------------------------
+
+
+class TestDiffReceiverAssertions:
+    def test_identical_assertions_produce_no_diff(self) -> None:
+        assert diff_receiver_assertions(_base_assertion(), _base_assertion()) == []
+
+    def test_baud_uart1_mismatch_is_one_leaf(self) -> None:
+        a = _base_assertion()
+        b = a.model_copy(update={"baud": BaudAssertion(uart1=115200, uart2=115200)})
+        assert diff_receiver_assertions(a, b) == [
+            ApplyDiffEntry(path="baud.uart1", expected=57600, actual=115200)
+        ]
+
+    def test_baud_uart2_mismatch_is_one_leaf(self) -> None:
+        a = _base_assertion()
+        b = a.model_copy(update={"baud": BaudAssertion(uart1=57600, uart2=38400)})
+        assert diff_receiver_assertions(a, b) == [
+            ApplyDiffEntry(path="baud.uart2", expected=115200, actual=38400)
+        ]
+
+    def test_meas_period_ms_mismatch_is_one_leaf(self) -> None:
+        a = _base_assertion()
+        b = a.model_copy(update={"meas_period_ms": 200})
+        assert diff_receiver_assertions(a, b) == [
+            ApplyDiffEntry(path="meas_period_ms", expected=1000, actual=200)
+        ]
+
+    def test_constellation_added_is_one_leaf(self) -> None:
+        a = _base_assertion()
+        b = a.model_copy(
+            update={
+                "constellations": [GnssConstellation.GPS, GnssConstellation.GLONASS]
+            }
+        )
+        assert diff_receiver_assertions(a, b) == [
+            ApplyDiffEntry(path="constellations.glonass", expected=False, actual=True)
+        ]
+
+    def test_port_out_protocol_mismatch_is_one_leaf(self) -> None:
+        a = _base_assertion()
+        new_ports = dict(a.ports)
+        new_ports[PortId.UART1] = PortProtocolSet(
+            **{"in": ["UBX"], "out": ["RTCM3X", "NMEA"]}
+        )
+        b = a.model_copy(update={"ports": new_ports})
+        assert diff_receiver_assertions(a, b) == [
+            ApplyDiffEntry(path="ports.UART1.out.NMEA", expected=False, actual=True)
+        ]
+
+    def test_port_in_protocol_mismatch_is_one_leaf(self) -> None:
+        a = _base_assertion()
+        new_ports = dict(a.ports)
+        new_ports[PortId.UART2] = PortProtocolSet(**{"in": [], "out": []})
+        b = a.model_copy(update={"ports": new_ports})
+        assert diff_receiver_assertions(a, b) == [
+            ApplyDiffEntry(path="ports.UART2.in.UBX", expected=True, actual=False)
+        ]
+
+    def test_dyn_model_mismatch_uses_string_values(self) -> None:
+        a = _base_assertion()
+        b = a.model_copy(update={"dyn_model": DynModel.PORTABLE})
+        assert diff_receiver_assertions(a, b) == [
+            ApplyDiffEntry(path="dyn_model", expected="stationary", actual="portable")
+        ]
+
+    def test_tmode_mode_mismatch_uses_string_values(self) -> None:
+        a = _base_assertion()
+        b = a.model_copy(update={"tmode_mode": TmodeMode.FIXED})
+        assert diff_receiver_assertions(a, b) == [
+            ApplyDiffEntry(path="tmode_mode", expected="disabled", actual="fixed")
+        ]
+
+    def test_elevation_mask_deg_mismatch_is_one_leaf(self) -> None:
+        a = _base_assertion()
+        b = a.model_copy(update={"elevation_mask_deg": 20})
+        assert diff_receiver_assertions(a, b) == [
+            ApplyDiffEntry(path="elevation_mask_deg", expected=10, actual=20)
+        ]
+
+    def test_bds_b2_enabled_mismatch_is_one_leaf(self) -> None:
+        a = _base_assertion()
+        b = a.model_copy(update={"bds_b2_enabled": True})
+        assert diff_receiver_assertions(a, b) == [
+            ApplyDiffEntry(path="bds_b2_enabled", expected=False, actual=True)
+        ]
+
+    def test_spi_enabled_mismatch_is_one_leaf(self) -> None:
+        a = _base_assertion()
+        b = a.model_copy(update={"spi_enabled": True})
+        assert diff_receiver_assertions(a, b) == [
+            ApplyDiffEntry(path="spi_enabled", expected=False, actual=True)
+        ]
+
+    def test_matrix_cell_mismatch_is_one_leaf(self) -> None:
+        a = _base_assertion()
+        new_matrix = {row: dict(ports) for row, ports in a.rtcm_stream.matrix.items()}
+        new_matrix.setdefault(RtcmRowId.RTCM_1077, {})[PortId.UART2] = True
+        b = a.model_copy(update={"rtcm_stream": RtcmStreamConfig(matrix=new_matrix)})
+        assert diff_receiver_assertions(a, b) == [
+            ApplyDiffEntry(path="rtcm.1077.UART2", expected=False, actual=True)
+        ]
+
+    def test_multiple_mismatches_all_reported(self) -> None:
+        a = _base_assertion()
+        b = a.model_copy(update={"meas_period_ms": 200, "spi_enabled": True})
+        diffs = diff_receiver_assertions(a, b)
+        assert {d.path for d in diffs} == {"meas_period_ms", "spi_enabled"}
+
+    def test_data_link_port_is_not_a_parameter(self) -> None:
+        """The function signature alone guarantees the data-link port
+        selection can never appear as a difference — it never sees a
+        ``ReceiverApplyRequest``, only two ``ReceiverAssertion``s."""
+        import inspect
+
+        params = inspect.signature(diff_receiver_assertions).parameters
+        assert set(params) == {"expected", "actual"}
+
+
+# ---------------------------------------------------------------------------
+# ApplyConfigResult (issue #98)
+# ---------------------------------------------------------------------------
+
+
+class TestApplyConfigResult:
+    def test_ok_result_defaults_diff_and_warnings_empty(self) -> None:
+        result = ApplyConfigResult(status="ok", read_back=_base_assertion())
+        assert result.diff == []
+        assert result.warnings == []
+
+    def test_failed_result_carries_the_diff(self) -> None:
+        entry = ApplyDiffEntry(path="meas_period_ms", expected=1000, actual=200)
+        result = ApplyConfigResult(
+            status="failed", read_back=_base_assertion(), diff=[entry]
+        )
+        assert result.diff == [entry]


### PR DESCRIPTION
## Summary

- **#98** — Apply now pushes the whole receiver form, not just the RTCM matrix and data-link ports. Introduces a `ReceiverApplyRequest` envelope (assertion + `data_link_port`, hosting the three cross-field validators moved off `ReceiverConfig`) and collapses verify/sync into one `diff_receiver_assertions()` function producing per-leaf, path-keyed differences — the old matrix-only `ApplyConfigCellDiff`/`ApplyConfigResult` is gone, no parallel diff type. Fixes the 1 Hz bug by skipping the measurement-rate write when unchanged (baud gets the same treatment, to avoid an unnecessary reopen-after-write on every Apply). Baud is still written last. `POST /api/device/apply-config`'s request/response shapes changed cleanly (no external consumer, no versioning).
- **#105** — The profile picker is now a real dropdown (Quasar `q-select` with a custom option-slot template) instead of a card list. Incompatible profiles are disabled with a hover tooltip explaining why; the suggested profile for detected hardware is highlighted; the unconfirmed-hardware banner is retained. The "modified from X" relation indicator moved out of the action row into the profile card, beside the picker, and always renders in a neutral grey — never the warning colour it used before.

Both issues were implemented in parallel on isolated branches and merged into this one; the single conflict (`_render_modified_indicator` in `gps_config.py`, where both tickets touched the same function) was resolved by keeping #105's neutral-colour styling/docstring while adopting #98's renamed `ReceiverApplyRequest` plumbing.

Closes #98, closes #105.

## Test plan

- [x] `uv run pyright src/` — 0 errors
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run pytest` (full unit suite) — 1426 passed, 93.59% coverage (gate 90%)
- [x] `uv run pytest tests/e2e --no-cov` — 67 passed
- [x] Two-axis `/code-review` (Standards + Spec) run against `main` — Standards clean (only minor optional judgement-call notes), Spec confirmed all 16 acceptance criteria across both issues met, no scope creep beyond a documented/reasonable baud-skip judgment call, no regression introduced by the merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AcBmmcpcJtBBxvDE8M3C6p