### PR TITLE
Apply gains per-step outcomes, a service-side no-op, and the warning channel

### DIFF
--- a/src/sp_rtk_base/models/profile_models.py
+++ b/src/sp_rtk_base/models/profile_models.py
@@ -529,6 +529,83 @@ def diff_receiver_assertions(
     return diffs
 
 
+#: The write steps ``apply_receiver_config`` performs, in execution
+#: order (issue #99). Baud is last — see
+#: ``DeviceService.apply_receiver_config`` for why.
+APPLY_STEPS: tuple[str, ...] = (
+    "meas_period_ms",
+    "ports",
+    "constellations",
+    "optimisations",
+    "dyn_model",
+    "tmode_mode",
+    "rtcm_matrix",
+    "baud",
+)
+
+
+def step_for_diff_path(path: str) -> str:
+    """Map one :class:`ApplyDiffEntry` ``path`` onto the write step that
+    owns it — the grouping :func:`~sp_rtk_base.services.device_service.
+    DeviceService.apply_receiver_config` uses to decide, per step,
+    whether the pre-write read-back already matches what's being sent
+    (issue #99). Every path :func:`diff_receiver_assertions` can ever
+    produce resolves to exactly one of :data:`APPLY_STEPS`.
+    """
+    if path == "meas_period_ms":
+        return "meas_period_ms"
+    if path.startswith("ports."):
+        return "ports"
+    if path.startswith("constellations."):
+        return "constellations"
+    if path in ("elevation_mask_deg", "bds_b2_enabled", "spi_enabled"):
+        return "optimisations"
+    if path == "dyn_model":
+        return "dyn_model"
+    if path == "tmode_mode":
+        return "tmode_mode"
+    if path.startswith("rtcm."):
+        return "rtcm_matrix"
+    if path.startswith("baud."):
+        return "baud"
+    raise ValueError(f"unrecognised apply-diff path: {path!r}")  # pragma: no cover
+
+
+class ApplyStepResult(BaseModel):
+    """One write step's outcome, in the order ``apply_receiver_config`` ran it.
+
+    ``"skipped"`` covers two distinct reasons alike (issue #99): the
+    step's fields already matched the pre-write read-back (the
+    service-decided no-op), or an earlier step failed and stopped the
+    rest of the sequence from running at all. Either way, nothing was
+    written for this step.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    step: str
+    status: Literal["ok", "failed", "skipped"]
+
+
+class ApplyStepWarning(BaseModel):
+    """One advisory drained from the driver's warning channel after a step
+    ran (issue #99).
+
+    Means exactly one thing, deliberately with no severity field: the
+    write appears to have succeeded, but something the sync check is
+    structurally unable to see is wrong (a write that landed in RAM
+    but not flash; a constellation the firmware acknowledged but does
+    not appear to act on). ``step`` is the step whose write produced
+    it — a step that warned on one Apply is excluded from the skip on
+    the next, so pressing Apply again actually retries it.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    step: str
+    message: str
+
+
 class ApplyConfigResult(BaseModel):
     """Response for ``POST /api/device/apply-config``.
 
@@ -538,9 +615,14 @@ class ApplyConfigResult(BaseModel):
     :func:`diff_receiver_assertions`). ``read_back`` is the full
     post-apply assertion read — callers (the Advanced GPS page) sync
     their live state from it whether ``status`` is ``"ok"`` or
-    ``"failed"``, since the writes land either way. ``warnings``
-    carries non-blocking advisories (e.g. the estimated-throughput
-    check) that never affect ``status``.
+    ``"failed"``, since the writes land either way (or didn't run at
+    all — a failed or skipped step still leaves ``read_back`` as the
+    truth of what the receiver holds). ``warnings`` carries
+    non-blocking advisories (e.g. the estimated-throughput check) that
+    never affect ``status``. ``steps`` reports every write step's
+    outcome in execution order (issue #99); ``step_warnings`` carries
+    the driver's step-tagged warning channel, distinct from
+    ``warnings`` — see :class:`ApplyStepWarning`.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -549,6 +631,12 @@ class ApplyConfigResult(BaseModel):
     read_back: ReceiverAssertion
     diff: list[ApplyDiffEntry] = Field(default_factory=lambda: list[ApplyDiffEntry]())
     warnings: list[str] = Field(default_factory=lambda: list[str]())
+    steps: list[ApplyStepResult] = Field(
+        default_factory=lambda: list[ApplyStepResult]()
+    )
+    step_warnings: list[ApplyStepWarning] = Field(
+        default_factory=lambda: list[ApplyStepWarning]()
+    )
 
 
 def _dense_matrix(

--- a/src/sp_rtk_base/services/device_service.py
+++ b/src/sp_rtk_base/services/device_service.py
@@ -39,8 +39,11 @@ from sp_rtk_base.models.device_models import (
     BaseMode as TmodeMode,
 )
 from sp_rtk_base.models.profile_models import (
+    APPLY_STEPS,
     MATRIX_PORTS,
     ApplyConfigResult,
+    ApplyStepResult,
+    ApplyStepWarning,
     BaudAssertion,
     PortProtocolSet,
     ReceiverApplyRequest,
@@ -48,6 +51,7 @@ from sp_rtk_base.models.profile_models import (
     RtcmStreamConfig,
     diff_receiver_assertions,
     merge_profile_into_assertion,
+    step_for_diff_path,
 )
 from sp_rtk_base.profiles import BUILTIN_PROFILES
 from sp_rtk_base.services.drivers.base import GpsReceiverDriver
@@ -214,18 +218,23 @@ def build_receiver_assertion(
 
 
 class ReceiverAssertionRead(NamedTuple):
-    """One ``get_receiver_assertion()`` read: the sync-set assertion plus
-    the raw multi-port RTCM read-back the page's I2C/SPI advisory needs.
+    """One ``get_receiver_assertion()`` read: the sync-set assertion, the
+    raw multi-port RTCM read-back the page's I2C/SPI advisory needs, and
+    the raw GNSS config the constellation apply-step needs (issue #99).
 
     I2C/SPI aren't part of ``assertion.rtcm_stream``'s matrix — that
     mirrors ``ReceiverConfig``'s UART1/UART2/USB-only scope — so the
     advisory display needs the wider read ``rtcm`` already carries.
-    Bundling both here means one receiver read serves both, rather than
-    the page re-polling RTCM a second time.
+    Likewise, ``assertion.constellations`` is just the flat enabled set —
+    writing a constellation change needs each system's channel tuning,
+    which only the raw ``gnss`` read carries. Bundling all three here
+    means one receiver read serves every caller, rather than any of them
+    re-polling RTCM or GNSS a second time.
     """
 
     assertion: ReceiverAssertion
     rtcm: RtcmPortConfig
+    gnss: GnssConfig
 
 
 class DeviceService:
@@ -252,6 +261,11 @@ class DeviceService:
         self._last_error: str | None = None
         self._connected_at: datetime | None = None
         self._relay_running_check: _RelayRunningCheck | None = None
+        # Steps whose drained warnings were non-empty on the previous
+        # apply-config call — excluded from the next call's skip so
+        # pressing Apply again actually retries them (issue #99).
+        # Reset on every fresh connect: a new session starts clean.
+        self._steps_warned_last_apply: set[str] = set()
 
     # ------------------------------------------------------------------
     # Properties
@@ -376,6 +390,7 @@ class DeviceService:
             self._baud_rate = baud_rate
             self._info = info
             self._connected_at = datetime.now(tz=timezone.utc)
+            self._steps_warned_last_apply = set()
             logger.info(
                 "Connected to %s %s on %s",
                 info.vendor,
@@ -779,12 +794,24 @@ class DeviceService:
             RuntimeError: If not connected.
         """
         driver = self._require_connected()
+        return await self._read_full_assertion(driver)
+
+    async def _read_full_assertion(
+        self, driver: GpsReceiverDriver
+    ) -> ReceiverAssertionRead:
+        """The four driver reads behind :meth:`get_receiver_assertion`.
+
+        Shared with ``apply_receiver_config``'s pre-write pre-read
+        (issue #99) so there's exactly one place composing a full
+        receiver read, rather than the pre-read duplicating this
+        method's body to also get at the raw ``gnss`` config it needs.
+        """
         rtcm = await asyncio.to_thread(driver.get_rtcm_port_config)
         ports = await asyncio.to_thread(driver.get_port_protocols)
         gnss = await asyncio.to_thread(driver.get_gnss_config)
         scalars = await asyncio.to_thread(driver.get_receiver_scalars)
         assertion = build_receiver_assertion(rtcm, ports, gnss, scalars)
-        return ReceiverAssertionRead(assertion=assertion, rtcm=rtcm)
+        return ReceiverAssertionRead(assertion=assertion, rtcm=rtcm, gnss=gnss)
 
     async def configure_gnss(self, config: GnssConfig) -> None:
         """Write GNSS constellation configuration to the receiver.
@@ -833,7 +860,7 @@ class DeviceService:
     async def apply_receiver_config(
         self, request: ReceiverApplyRequest
     ) -> ApplyConfigResult:
-        """Apply the whole form as an ordered series of layer=5 writes (issue #98).
+        """Apply the form as an ordered series of per-step, layer=5 writes (issue #99).
 
         *request* is the envelope Apply sends: a fully-populated
         ``ReceiverAssertion`` (every receiver field, no "leave alone"
@@ -842,27 +869,51 @@ class DeviceService:
         guards/warnings below and by ``ReceiverApplyRequest``'s own
         cross-field validators.
 
-        Sequence: guards -> measurement rate -> ports -> constellations
-        -> optimisations -> role fields (dyn_model, then tmode_mode) ->
-        the full RTCM matrix -> baud -> reopen (if UART1's baud changed)
-        -> read-back verify. Baud is written **last**, after every other
-        key has landed, and only once every other write's ACK is safely
-        in — a baud change is the one write that can move the console's
-        own management link out from under this very request (issue #62).
+        Sequence: guards -> a fresh pre-read -> :data:`APPLY_STEPS` in
+        order (measurement rate, ports, constellations, optimisations,
+        dyn_model, tmode_mode, the RTCM matrix, baud) -> reopen (if
+        UART1's baud changed) -> read-back verify. Baud is last, after
+        every other key has landed and only once every other write's
+        ACK is safely in — a baud change is the one write that can move
+        the console's own management link out from under this very
+        request (issue #62).
 
-        Every field is sent on every Apply — this ticket's "whole form"
-        change — with two deliberate exceptions that skip their write
-        entirely when the live receiver already holds the value being
-        sent: **measurement rate** (this ticket fixes the 1 Hz bug by
-        construction — the caller always seeds it from the receiver
-        rather than a schema default, and this skip means an unchanged
-        rate is never rewritten either) and **baud** (skipping an
-        unchanged baud avoids the reopen-after-write dance below on
-        every single Apply, not just the ones that actually change it).
-        Both compare against one early ``get_receiver_scalars()`` poll.
-        No other field gets this treatment — ports, constellations,
-        optimisations, dyn_model, tmode_mode and the RTCM matrix are
-        always (re)written, matching "send every field".
+        **The pre-read decides the no-op.** One fresh full read, taken
+        at the instant of Apply (never the page's seed — a stale seed
+        another client or a reboot has invalidated can't be trusted to
+        rest a "nothing to do" claim on), is diffed per-leaf against
+        *request.assertion* and grouped by :func:`profile_models.
+        step_for_diff_path`. A step is skipped when every leaf it
+        covers already matches; a step that runs writes its complete
+        key set assertively (never a partial, per-leaf write) — so an
+        unqualified whole-form assert doesn't push every key to flash
+        on every Apply, but pressing Apply on a genuinely unchanged
+        form still performs no writes at all and just re-verifies.
+        **Exception:** a step that produced a warning on the *previous*
+        Apply is excluded from this skip, so it actually retries
+        instead of the remedy being a no-op that quietly erases its own
+        warning.
+
+        **Step outcomes.** Each step reports ``"ok"``, ``"failed"`` or
+        ``"skipped"`` in ``result.steps``, in execution order. A step
+        that raises stops every subsequent step (they report
+        ``"skipped"`` too — nothing further is written) but never
+        propagates: only a pre-write refusal or a lost link still
+        raises out of this method. The read-back always runs
+        regardless, so ``result.diff``/``result.read_back`` state what
+        the receiver actually holds even when a step failed.
+
+        **Warnings.** After each step that runs, ``GpsReceiverDriver.
+        drain_warnings`` is drained and whatever comes back is tagged
+        with that step's name onto ``result.step_warnings`` — see
+        :class:`profile_models.ApplyStepWarning`. A step that ran and
+        drained nothing clears its membership in the warned set; one
+        that ran and drained something (again) keeps it. A step this
+        Apply never got the chance to run — skipped because an earlier
+        step failed — carries its prior membership forward unchanged,
+        so an unresolved warning survives an unrelated failure rather
+        than being silently dropped the moment one Apply doesn't reach
+        it.
 
         Guards run before any write and refuse with nothing written:
 
@@ -873,6 +924,13 @@ class DeviceService:
           UBX off on USB IN is refused, since it would cut the
           console's own control channel with nothing left to write it
           back with.
+        - **Survey-in active.** Whole-form assert makes ``tmode_mode``
+          a required assertion field, so an Apply that leaves it alone
+          would otherwise silently cancel an in-progress survey-in that
+          may be hours in. Refused only when this Apply would actually
+          change base mode (``request.assertion.tmode_mode`` differs
+          from the pre-read) while a survey-in is running — an Apply
+          that leaves base mode alone still proceeds mid-survey.
         - **Coordinate guard.** ``tmode_mode: fixed`` is refused unless
           the receiver already holds a valid, non-zero position —
           otherwise a fresh receiver becomes a base broadcasting 1005
@@ -928,6 +986,20 @@ class DeviceService:
                 "the receiver over its own USB connection",
             )
 
+        pre_read = await self._read_full_assertion(driver)
+        pre_assertion = pre_read.assertion
+
+        if assertion.tmode_mode != pre_assertion.tmode_mode:
+            survey = await asyncio.to_thread(driver.get_survey_in_status)
+            if survey.active:
+                raise ApplyConfigRefusedError(
+                    "survey_in_active",
+                    "a survey-in is running — changing base mode would "
+                    "cancel it. Cancel the survey from the Survey page "
+                    "first, or leave tmode_mode unchanged to apply "
+                    "everything else",
+                )
+
         if assertion.tmode_mode == TmodeMode.FIXED:
             current_base = await asyncio.to_thread(driver.get_base_config)
             if (
@@ -942,64 +1014,59 @@ class DeviceService:
                     "position first",
                 )
 
+        pre_diff = diff_receiver_assertions(assertion, pre_assertion)
+        changed_steps = {step_for_diff_path(d.path) for d in pre_diff}
+
         self._state = DeviceConnectionState.CONFIGURING
+        steps: list[ApplyStepResult] = []
+        step_warnings: list[ApplyStepWarning] = []
+        # Starts as a copy of the previous Apply's warned steps and is
+        # only touched by a step that actually gets to run this time —
+        # a step skipped by an earlier failure (``blocked``) hasn't been
+        # given the chance to resolve its warning, so its membership
+        # carries forward untouched rather than being dropped just
+        # because this particular Apply didn't reach it.
+        updated_warned_steps = set(self._steps_warned_last_apply)
         new_uart1: int | None = None
-        try:
-            current_scalars = await asyncio.to_thread(driver.get_receiver_scalars)
+        blocked = False
 
-            if current_scalars.meas_period_ms != assertion.meas_period_ms:
-                await asyncio.to_thread(
-                    driver.configure_measurement_rate, assertion.meas_period_ms
+        for step_name in APPLY_STEPS:
+            if blocked:
+                steps.append(ApplyStepResult(step=step_name, status="skipped"))
+                continue
+
+            if (
+                step_name not in changed_steps
+                and step_name not in self._steps_warned_last_apply
+            ):
+                steps.append(ApplyStepResult(step=step_name, status="skipped"))
+                continue
+
+            try:
+                await self._run_apply_step(driver, step_name, assertion, pre_read.gnss)
+            except Exception as exc:
+                logger.warning("apply-config step %r failed: %s", step_name, exc)
+                self._last_error = f"apply-config step {step_name!r} failed: {exc}"
+                steps.append(ApplyStepResult(step=step_name, status="failed"))
+                blocked = True
+                continue
+
+            if step_name == "baud" and assertion.baud.uart1 != pre_assertion.baud.uart1:
+                new_uart1 = assertion.baud.uart1
+
+            drained = await asyncio.to_thread(driver.drain_warnings)
+            if drained:
+                updated_warned_steps.add(step_name)
+                step_warnings.extend(
+                    ApplyStepWarning(step=step_name, message=message)
+                    for message in drained
                 )
+            else:
+                updated_warned_steps.discard(step_name)
+            steps.append(ApplyStepResult(step=step_name, status="ok"))
 
-            in_map = {port: cfg.in_ for port, cfg in assertion.ports.items()}
-            out_map = {port: cfg.out for port, cfg in assertion.ports.items()}
-            await asyncio.to_thread(driver.configure_port_protocols, in_map, out_map)
-
-            current_gnss = await asyncio.to_thread(driver.get_gnss_config)
-            wanted = set(assertion.constellations)
-            updated_gnss = GnssConfig(
-                systems=[
-                    system.model_copy(
-                        update={"enabled": system.constellation in wanted}
-                    )
-                    for system in current_gnss.systems
-                ]
-            )
-            await asyncio.to_thread(driver.configure_gnss, updated_gnss)
-
-            await asyncio.to_thread(
-                driver.configure_optimisations,
-                assertion.elevation_mask_deg,
-                assertion.bds_b2_enabled,
-                assertion.spi_enabled,
-            )
-
-            await asyncio.to_thread(driver.configure_dyn_model, assertion.dyn_model)
-            await asyncio.to_thread(driver.configure_tmode_mode, assertion.tmode_mode)
-
-            await asyncio.to_thread(
-                driver.apply_rtcm_matrix, assertion.rtcm_stream.matrix
-            )
-
-            new_uart1 = (
-                assertion.baud.uart1
-                if assertion.baud.uart1 != current_scalars.uart1_baud
-                else None
-            )
-            new_uart2 = (
-                assertion.baud.uart2
-                if assertion.baud.uart2 != current_scalars.uart2_baud
-                else None
-            )
-            if new_uart1 is not None or new_uart2 is not None:
-                await asyncio.to_thread(driver.configure_baud, new_uart1, new_uart2)
-
-            self._state = DeviceConnectionState.CONNECTED
-        except Exception as exc:
-            self._state = DeviceConnectionState.CONNECTED
-            self._last_error = str(exc)
-            raise
+        self._state = DeviceConnectionState.CONNECTED
+        self._steps_warned_last_apply = updated_warned_steps
 
         if new_uart1 is not None:
             await self._reopen_after_baud_write(driver, new_uart1)
@@ -1014,13 +1081,77 @@ class DeviceService:
                 "apply-config read-back mismatch: %d leaf(ves) differ", len(diff)
             )
             return ApplyConfigResult(
-                status="failed", read_back=read.assertion, diff=diff, warnings=warnings
+                status="failed",
+                read_back=read.assertion,
+                diff=diff,
+                warnings=warnings,
+                steps=steps,
+                step_warnings=step_warnings,
             )
 
         logger.info("apply-config applied and read-back verified")
         return ApplyConfigResult(
-            status="ok", read_back=read.assertion, warnings=warnings
+            status="ok",
+            read_back=read.assertion,
+            warnings=warnings,
+            steps=steps,
+            step_warnings=step_warnings,
         )
+
+    async def _run_apply_step(
+        self,
+        driver: GpsReceiverDriver,
+        step_name: str,
+        assertion: ReceiverAssertion,
+        pre_gnss: GnssConfig,
+    ) -> None:
+        """Perform one write step's driver call (issue #99).
+
+        *pre_gnss* is the raw pre-read GNSS config — the constellation
+        step needs it (not just ``assertion.constellations``) to
+        preserve each system's channel tuning, which
+        ``ReceiverAssertion`` doesn't carry.
+        """
+        if step_name == "meas_period_ms":
+            await asyncio.to_thread(
+                driver.configure_measurement_rate, assertion.meas_period_ms
+            )
+        elif step_name == "ports":
+            in_map = {port: cfg.in_ for port, cfg in assertion.ports.items()}
+            out_map = {port: cfg.out for port, cfg in assertion.ports.items()}
+            await asyncio.to_thread(driver.configure_port_protocols, in_map, out_map)
+        elif step_name == "constellations":
+            wanted = set(assertion.constellations)
+            updated_gnss = GnssConfig(
+                systems=[
+                    system.model_copy(
+                        update={"enabled": system.constellation in wanted}
+                    )
+                    for system in pre_gnss.systems
+                ]
+            )
+            await asyncio.to_thread(driver.configure_gnss, updated_gnss)
+        elif step_name == "optimisations":
+            await asyncio.to_thread(
+                driver.configure_optimisations,
+                assertion.elevation_mask_deg,
+                assertion.bds_b2_enabled,
+                assertion.spi_enabled,
+            )
+        elif step_name == "dyn_model":
+            await asyncio.to_thread(driver.configure_dyn_model, assertion.dyn_model)
+        elif step_name == "tmode_mode":
+            await asyncio.to_thread(driver.configure_tmode_mode, assertion.tmode_mode)
+        elif step_name == "rtcm_matrix":
+            await asyncio.to_thread(
+                driver.apply_rtcm_matrix, assertion.rtcm_stream.matrix
+            )
+        elif step_name == "baud":
+            await asyncio.to_thread(
+                driver.configure_baud, assertion.baud.uart1, assertion.baud.uart2
+            )
+        else:  # pragma: no cover
+            raise AssertionError(f"unhandled apply step: {step_name!r}")
 
     async def _reopen_after_baud_write(
         self, driver: GpsReceiverDriver, new_baud: int

--- a/src/sp_rtk_base/services/drivers/base.py
+++ b/src/sp_rtk_base/services/drivers/base.py
@@ -330,6 +330,27 @@ class GpsReceiverDriver(abc.ABC):
         """
 
     @abc.abstractmethod
+    def drain_warnings(self) -> list[str]:
+        """Drain and return every warning queued since the last drain (issue #99).
+
+        The apply-config service calls this after each write step that
+        actually runs, tagging whatever comes back with that step's
+        name. The channel means exactly one thing: the write appears
+        to have succeeded, but something the sync check is
+        structurally unable to see is wrong — e.g. a value that landed
+        in RAM but not flash, or a constellation the firmware
+        acknowledged but does not appear to act on. No severity field,
+        and no producer on this driver yet — a concrete driver with
+        nothing to report simply returns an empty list every time.
+
+        Returns:
+            Warning messages queued since the last call; empty if none.
+
+        Raises:
+            ConnectionError: If not connected.
+        """
+
+    @abc.abstractmethod
     def get_receiver_scalars(self) -> ReceiverScalarConfig:
         """Batched read of every scalar CFG value the full receiver read needs.
 

--- a/src/sp_rtk_base/services/drivers/fake.py
+++ b/src/sp_rtk_base/services/drivers/fake.py
@@ -496,6 +496,11 @@ class FakeGpsDriver(GpsReceiverDriver):
         if uart2 is not None:
             self._uart_baud_rates[PortId.UART2] = uart2
 
+    def drain_warnings(self) -> list[str]:
+        """No producer wired up yet — the fake driver never warns (issue #99)."""
+        self._ensure_connected()
+        return []
+
     def get_receiver_scalars(self) -> ReceiverScalarConfig:
         """Return the fake driver's in-memory scalar config (issue #97)."""
         self._ensure_connected()

--- a/src/sp_rtk_base/services/drivers/ublox.py
+++ b/src/sp_rtk_base/services/drivers/ublox.py
@@ -1246,6 +1246,12 @@ class UbloxDriver(GpsReceiverDriver):
         with self._lock:
             self._send_cfg_valset_locked(cfg_data, layer=5)
 
+    def drain_warnings(self) -> list[str]:
+        """No producer wired up yet on this driver — always empty (issue #99)."""
+        if not self.is_connected:
+            raise ConnectionError("Not connected to device")
+        return []
+
     def get_receiver_scalars(self) -> ReceiverScalarConfig:
         """Batched read of baud, meas rate, dyn model, tmode mode and the
         three optimisation fields — one CFG-VALGET poll (issue #97).

--- a/tests/unit/test_device_service.py
+++ b/tests/unit/test_device_service.py
@@ -28,6 +28,7 @@ from sp_rtk_base.models.device_models import (
     UbxProtocol,
 )
 from sp_rtk_base.models.profile_models import (
+    APPLY_STEPS,
     ApplyConfigResult,
     BaudAssertion,
     PortProtocolSet,
@@ -623,6 +624,13 @@ class TestApplyReceiverConfig:
             PortId.UART1: 57600,
             PortId.UART2: 115200,
         }
+        driver.drain_warnings.return_value = []
+        # ``_make_mock_driver()`` defaults survey-in to active — most of
+        # this class doesn't care, and an active survey would refuse
+        # any request that changes ``tmode_mode`` (issue #99's
+        # survey-in-active guard). Tests exercising that guard override
+        # this back to ``active=True`` themselves.
+        driver.get_survey_in_status.return_value = SurveyInProgress(active=False)
         svc.set_driver(driver)
         svc._state = DeviceConnectionState.CONNECTED
         svc._info = DeviceInfo(vendor="MockVendor", model="MockModel")
@@ -694,7 +702,10 @@ class TestApplyReceiverConfig:
             if call_[0] in write_methods
         ]
         assert order[-1] == "configure_baud"
-        driver.configure_baud.assert_called_once_with(115200, None)  # type: ignore[union-attr]
+        # A step that runs writes its complete key set assertively
+        # (issue #99) — uart2 is reasserted at its unchanged value,
+        # not omitted as ``None``.
+        driver.configure_baud.assert_called_once_with(115200, 115200)  # type: ignore[union-attr]
 
     @pytest.mark.asyncio()
     async def test_baud_uart1_and_uart2_both_written(
@@ -728,7 +739,9 @@ class TestApplyReceiverConfig:
         result = await connected_svc.apply_receiver_config(request)
 
         assert result.status == "ok"
-        driver.configure_baud.assert_called_once_with(None, 38400)  # type: ignore[union-attr]
+        # Complete-key-set write (issue #99): uart1 is reasserted at
+        # its unchanged value, not omitted as ``None``.
+        driver.configure_baud.assert_called_once_with(57600, 38400)  # type: ignore[union-attr]
         driver.reconnect_at_baud.assert_not_called()  # type: ignore[union-attr]
 
     @pytest.mark.asyncio()
@@ -756,7 +769,14 @@ class TestApplyReceiverConfig:
             for call_ in driver.method_calls  # type: ignore[union-attr]
             if call_[0] in {"reconnect_at_baud", "get_rtcm_port_config"}
         ]
-        assert order == ["reconnect_at_baud", "get_rtcm_port_config"]
+        # The first ``get_rtcm_port_config`` is the pre-write pre-read
+        # (issue #99); the second is the post-write read-back verify,
+        # which must come after the reopen.
+        assert order == [
+            "get_rtcm_port_config",
+            "reconnect_at_baud",
+            "get_rtcm_port_config",
+        ]
 
     @pytest.mark.asyncio()
     async def test_baud_uart1_reopen_success_updates_tracked_baud(
@@ -795,7 +815,10 @@ class TestApplyReceiverConfig:
             [call(115200), call(57600)]
         )
         assert connected_svc.state == DeviceConnectionState.DISCONNECTED
-        driver.get_rtcm_port_config.assert_not_called()  # type: ignore[union-attr]
+        # Called once, for the pre-write pre-read (issue #99) — the
+        # reopen failure raises before the post-write read-back verify
+        # would call it a second time.
+        driver.get_rtcm_port_config.assert_called_once()  # type: ignore[union-attr]
 
     @pytest.mark.asyncio()
     async def test_baud_uart1_reopen_retry_recovers_link_but_still_raises(
@@ -818,7 +841,9 @@ class TestApplyReceiverConfig:
 
         assert connected_svc.state == DeviceConnectionState.CONNECTED
         assert connected_svc._baud_rate == 57600  # pyright: ignore[reportPrivateUsage]
-        driver.get_rtcm_port_config.assert_not_called()  # type: ignore[union-attr]
+        # Called once, for the pre-write pre-read (issue #99) — see
+        # the sibling test above.
+        driver.get_rtcm_port_config.assert_called_once()  # type: ignore[union-attr]
 
     @pytest.mark.asyncio()
     async def test_ubx_in_liveness_guard_refuses_before_any_write(
@@ -881,6 +906,15 @@ class TestApplyReceiverConfig:
         )
         request = _minimal_request(tmode_mode=BaseMode.FIXED)
         _mock_read_back_matches(driver, request.assertion)
+        # ``_mock_read_back_matches`` points every read at the
+        # post-apply state — fine for the final read-back verify, but
+        # the pre-read (issue #99) needs to see the *old* tmode_mode
+        # first so the ``tmode_mode`` step actually runs rather than
+        # skipping (it would otherwise already "match").
+        driver.get_receiver_scalars.side_effect = [
+            _scalars_for(_minimal_assertion()),
+            _scalars_for(request.assertion),
+        ]
 
         result = await connected_svc.apply_receiver_config(request)
 
@@ -891,6 +925,8 @@ class TestApplyReceiverConfig:
     async def test_write_order_matches_the_specified_sequence(
         self, connected_svc: DeviceService
     ) -> None:
+        """Every step differs from the pre-read, so every step runs — and
+        runs in ``APPLY_STEPS`` order (issue #99)."""
         assert connected_svc.driver is not None
         request = _minimal_request(
             ports={
@@ -901,11 +937,24 @@ class TestApplyReceiverConfig:
             constellations=[GnssConstellation.GPS],
             elevation_mask_deg=10,
             dyn_model=DynModel.STATIONARY,
-            tmode_mode=BaseMode.DISABLED,
+            # Differs from the fixture's default live tmode (DISABLED)
+            # so the ``tmode_mode`` step actually runs; SURVEY_IN (not
+            # FIXED) keeps the coordinate guard out of the way, and
+            # ``connected_svc``'s survey-in status defaults to inactive
+            # so the new survey-in-active guard doesn't refuse it.
+            tmode_mode=BaseMode.SURVEY_IN,
             # Differs from the fixture's default current scalars so
             # ``configure_measurement_rate`` actually fires and can be
             # asserted first in the order below.
             meas_period_ms=333,
+            # Differs from the fixture's default matrix (1005/UART1
+            # only) so the ``rtcm_matrix`` step actually runs.
+            rtcm_stream=RtcmStreamConfig(
+                matrix={
+                    RtcmRowId.RTCM_1005: {PortId.UART1: True},
+                    RtcmRowId.RTCM_1077: {PortId.UART1: True},
+                }
+            ),
         )
 
         await connected_svc.apply_receiver_config(request)
@@ -935,12 +984,35 @@ class TestApplyReceiverConfig:
         ]
 
     @pytest.mark.asyncio()
-    async def test_ports_always_written(self, connected_svc: DeviceService) -> None:
-        """Issue #98: every field is sent on every Apply — ``ports`` is no
-        longer conditionally omitted."""
+    async def test_ports_step_skips_when_unchanged(
+        self, connected_svc: DeviceService
+    ) -> None:
+        """Issue #99: a step skips when its fields already match the
+        pre-read, rather than always (re)writing — the walk-back of
+        issue #98's "every field, every Apply"."""
         assert connected_svc.driver is not None
         await connected_svc.apply_receiver_config(_minimal_request())
-        connected_svc.driver.configure_port_protocols.assert_called_once()  # type: ignore[union-attr]
+        connected_svc.driver.configure_port_protocols.assert_not_called()  # type: ignore[union-attr]
+
+    @pytest.mark.asyncio()
+    async def test_ports_step_runs_when_changed(
+        self, connected_svc: DeviceService
+    ) -> None:
+        driver = connected_svc.driver
+        assert driver is not None
+        request = _minimal_request(
+            ports={
+                PortId.UART1: PortProtocolSet(
+                    **{"in": [UbxProtocol.UBX], "out": [UbxProtocol.RTCM3X]}
+                )
+            }
+        )
+
+        await connected_svc.apply_receiver_config(request)
+
+        driver.configure_port_protocols.assert_called_once_with(  # type: ignore[union-attr]
+            {PortId.UART1: [UbxProtocol.UBX]}, {PortId.UART1: [UbxProtocol.RTCM3X]}
+        )
 
     @pytest.mark.asyncio()
     async def test_constellations_flip_enabled_and_preserve_channels(
@@ -979,30 +1051,52 @@ class TestApplyReceiverConfig:
         assert by_constellation[GnssConstellation.GALILEO].max_channels == 12
 
     @pytest.mark.asyncio()
-    async def test_dyn_model_and_tmode_mode_always_written(
+    async def test_dyn_model_and_tmode_mode_skip_when_unchanged(
         self, connected_svc: DeviceService
     ) -> None:
-        """Issue #98: every field is sent on every Apply — ``dyn_model``/
-        ``tmode_mode`` are no longer conditionally omitted. Plain
-        reassertion of the same value is safe here (not the edge-
-        triggered survey-in path — see ``UbloxDriver.configure_tmode_mode``)."""
+        """Issue #99: a plain reassertion of the receiver's current value
+        is exactly the no-op case the step-level skip exists for."""
         assert connected_svc.driver is not None
         await connected_svc.apply_receiver_config(_minimal_request())
+        connected_svc.driver.configure_dyn_model.assert_not_called()  # type: ignore[union-attr]
+        connected_svc.driver.configure_tmode_mode.assert_not_called()  # type: ignore[union-attr]
+
+    @pytest.mark.asyncio()
+    async def test_dyn_model_and_tmode_mode_run_when_changed(
+        self, connected_svc: DeviceService
+    ) -> None:
+        """Plain reassertion of a *changed* value is safe here (not the
+        edge-triggered survey-in path — see
+        ``UbloxDriver.configure_tmode_mode``)."""
+        assert connected_svc.driver is not None
+        request = _minimal_request(
+            dyn_model=DynModel.STATIONARY, tmode_mode=BaseMode.SURVEY_IN
+        )
+        await connected_svc.apply_receiver_config(request)
         connected_svc.driver.configure_dyn_model.assert_called_once_with(  # type: ignore[union-attr]
-            DynModel.PORTABLE
+            DynModel.STATIONARY
         )
         connected_svc.driver.configure_tmode_mode.assert_called_once_with(  # type: ignore[union-attr]
-            BaseMode.DISABLED
+            BaseMode.SURVEY_IN
         )
 
     @pytest.mark.asyncio()
-    async def test_optimisations_always_invoked(
+    async def test_optimisations_skip_when_unchanged(
         self, connected_svc: DeviceService
     ) -> None:
         assert connected_svc.driver is not None
         await connected_svc.apply_receiver_config(_minimal_request())
+        connected_svc.driver.configure_optimisations.assert_not_called()  # type: ignore[union-attr]
+
+    @pytest.mark.asyncio()
+    async def test_optimisations_run_when_changed(
+        self, connected_svc: DeviceService
+    ) -> None:
+        assert connected_svc.driver is not None
+        request = _minimal_request(elevation_mask_deg=10)
+        await connected_svc.apply_receiver_config(request)
         connected_svc.driver.configure_optimisations.assert_called_once_with(  # type: ignore[union-attr]
-            0, False, False
+            10, False, False
         )
 
     @pytest.mark.asyncio()
@@ -1078,6 +1172,214 @@ class TestApplyReceiverConfig:
         }
         result = await connected_svc.apply_receiver_config(_minimal_request())
         assert result.warnings == []
+
+    # ------------------------------------------------------------------
+    # Per-step outcomes, the service-side no-op, and the warning
+    # channel (issue #99)
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio()
+    async def test_unchanged_form_reports_every_step_skipped_and_still_rereads(
+        self, connected_svc: DeviceService
+    ) -> None:
+        driver = connected_svc.driver
+        assert driver is not None
+        result = await connected_svc.apply_receiver_config(_minimal_request())
+
+        assert result.status == "ok"
+        assert [s.step for s in result.steps] == list(APPLY_STEPS)
+        assert all(s.status == "skipped" for s in result.steps)
+        # Once for the pre-read's no-op decision, once for the
+        # post-apply read-back verify — nothing was written in
+        # between, but both reads still happen.
+        assert driver.get_rtcm_port_config.call_count == 2  # type: ignore[union-attr]
+
+    @pytest.mark.asyncio()
+    async def test_failed_step_stops_remaining_steps_without_raising(
+        self, connected_svc: DeviceService
+    ) -> None:
+        driver = connected_svc.driver
+        assert driver is not None
+        driver.configure_port_protocols.side_effect = RuntimeError("NAK")  # type: ignore[union-attr]
+        request = _minimal_request(
+            ports={
+                PortId.UART1: PortProtocolSet(
+                    **{"in": [UbxProtocol.UBX], "out": [UbxProtocol.RTCM3X]}
+                )
+            },
+            dyn_model=DynModel.STATIONARY,
+        )
+
+        result = await connected_svc.apply_receiver_config(request)
+
+        by_step = {s.step: s.status for s in result.steps}
+        assert by_step["meas_period_ms"] == "skipped"
+        assert by_step["ports"] == "failed"
+        # Every step after the failure reports "skipped" too — not
+        # just the ones that happened to already match the pre-read
+        # (``dyn_model`` deliberately differs here).
+        assert by_step["constellations"] == "skipped"
+        assert by_step["optimisations"] == "skipped"
+        assert by_step["dyn_model"] == "skipped"
+        assert by_step["tmode_mode"] == "skipped"
+        assert by_step["rtcm_matrix"] == "skipped"
+        assert by_step["baud"] == "skipped"
+        driver.configure_dyn_model.assert_not_called()  # type: ignore[union-attr]
+        # The read-back still ran (pre-read + final verify) despite
+        # the failed step never raising out of apply_receiver_config.
+        assert driver.get_rtcm_port_config.call_count == 2  # type: ignore[union-attr]
+        assert result.status == "failed"
+        assert result.read_back is not None
+
+    @pytest.mark.asyncio()
+    async def test_survey_in_active_refuses_tmode_mode_change(
+        self, connected_svc: DeviceService
+    ) -> None:
+        driver = connected_svc.driver
+        assert driver is not None
+        driver.get_survey_in_status.return_value = SurveyInProgress(active=True)  # type: ignore[union-attr]
+        request = _minimal_request(tmode_mode=BaseMode.SURVEY_IN)
+
+        with pytest.raises(ApplyConfigRefusedError) as exc_info:
+            await connected_svc.apply_receiver_config(request)
+
+        assert exc_info.value.rule == "survey_in_active"
+        driver.configure_tmode_mode.assert_not_called()  # type: ignore[union-attr]
+        driver.configure_measurement_rate.assert_not_called()  # type: ignore[union-attr]
+
+    @pytest.mark.asyncio()
+    async def test_survey_in_active_allows_apply_when_base_mode_unchanged(
+        self, connected_svc: DeviceService
+    ) -> None:
+        """An Apply that leaves ``tmode_mode`` alone still proceeds
+        mid-survey — only a base-mode *change* is refused."""
+        driver = connected_svc.driver
+        assert driver is not None
+        driver.get_survey_in_status.return_value = SurveyInProgress(active=True)  # type: ignore[union-attr]
+        request = _minimal_request(elevation_mask_deg=10)
+
+        result = await connected_svc.apply_receiver_config(request)
+
+        by_step = {s.step: s.status for s in result.steps}
+        assert by_step["optimisations"] == "ok"
+        driver.configure_optimisations.assert_called_once_with(  # type: ignore[union-attr]
+            10, False, False
+        )
+
+    @pytest.mark.asyncio()
+    async def test_step_warning_drained_and_tagged_with_step_name(
+        self, connected_svc: DeviceService
+    ) -> None:
+        driver = connected_svc.driver
+        assert driver is not None
+        driver.drain_warnings.return_value = ["flash write not confirmed"]  # type: ignore[union-attr]
+        request = _minimal_request(
+            ports={
+                PortId.UART1: PortProtocolSet(
+                    **{"in": [UbxProtocol.UBX], "out": [UbxProtocol.RTCM3X]}
+                )
+            }
+        )
+
+        result = await connected_svc.apply_receiver_config(request)
+
+        assert len(result.step_warnings) == 1
+        warning = result.step_warnings[0]
+        assert warning.step == "ports"
+        assert warning.message == "flash write not confirmed"
+
+    @pytest.mark.asyncio()
+    async def test_step_that_warned_is_excluded_from_next_apply_skip(
+        self, connected_svc: DeviceService
+    ) -> None:
+        """A step that warned on the previous Apply retries on the next
+        one even though nothing changed — the remedy for a durability
+        warning must not be a no-op that erases its own warning."""
+        driver = connected_svc.driver
+        assert driver is not None
+        driver.drain_warnings.return_value = ["flash write not confirmed"]  # type: ignore[union-attr]
+        request = _minimal_request(
+            ports={
+                PortId.UART1: PortProtocolSet(
+                    **{"in": [UbxProtocol.UBX], "out": [UbxProtocol.RTCM3X]}
+                )
+            }
+        )
+
+        await connected_svc.apply_receiver_config(request)
+        driver.configure_port_protocols.reset_mock()  # type: ignore[union-attr]
+        driver.drain_warnings.return_value = []  # type: ignore[union-attr]
+        # The pre-read now reflects what the first Apply just wrote —
+        # were it not for the warning exception, this would make the
+        # ``ports`` step look unchanged and skip.
+        driver.get_port_protocols.return_value = PortProtocolConfig(  # type: ignore[union-attr]
+            in_protocols={PortId.UART1: [UbxProtocol.UBX]},
+            out_protocols={PortId.UART1: [UbxProtocol.RTCM3X]},
+        )
+
+        result = await connected_svc.apply_receiver_config(request)
+
+        driver.configure_port_protocols.assert_called_once()  # type: ignore[union-attr]
+        by_step = {s.step: s.status for s in result.steps}
+        assert by_step["ports"] == "ok"
+
+    @pytest.mark.asyncio()
+    async def test_warned_step_blocked_by_earlier_failure_keeps_warned_status(
+        self, connected_svc: DeviceService
+    ) -> None:
+        """A step that warned on Apply N, then gets blocked (never
+        reached) by an unrelated earlier failure on Apply N+1, still
+        retries on Apply N+2 — the warning isn't silently dropped just
+        because one Apply in between never got a chance to resolve
+        it."""
+        driver = connected_svc.driver
+        assert driver is not None
+        driver.drain_warnings.return_value = ["flash write not confirmed"]  # type: ignore[union-attr]
+        ports_override = {
+            PortId.UART1: PortProtocolSet(
+                **{"in": [UbxProtocol.UBX], "out": [UbxProtocol.RTCM3X]}
+            )
+        }
+        ports_request = _minimal_request(ports=ports_override)
+
+        # Apply #1: ``ports`` differs, runs, and warns.
+        await connected_svc.apply_receiver_config(ports_request)
+        assert connected_svc._steps_warned_last_apply == {"ports"}
+        driver.configure_port_protocols.reset_mock()  # type: ignore[union-attr]
+
+        # Apply #2: ``ports`` now matches the receiver (were it not
+        # for the warning, it would skip) but an unrelated, earlier
+        # step (``meas_period_ms``) fails first and blocks the rest —
+        # ``ports`` never gets the chance to run or resolve.
+        driver.get_port_protocols.return_value = PortProtocolConfig(  # type: ignore[union-attr]
+            in_protocols={PortId.UART1: [UbxProtocol.UBX]},
+            out_protocols={PortId.UART1: [UbxProtocol.RTCM3X]},
+        )
+        driver.configure_measurement_rate.side_effect = RuntimeError("NAK")  # type: ignore[union-attr]
+        blocked_request = _minimal_request(ports=ports_override, meas_period_ms=333)
+
+        result2 = await connected_svc.apply_receiver_config(blocked_request)
+
+        by_step2 = {s.step: s.status for s in result2.steps}
+        assert by_step2["meas_period_ms"] == "failed"
+        assert by_step2["ports"] == "skipped"
+        driver.configure_port_protocols.assert_not_called()  # type: ignore[union-attr]
+        # The warning survives — it wasn't cleared just because
+        # ``ports`` never got a chance to run this Apply.
+        assert connected_svc._steps_warned_last_apply == {"ports"}
+
+        # Apply #3: the earlier step no longer fails, and ``ports``
+        # still matches — it runs anyway, purely because it's still
+        # in the warned set from Apply #1.
+        driver.configure_measurement_rate.side_effect = None  # type: ignore[union-attr]
+        driver.drain_warnings.return_value = []  # type: ignore[union-attr]
+
+        result3 = await connected_svc.apply_receiver_config(ports_request)
+
+        by_step3 = {s.step: s.status for s in result3.steps}
+        assert by_step3["ports"] == "ok"
+        driver.configure_port_protocols.assert_called_once()  # type: ignore[union-attr]
+        assert connected_svc._steps_warned_last_apply == set()
 
 
 class TestSurveyInPreservesAppliedProfile:
@@ -1273,6 +1575,38 @@ class TestBaseInvariants:
         assert applied_request.assertion.tmode_mode == BaseMode.SURVEY_IN
 
         assert result.status == "ok"
+
+    @pytest.mark.asyncio()
+    async def test_apply_base_invariants_never_rewrites_baud(
+        self, connected_svc: DeviceService
+    ) -> None:
+        """Issue #99 acceptance criterion: applying base invariants no
+        longer rearms a baud write. End to end through the real
+        ``apply_receiver_config`` step-skip (not a mocked delegate, as
+        ``test_apply_delegates_...`` above uses) — baud falling back to
+        live in the merged request only prevents a rewrite if the new
+        per-step skip actually sees it as unchanged."""
+        driver = connected_svc.driver
+        assert driver is not None
+        driver.get_uart_baud_rates.return_value = {  # type: ignore[union-attr]
+            PortId.UART1: 9600,
+            PortId.UART2: 9600,
+        }
+        driver.drain_warnings.return_value = []  # type: ignore[union-attr]
+        # The built-in profile doesn't mention USB, so the merged
+        # request's USB ports fall back to live — which must keep UBX
+        # enabled on USB IN (the console's own management link) or the
+        # ubx_in_liveness guard refuses, as it would on any real,
+        # connected receiver.
+        driver.get_port_protocols.return_value = PortProtocolConfig(  # type: ignore[union-attr]
+            in_protocols={PortId.USB: [UbxProtocol.UBX]},
+            out_protocols={},
+        )
+
+        await connected_svc.apply_base_invariants()
+
+        driver.configure_baud.assert_not_called()  # type: ignore[union-attr]
+        driver.reconnect_at_baud.assert_not_called()  # type: ignore[union-attr]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_driver_registry.py
+++ b/tests/unit/test_driver_registry.py
@@ -129,6 +129,9 @@ class StubDriver(GpsReceiverDriver):
     def get_uart_baud_rates(self) -> dict[PortId, int]:
         return {}
 
+    def drain_warnings(self) -> list[str]:
+        return []
+
     def get_receiver_scalars(self) -> ReceiverScalarConfig:
         return ReceiverScalarConfig(
             uart1_baud=115200,

--- a/tests/unit/test_fake_driver.py
+++ b/tests/unit/test_fake_driver.py
@@ -280,6 +280,10 @@ class TestDisconnectedGuards:
         with pytest.raises(ConnectionError):
             driver.get_uart_baud_rates()
 
+    def test_drain_warnings_requires_connection(self, driver: FakeGpsDriver) -> None:
+        with pytest.raises(ConnectionError):
+            driver.drain_warnings()
+
 
 # ---------------------------------------------------------------------------
 # Configuration round-trips
@@ -448,6 +452,14 @@ class TestConfigurationRoundTrips:
     ) -> None:
         rates = connected_driver.get_uart_baud_rates()
         assert rates == {PortId.UART1: 57600, PortId.UART2: 115200}
+
+    def test_drain_warnings_is_always_empty(
+        self, connected_driver: FakeGpsDriver
+    ) -> None:
+        """No producer is wired up on the fake driver yet (issue #99)."""
+        assert connected_driver.drain_warnings() == []
+        connected_driver.configure_baud(115200, None)
+        assert connected_driver.drain_warnings() == []
 
     def test_configure_baud_stores_only_provided_fields(
         self, connected_driver: FakeGpsDriver

--- a/tests/unit/test_profile_models.py
+++ b/tests/unit/test_profile_models.py
@@ -18,8 +18,11 @@ from sp_rtk_base.models.device_models import (
     UbxProtocol,
 )
 from sp_rtk_base.models.profile_models import (
+    APPLY_STEPS,
     ApplyConfigResult,
     ApplyDiffEntry,
+    ApplyStepResult,
+    ApplyStepWarning,
     BaudAssertion,
     BaudConfig,
     DynModel,
@@ -32,6 +35,7 @@ from sp_rtk_base.models.profile_models import (
     TmodeMode,
     diff_receiver_assertions,
     merge_profile_into_assertion,
+    step_for_diff_path,
 )
 
 
@@ -729,3 +733,101 @@ class TestApplyConfigResult:
             status="failed", read_back=_base_assertion(), diff=[entry]
         )
         assert result.diff == [entry]
+
+    def test_steps_and_step_warnings_default_empty(self) -> None:
+        result = ApplyConfigResult(status="ok", read_back=_base_assertion())
+        assert result.steps == []
+        assert result.step_warnings == []
+
+    def test_carries_steps_and_step_warnings(self) -> None:
+        result = ApplyConfigResult(
+            status="ok",
+            read_back=_base_assertion(),
+            steps=[ApplyStepResult(step="ports", status="ok")],
+            step_warnings=[ApplyStepWarning(step="ports", message="flash mismatch")],
+        )
+        assert result.steps == [ApplyStepResult(step="ports", status="ok")]
+        assert result.step_warnings == [
+            ApplyStepWarning(step="ports", message="flash mismatch")
+        ]
+
+
+# ---------------------------------------------------------------------------
+# APPLY_STEPS / step_for_diff_path / ApplyStepResult / ApplyStepWarning
+# (issue #99)
+# ---------------------------------------------------------------------------
+
+
+class TestApplyStepResult:
+    def test_rejects_unknown_status(self) -> None:
+        with pytest.raises(ValidationError):
+            ApplyStepResult.model_validate({"name": "ports", "status": "bogus"})
+
+    def test_rejects_extra_fields(self) -> None:
+        with pytest.raises(ValidationError):
+            ApplyStepResult.model_validate(
+                {"name": "ports", "status": "ok", "extra": 1}
+            )
+
+
+class TestApplyStepWarning:
+    def test_rejects_extra_fields(self) -> None:
+        with pytest.raises(ValidationError):
+            ApplyStepWarning.model_validate(
+                {"step": "ports", "message": "x", "severity": "high"}
+            )
+
+
+class TestStepForDiffPath:
+    @pytest.mark.parametrize(
+        ("path", "step"),
+        [
+            ("meas_period_ms", "meas_period_ms"),
+            ("ports.UART1.in.UBX", "ports"),
+            ("ports.USB.out.NMEA", "ports"),
+            ("constellations.gps", "constellations"),
+            ("elevation_mask_deg", "optimisations"),
+            ("bds_b2_enabled", "optimisations"),
+            ("spi_enabled", "optimisations"),
+            ("dyn_model", "dyn_model"),
+            ("tmode_mode", "tmode_mode"),
+            ("rtcm.1005.UART1", "rtcm_matrix"),
+            ("baud.uart1", "baud"),
+            ("baud.uart2", "baud"),
+        ],
+    )
+    def test_maps_known_paths_to_their_step(self, path: str, step: str) -> None:
+        assert step_for_diff_path(path) == step
+        assert step in APPLY_STEPS
+
+    def test_unrecognised_path_raises(self) -> None:
+        with pytest.raises(ValueError, match="unrecognised"):
+            step_for_diff_path("not.a.real.path")
+
+    def test_every_real_diff_leaf_resolves_to_a_step(self) -> None:
+        """Every leaf ``diff_receiver_assertions`` can ever emit maps onto
+        exactly one ``APPLY_STEPS`` entry — the grouping
+        ``DeviceService.apply_receiver_config`` relies on for its
+        per-step skip decision never raises on a real diff."""
+        a = _base_assertion()
+        b = ReceiverAssertion(
+            baud=BaudAssertion(uart1=115200, uart2=38400),
+            meas_period_ms=200,
+            constellations=[GnssConstellation.GLONASS],
+            ports={
+                PortId.UART1: PortProtocolSet(**{"in": [], "out": []}),
+                PortId.UART2: PortProtocolSet(**{"in": [], "out": ["NMEA"]}),
+                PortId.USB: PortProtocolSet(**{"in": [], "out": []}),
+            },
+            dyn_model=DynModel.PORTABLE,
+            tmode_mode=TmodeMode.FIXED,
+            elevation_mask_deg=20,
+            bds_b2_enabled=True,
+            spi_enabled=True,
+            rtcm_stream=RtcmStreamConfig(
+                matrix={RtcmRowId.RTCM_1077: {PortId.UART2: True}}
+            ),
+        )
+        diffs = diff_receiver_assertions(a, b)
+        assert diffs, "fixture should produce at least one diff leaf"
+        assert {step_for_diff_path(d.path) for d in diffs} <= set(APPLY_STEPS)

--- a/tests/unit/test_ublox_driver.py
+++ b/tests/unit/test_ublox_driver.py
@@ -1911,6 +1911,29 @@ class TestGetUartBaudRates:
         assert result == {PortId.UART1: 57600, PortId.UART2: 115200}
 
 
+class TestDrainWarnings:
+    """No producer is wired up on this driver yet (issue #99)."""
+
+    def test_requires_connection(self) -> None:
+        driver = UbloxDriver()
+        with pytest.raises(ConnectionError, match="Not connected"):
+            driver.drain_warnings()
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_returns_empty_when_connected(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        driver, _reader = _connect_driver(
+            mock_serial_cls, mock_reader_cls, mock_ubx_msg, []
+        )
+        assert driver.drain_warnings() == []
+
+
 class TestGetReceiverScalars:
     """Tests for ``UbloxDriver.get_receiver_scalars`` (issue #97)."""
 


### PR DESCRIPTION
## Summary

Closes #99.

- `apply_receiver_config` now takes a fresh pre-read at the instant of Apply and decides, per write step (measurement rate, ports, constellations, optimisations, dyn_model, tmode_mode, RTCM matrix, baud), whether it's `ok`/`failed`/`skipped` — a step skips only when it already matches the receiver, unless it warned on the previous Apply (that exception survives an unrelated later Apply that blocks the step from running before it can resolve).
- A failed step stops the rest but never raises — only a pre-write refusal or a lost link still does. The read-back always runs regardless, so the diff always states the receiver's real final state.
- New `survey_in_active` guard refuses an Apply that would change base mode while a survey is running; an Apply that leaves base mode alone still proceeds mid-survey.
- New driver-drained, step-tagged warning channel (`ApplyStepWarning` / `GpsReceiverDriver.drain_warnings()`) — no producer wired up on either concrete driver yet, per spec.
- `apply_base_invariants` no longer rearms a baud write, now verified end-to-end through the real step-skip rather than only asserted via a mocked delegate.

## Test plan

- [x] `uv run pytest` — 1460 unit tests pass, coverage 93.82% (gate 90%)
- [x] `uv run pyright src/` — clean (strict)
- [x] `uv run mypy src/` — clean
- [x] `uv run ruff check` / `ruff format --check` — clean
- [x] New/updated tests cover: unchanged-form re-verify with all steps skipped, a failed step blocking and skipping the rest without raising, the survey-in-active guard both ways, the warning-drain/tagging, the warned-step skip exception, and that exception surviving a blocked intervening Apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AcBmmcpcJtBBxvDE8M3C6p