### PR TITLE
feat(gps): verify durable writes at the flash layer, not just RAM

### DIFF
--- a/src/sp_rtk_base/services/device_service.py
+++ b/src/sp_rtk_base/services/device_service.py
@@ -484,6 +484,13 @@ class DeviceService:
                 config.min_duration_seconds,
                 config.accuracy_limit_mm,
             )
+            # Drain immediately: this call sits outside apply_receiver_
+            # config's per-step loop, the only other drain site. Left
+            # undrained, a flash-divergence warning (issue #103) would
+            # sit on the driver's shared queue and get misattributed to
+            # whatever unrelated step a later Apply happens to run.
+            for warning in await asyncio.to_thread(driver.drain_warnings):
+                logger.warning("configure_survey_in: %s", warning)
         except Exception as exc:
             self._state = DeviceConnectionState.CONNECTED
             self._last_error = str(exc)
@@ -732,6 +739,13 @@ class DeviceService:
             await asyncio.to_thread(driver.configure_rtcm_ports, config)
             self._state = DeviceConnectionState.CONNECTED
             logger.info("Multi-port RTCM config applied")
+            # Drain immediately — see the matching comment in
+            # configure_survey_in (issue #103): this call sits outside
+            # apply_receiver_config's per-step loop, the only other
+            # drain site, so an undrained warning would otherwise be
+            # misattributed to a later, unrelated Apply step.
+            for warning in await asyncio.to_thread(driver.drain_warnings):
+                logger.warning("configure_rtcm_ports: %s", warning)
         except Exception as exc:
             self._state = DeviceConnectionState.CONNECTED
             self._last_error = str(exc)

--- a/src/sp_rtk_base/services/drivers/base.py
+++ b/src/sp_rtk_base/services/drivers/base.py
@@ -339,9 +339,10 @@ class GpsReceiverDriver(abc.ABC):
         to have succeeded, but something the sync check is
         structurally unable to see is wrong — e.g. a value that landed
         in RAM but not flash, or a constellation the firmware
-        acknowledged but does not appear to act on. No severity field,
-        and no producer on this driver yet — a concrete driver with
-        nothing to report simply returns an empty list every time.
+        acknowledged but does not appear to act on. No severity field.
+        A concrete driver with nothing to report simply returns an
+        empty list every time — the u-blox driver's only producer is
+        its write-and-verify helper's flash read-back (issue #103).
 
         Returns:
             Warning messages queued since the last call; empty if none.

--- a/src/sp_rtk_base/services/drivers/ublox.py
+++ b/src/sp_rtk_base/services/drivers/ublox.py
@@ -185,6 +185,9 @@ class UbloxDriver(GpsReceiverDriver):
         # the hardware reset re-enumerates the USB.
         self._port: str | None = None
         self._baud_rate: int | None = None
+        # Advisories queued by ``_write_and_verify_locked`` for a flash
+        # divergence (issue #103) — drained by ``drain_warnings``.
+        self._warnings: list[str] = []
 
     # ------------------------------------------------------------------
     # Identity
@@ -412,6 +415,13 @@ class UbloxDriver(GpsReceiverDriver):
     # ``_read_cfg_keys_locked`` (issue #94): every existing caller
     # wants RAM, matching this method's pre-#94 hardcoded behaviour.
     _CFG_LAYER_RAM: int = 0
+    _CFG_LAYER_FLASH: int = 2
+
+    # The CFG-VALSET bitmask's Flash bit (see the layer comment above:
+    # 1=RAM, 2=BBR, 4=Flash). Gates the flash read-back in
+    # ``_write_and_verify_locked`` (issue #103) — a write that never
+    # targets flash has nothing durable to check.
+    _CFG_VALSET_FLASH_BIT: int = 4
 
     # How long to wait after a UBX-CFG-RST resetMode=0 (hardware
     # reset) for the chip to re-enumerate on USB and be ready to
@@ -810,17 +820,34 @@ class UbloxDriver(GpsReceiverDriver):
         the same read-back check ``configure_fixed_base`` established for
         ECEF (issue #39).
 
+        When ``layer`` includes the Flash bit, each attempt also polls
+        the flash layer itself (issue #103) — the RAM check above only
+        proves the receiver's *live* state is correct, not that it will
+        survive a power cycle. A flash divergence never fails the write:
+        RAM already matches, so the receiver is correctly configured
+        right now. It folds into this method's existing single retry
+        (a spurious first-attempt flash miss is re-written and re-polled
+        the same as a RAM mismatch) and, if it survives that retry,
+        queues an advisory on ``self._warnings`` naming the affected
+        keys and the failure shape instead of raising.
+
         Raises:
-            RuntimeError: if the read-back still doesn't match after one
-                retry.
+            RuntimeError: if the RAM read-back still doesn't match after
+                one retry.
         """
         expected = dict(cfg_data)
+        check_flash = bool(layer & self._CFG_VALSET_FLASH_BIT)
+
         self._send_cfg_valset_locked(cfg_data, layer=layer)
         actual = self._read_cfg_keys_locked(list(expected))
-        if actual == expected:
+        flash_divergence = (
+            self._flash_divergence_locked(expected) if check_flash else None
+        )
+        if actual == expected and flash_divergence is None:
             return
 
-        logger.warning("%s mismatch after first write — retrying", label)
+        if actual != expected:
+            logger.warning("%s mismatch after first write — retrying", label)
         self._send_cfg_valset_locked(cfg_data, layer=layer)
         actual = self._read_cfg_keys_locked(list(expected))
         if actual != expected:
@@ -830,6 +857,60 @@ class UbloxDriver(GpsReceiverDriver):
                 "disconnecting and reconnecting, or power-cycle the "
                 "receiver."
             )
+
+        if check_flash:
+            flash_divergence = self._flash_divergence_locked(expected)
+            if flash_divergence is not None:
+                message = f"{label}: {flash_divergence}"
+                logger.warning(
+                    "%s did not durably store the write after two attempts "
+                    "— RAM is correctly configured, but this will not "
+                    "survive a power cycle",
+                    label,
+                )
+                self._warnings.append(message)
+
+    def _flash_divergence_locked(self, expected: dict[str, int]) -> str | None:
+        """Poll ``expected``'s keys at the flash layer and describe any divergence.
+
+        Must hold ``self._lock``. Companion to ``_write_and_verify_locked``
+        (issue #103) — never raises for a divergence, only for a transport
+        failure: ``_read_cfg_keys_locked`` raises ``RuntimeError`` both for
+        an explicit ACK-NAK (one of the three divergence shapes this method
+        reports, caught below) and for no response at all within the read
+        budget (a genuine communication failure, not one of the shapes the
+        spec describes — left to propagate rather than softened into a
+        warning). Returns ``None`` when flash agrees with what was just
+        written to RAM, else a message naming the affected keys and which
+        of the three observed shapes occurred: a value differs from what
+        was written, the key comes back NAK'd, or it's silently omitted
+        from a partial batch response.
+        """
+        try:
+            flash_actual = self._read_cfg_keys_locked(
+                list(expected), layer=self._CFG_LAYER_FLASH
+            )
+        except RuntimeError as exc:
+            if "NAK" not in str(exc):
+                raise
+            return f"flash NAK'd the read-back for {list(expected)}: {exc}"
+
+        omitted = sorted(k for k in expected if k not in flash_actual)
+        differing = {
+            k: v for k, v in sorted(flash_actual.items()) if expected.get(k) != v
+        }
+        if not omitted and not differing:
+            return None
+
+        parts: list[str] = []
+        if differing:
+            mismatches = ", ".join(
+                f"{k}={v} (expected {expected[k]})" for k, v in differing.items()
+            )
+            parts.append(f"value differs at flash: {mismatches}")
+        if omitted:
+            parts.append(f"omitted from flash read-back: {', '.join(omitted)}")
+        return "; ".join(parts)
 
     # ------------------------------------------------------------------
     # Multi-port RTCM configuration
@@ -1247,10 +1328,16 @@ class UbloxDriver(GpsReceiverDriver):
             self._send_cfg_valset_locked(cfg_data, layer=5)
 
     def drain_warnings(self) -> list[str]:
-        """No producer wired up yet on this driver — always empty (issue #99)."""
+        """Drain flash-divergence advisories queued by durable writes (issue #103).
+
+        The only producer on this driver is ``_write_and_verify_locked``'s
+        flash read-back — see its docstring for what lands here.
+        """
         if not self.is_connected:
             raise ConnectionError("Not connected to device")
-        return []
+        with self._lock:
+            drained, self._warnings = self._warnings, []
+        return drained
 
     def get_receiver_scalars(self) -> ReceiverScalarConfig:
         """Batched read of baud, meas rate, dyn model, tmode mode and the

--- a/tests/unit/test_cancel_survey_in.py
+++ b/tests/unit/test_cancel_survey_in.py
@@ -158,10 +158,11 @@ class TestUbloxDisableBaseMode:
         #   0. NAV-SVIN baseline poll                       -> dur=0 (no pre-reset)
         #   1. CFG-VALSET TMODE=0 (layer=7: RAM+BBR+Flash)  -> ACK
         #   2. CFG-VALSET TMODE=1 + SVIN params (layer=5)   -> ACK
-        #   3. CFG-VALGET read-back                         -> matches (issue #42)
-        #   4. NAV-SVIN poll                                -> dur=0
-        #   5. (wait ~2s)
-        #   6. NAV-SVIN poll                                -> dur=2 (incremented)
+        #   3. CFG-VALGET RAM read-back                     -> matches (issue #42)
+        #   4. CFG-VALGET flash read-back                   -> matches (issue #103)
+        #   5. NAV-SVIN poll                                -> dur=0
+        #   6. (wait ~2s)
+        #   7. NAV-SVIN poll                                -> dur=2 (incremented)
         reader.read.side_effect = [
             (b"", _make_mon_ver()),
             (
@@ -185,7 +186,16 @@ class TestUbloxDisableBaseMode:
                     CFG_TMODE_SVIN_ACC_LIMIT=500000,
                     CFG_TMODE_MODE=1,
                 ),
-            ),  # enable read-back — matches
+            ),  # enable RAM read-back — matches
+            (
+                b"",
+                SimpleNamespace(
+                    identity="CFG-VALGET",
+                    CFG_TMODE_SVIN_MIN_DUR=120,
+                    CFG_TMODE_SVIN_ACC_LIMIT=500000,
+                    CFG_TMODE_MODE=1,
+                ),
+            ),  # enable flash read-back — matches (issue #103)
             (
                 b"",
                 SimpleNamespace(
@@ -290,7 +300,16 @@ class TestUbloxDisableBaseMode:
                     CFG_TMODE_SVIN_ACC_LIMIT=500000,
                     CFG_TMODE_MODE=1,
                 ),
-            ),  # enable read-back — matches (issue #42)
+            ),  # enable RAM read-back — matches (issue #42)
+            (
+                b"",
+                SimpleNamespace(
+                    identity="CFG-VALGET",
+                    CFG_TMODE_SVIN_MIN_DUR=60,
+                    CFG_TMODE_SVIN_ACC_LIMIT=500000,
+                    CFG_TMODE_MODE=1,
+                ),
+            ),  # enable flash read-back — matches (issue #103)
             (b"", nav_svin_idle),  # before-snapshot
             (b"", nav_svin_idle),  # after-snapshot, dur unchanged
             (b"", _make_ack()),  # rollback layer=7 disable
@@ -382,7 +401,16 @@ class TestUbloxDisableBaseMode:
                     CFG_TMODE_SVIN_ACC_LIMIT=500000,
                     CFG_TMODE_MODE=1,
                 ),
-            ),  # enable read-back — matches (issue #42)
+            ),  # enable RAM read-back — matches (issue #42)
+            (
+                b"",
+                SimpleNamespace(
+                    identity="CFG-VALGET",
+                    CFG_TMODE_SVIN_MIN_DUR=60,
+                    CFG_TMODE_SVIN_ACC_LIMIT=500000,
+                    CFG_TMODE_MODE=1,
+                ),
+            ),  # enable flash read-back — matches (issue #103)
             (b"", nav_svin_fresh_before),  # before-snapshot
             (b"", nav_svin_fresh_after),  # after-snapshot
         ]
@@ -441,7 +469,11 @@ class TestUbloxDisableBaseMode:
             (b"", nav_svin_idle),  # baseline (no pre-reset)
             (b"", _make_ack()),  # full-layer disable
             (b"", _make_ack()),  # enable (first attempt)
-            (b"", SimpleNamespace(identity="CFG-VALGET")),  # read-back — mismatch
+            (b"", SimpleNamespace(identity="CFG-VALGET")),  # RAM read-back — mismatch
+            (
+                b"",
+                SimpleNamespace(identity="CFG-VALGET"),
+            ),  # flash read-back (issue #103) — discarded, RAM already retrying
             (b"", _make_ack()),  # enable (retried)
             (
                 b"",
@@ -451,7 +483,16 @@ class TestUbloxDisableBaseMode:
                     CFG_TMODE_SVIN_ACC_LIMIT=500000,
                     CFG_TMODE_MODE=1,
                 ),
-            ),  # read-back — matches on retry
+            ),  # RAM read-back — matches on retry
+            (
+                b"",
+                SimpleNamespace(
+                    identity="CFG-VALGET",
+                    CFG_TMODE_SVIN_MIN_DUR=60,
+                    CFG_TMODE_SVIN_ACC_LIMIT=500000,
+                    CFG_TMODE_MODE=1,
+                ),
+            ),  # flash read-back — matches (issue #103)
             (b"", nav_svin_idle),  # before-snapshot
             (b"", nav_svin_progressed),  # after-snapshot
         ]
@@ -504,9 +545,10 @@ class TestUbloxDisableBaseMode:
             (b"", nav_svin_idle),  # baseline (no pre-reset)
             (b"", _make_ack()),  # full-layer disable
             (b"", _make_ack()),  # enable (first attempt)
-            (b"", mismatch),  # read-back — mismatch
+            (b"", mismatch),  # RAM read-back — mismatch
+            (b"", mismatch),  # flash read-back (issue #103) — discarded
             (b"", _make_ack()),  # enable (retried)
-            (b"", mismatch),  # read-back — still mismatched
+            (b"", mismatch),  # RAM read-back — still mismatched -> raises
         ]
         mock_reader_cls.return_value = reader
 

--- a/tests/unit/test_rtcm_port_config.py
+++ b/tests/unit/test_rtcm_port_config.py
@@ -284,7 +284,7 @@ class TestConfigureRtcmPorts:
         # Patch the *locked* variant — that's what writers call now that
         # all CFG-VALSET callers acquire ``self._lock`` directly to make
         # multi-step writes atomic against concurrent polls.
-        def _fake_read_back(keys: list[str]) -> dict[str, int]:
+        def _fake_read_back(keys: list[str], layer: int = 0) -> dict[str, int]:
             return dict.fromkeys(keys, 0) | {k: 1 for k in keys if k.endswith("_USB")}
 
         with (
@@ -306,10 +306,15 @@ class TestConfigureRtcmPorts:
             # Issue #42: RAM+Flash, not RAM-only — a layer=1 write
             # reverted to the last-flashed rates on reboot / reconnect.
             assert mock_valset.call_args.kwargs["layer"] == 5
-            # Verify-after-write: the read-back must be polled with
-            # exactly the keys just written.
-            mock_read.assert_called_once()
-            assert set(mock_read.call_args[0][0]) == {k for k, _ in cfg_data}
+            # Verify-after-write: RAM and, since this is a layer=5
+            # write, flash too (issue #103) — both polled with exactly
+            # the keys just written.
+            assert mock_read.call_count == 2
+            ram_call, flash_call = mock_read.call_args_list
+            assert set(ram_call[0][0]) == {k for k, _ in cfg_data}
+            assert "layer" not in ram_call.kwargs
+            assert set(flash_call[0][0]) == {k for k, _ in cfg_data}
+            assert flash_call.kwargs["layer"] == driver._CFG_LAYER_FLASH
 
     def test_configure_empty_config(self) -> None:
         from sp_rtk_base.services.drivers.ublox import UbloxDriver
@@ -339,18 +344,29 @@ class TestConfigureRtcmPorts:
 
         config = RtcmPortConfig(messages={RtcmRowId.RTCM_1005: {"USB": 1}})
 
+        def _fake_read(keys: list[str], layer: int = 0) -> dict[str, int]:
+            if layer == driver._CFG_LAYER_FLASH:
+                return {"CFG_MSGOUT_RTCM_3X_TYPE1005_USB": 1}
+            return next(ram_reads)
+
+        ram_reads = iter(
+            [
+                {"CFG_MSGOUT_RTCM_3X_TYPE1005_USB": 0},  # mismatch
+                {"CFG_MSGOUT_RTCM_3X_TYPE1005_USB": 1},  # matches on retry
+            ]
+        )
+
         with (
             patch.object(driver, "_send_cfg_valset_locked") as mock_valset,
             patch.object(driver, "_read_cfg_keys_locked") as mock_read,
         ):
-            mock_read.side_effect = [
-                {"CFG_MSGOUT_RTCM_3X_TYPE1005_USB": 0},  # mismatch
-                {"CFG_MSGOUT_RTCM_3X_TYPE1005_USB": 1},  # matches on retry
-            ]
+            mock_read.side_effect = _fake_read
             driver.configure_rtcm_ports(config)  # must not raise
 
         assert mock_valset.call_count == 2
-        assert mock_read.call_count == 2
+        # 2 RAM reads (mismatch + retry-match) + a flash read on each
+        # attempt (issue #103) = 4.
+        assert mock_read.call_count == 4
 
     def test_configure_raises_after_second_mismatch(self) -> None:
         """Issue #42: if the read-back still doesn't match after the
@@ -374,7 +390,10 @@ class TestConfigureRtcmPorts:
                 driver.configure_rtcm_ports(config)
 
         assert mock_valset.call_count == 2
-        assert mock_read.call_count == 2
+        # RAM read on the first attempt, a flash read on the first
+        # attempt (issue #103), then the retry's RAM read raises before
+        # a second flash read would happen.
+        assert mock_read.call_count == 3
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_ublox_driver.py
+++ b/tests/unit/test_ublox_driver.py
@@ -331,24 +331,24 @@ class TestUbloxDriverConfiguration:
         #   0. NAV-SVIN baseline poll                       -> dur=0 (no pre-reset)
         #   1. CFG-VALSET TMODE=0 (layer=7: RAM+BBR+Flash)  -> ACK
         #   2. CFG-VALSET TMODE=1 + SVIN params (layer=5)   -> ACK
-        #   3. CFG-VALGET read-back                         -> matches (issue #42)
-        #   4. NAV-SVIN poll                                -> dur=0
-        #   5. (~2 s gap)
-        #   6. NAV-SVIN poll                                -> dur=3 (incremented)
+        #   3. CFG-VALGET RAM read-back                     -> matches (issue #42)
+        #   4. CFG-VALGET flash read-back                   -> matches (issue #103)
+        #   5. NAV-SVIN poll                                -> dur=0
+        #   6. (~2 s gap)
+        #   7. NAV-SVIN poll                                -> dur=3 (incremented)
+        enable_read_back = SimpleNamespace(
+            identity="CFG-VALGET",
+            CFG_TMODE_SVIN_MIN_DUR=300,
+            CFG_TMODE_SVIN_ACC_LIMIT=400000,
+            CFG_TMODE_MODE=1,
+        )
         reader.read.side_effect = [
             (b"", _make_mon_ver_response()),
             (b"", _make_nav_svin_response(active=0, valid=0, dur=0, obs=0)),  # baseline
             (b"", _make_ack_response()),  # full-layer disable
             (b"", _make_ack_response()),  # enable
-            (
-                b"",
-                SimpleNamespace(
-                    identity="CFG-VALGET",
-                    CFG_TMODE_SVIN_MIN_DUR=300,
-                    CFG_TMODE_SVIN_ACC_LIMIT=400000,
-                    CFG_TMODE_MODE=1,
-                ),
-            ),  # enable read-back — matches
+            (b"", enable_read_back),  # enable RAM read-back — matches
+            (b"", enable_read_back),  # enable flash read-back — matches
             (b"", _make_nav_svin_response(active=0, valid=0, dur=0, obs=0)),
             (b"", _make_nav_svin_response(active=0, valid=0, dur=3, obs=1)),
         ]
@@ -1563,7 +1563,10 @@ class TestConfigurePortProtocols:
             mock_serial_cls,
             mock_reader_cls,
             mock_ubx_msg,
-            [_make_ack_response(), read_back],
+            # Second ``read_back`` is the flash-layer poll a layer=5
+            # write now also performs (issue #103) — matches, so no
+            # warning is queued.
+            [_make_ack_response(), read_back, read_back],
         )
 
         driver.configure_port_protocols(
@@ -1621,7 +1624,10 @@ class TestConfigureMeasurementRate:
             mock_serial_cls,
             mock_reader_cls,
             mock_ubx_msg,
-            [_make_ack_response(), read_back],
+            # Second ``read_back`` is the flash-layer poll a layer=5
+            # write now also performs (issue #103); matches, so no
+            # warning is queued.
+            [_make_ack_response(), read_back, read_back],
         )
 
         driver.configure_measurement_rate(333)
@@ -1652,16 +1658,16 @@ class TestConfigureDynModel:
         model: DynModel,
         expected_value: int,
     ) -> None:
+        read_back = SimpleNamespace(
+            identity="CFG-VALGET", CFG_NAVSPG_DYNMODEL=expected_value
+        )
         driver, _reader = _connect_driver(
             mock_serial_cls,
             mock_reader_cls,
             mock_ubx_msg,
-            [
-                _make_ack_response(),
-                SimpleNamespace(
-                    identity="CFG-VALGET", CFG_NAVSPG_DYNMODEL=expected_value
-                ),
-            ],
+            # Second copy is the flash-layer poll a layer=5 write now
+            # also performs (issue #103); matches, so no warning.
+            [_make_ack_response(), read_back, read_back],
         )
 
         driver.configure_dyn_model(model)
@@ -1726,14 +1732,16 @@ class TestConfigureTmodeMode:
         mode: BaseMode,
         expected_value: int,
     ) -> None:
+        read_back = SimpleNamespace(
+            identity="CFG-VALGET", CFG_TMODE_MODE=expected_value
+        )
         driver, _reader = _connect_driver(
             mock_serial_cls,
             mock_reader_cls,
             mock_ubx_msg,
-            [
-                _make_ack_response(),
-                SimpleNamespace(identity="CFG-VALGET", CFG_TMODE_MODE=expected_value),
-            ],
+            # Second copy is the flash-layer poll a layer=5 write now
+            # also performs (issue #103); matches, so no warning.
+            [_make_ack_response(), read_back, read_back],
         )
 
         driver.configure_tmode_mode(mode)
@@ -1759,7 +1767,9 @@ class TestConfigureOptimisations:
             mock_serial_cls,
             mock_reader_cls,
             mock_ubx_msg,
-            [_make_ack_response(), read_back],
+            # Second copy is the flash-layer poll a layer=5 write now
+            # also performs (issue #103); matches, so no warning.
+            [_make_ack_response(), read_back, read_back],
         )
 
         driver.configure_optimisations(
@@ -1807,7 +1817,9 @@ class TestConfigureOptimisations:
             mock_serial_cls,
             mock_reader_cls,
             mock_ubx_msg,
-            [_make_ack_response(), read_back],
+            # Second copy is the flash-layer poll a layer=5 write now
+            # also performs (issue #103); matches, so no warning.
+            [_make_ack_response(), read_back, read_back],
         )
 
         driver.configure_optimisations(
@@ -1912,7 +1924,9 @@ class TestGetUartBaudRates:
 
 
 class TestDrainWarnings:
-    """No producer is wired up on this driver yet (issue #99)."""
+    """No producer is wired up on the fake driver; the u-blox driver's only
+    producer is ``_write_and_verify_locked``'s flash read-back (issue #103) —
+    see ``TestWriteAndVerifyFlashDivergence`` for that coverage."""
 
     def test_requires_connection(self) -> None:
         driver = UbloxDriver()
@@ -1931,6 +1945,246 @@ class TestDrainWarnings:
         driver, _reader = _connect_driver(
             mock_serial_cls, mock_reader_cls, mock_ubx_msg, []
         )
+        assert driver.drain_warnings() == []
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_drain_clears_the_queue(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        """A second drain with nothing new queued returns empty — the
+        first drain must actually clear the queue, not just read it."""
+        driver, _reader = _connect_driver(
+            mock_serial_cls, mock_reader_cls, mock_ubx_msg, []
+        )
+        driver._warnings.append("flash divergence")  # pyright: ignore[reportPrivateUsage]
+
+        assert driver.drain_warnings() == ["flash divergence"]
+        assert driver.drain_warnings() == []
+
+
+class TestWriteAndVerifyFlashDivergence:
+    """Tests for the flash-layer check in ``_write_and_verify_locked`` (issue #103).
+
+    RAM always matches in these scenarios — flash is the only thing
+    diverging — so none of them should raise; the divergence is queued
+    on ``drain_warnings`` instead.
+    """
+
+    _CFG_DATA = [("CFG_RATE_MEAS", 250)]
+    _EXPECTED = dict(_CFG_DATA)
+
+    @staticmethod
+    def _ram_match() -> SimpleNamespace:
+        return SimpleNamespace(identity="CFG-VALGET", CFG_RATE_MEAS=250)
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_value_differs_at_flash_warns_without_raising(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        """A flash value that still differs after the retry produces a
+        warning naming the key and both values, never a raise."""
+        flash_mismatch = SimpleNamespace(identity="CFG-VALGET", CFG_RATE_MEAS=1000)
+        driver, _reader = _connect_driver(
+            mock_serial_cls,
+            mock_reader_cls,
+            mock_ubx_msg,
+            [
+                _make_ack_response(),  # first write
+                self._ram_match(),  # RAM read-back — matches
+                flash_mismatch,  # flash read-back — differs
+                _make_ack_response(),  # retry write
+                self._ram_match(),  # RAM read-back — matches
+                flash_mismatch,  # flash read-back — still differs
+            ],
+        )
+
+        with driver._lock:  # pyright: ignore[reportPrivateUsage]
+            driver._write_and_verify_locked(  # pyright: ignore[reportPrivateUsage]
+                self._CFG_DATA, layer=5, label="Measurement rate"
+            )
+
+        assert mock_ubx_msg.config_set.call_count == 2
+        warnings = driver.drain_warnings()
+        assert len(warnings) == 1
+        assert "Measurement rate" in warnings[0]
+        assert "CFG_RATE_MEAS" in warnings[0]
+        assert "1000" in warnings[0]
+        assert "250" in warnings[0]
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_flash_nak_warns_without_raising(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        """A flash poll the receiver NAKs is a divergence shape, not a
+        transport failure — it must warn, not raise."""
+        driver, _reader = _connect_driver(
+            mock_serial_cls,
+            mock_reader_cls,
+            mock_ubx_msg,
+            [
+                _make_ack_response(),
+                self._ram_match(),
+                _make_nak_response(),
+                _make_ack_response(),
+                self._ram_match(),
+                _make_nak_response(),
+            ],
+        )
+
+        with driver._lock:  # pyright: ignore[reportPrivateUsage]
+            driver._write_and_verify_locked(  # pyright: ignore[reportPrivateUsage]
+                self._CFG_DATA, layer=5, label="Measurement rate"
+            )
+
+        warnings = driver.drain_warnings()
+        assert len(warnings) == 1
+        assert "NAK" in warnings[0]
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_flash_transport_timeout_raises_instead_of_warning(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        """A flash poll that gets no response at all — not an ACK-NAK —
+        is a transport/hardware failure, not one of the three divergence
+        shapes the spec describes. It must propagate as a hard failure,
+        not be softened into a durability warning."""
+        driver, _reader = _connect_driver(
+            mock_serial_cls, mock_reader_cls, mock_ubx_msg, [_make_ack_response()]
+        )
+
+        with patch.object(
+            driver,
+            "_read_cfg_keys_locked",  # pyright: ignore[reportPrivateUsage]
+            side_effect=[
+                dict(self._CFG_DATA),  # RAM read-back — matches
+                RuntimeError("No CFG-VALGET response for config keys"),
+            ],
+        ):
+            with pytest.raises(RuntimeError, match="No CFG-VALGET response"):
+                with driver._lock:  # pyright: ignore[reportPrivateUsage]
+                    driver._write_and_verify_locked(  # pyright: ignore[reportPrivateUsage]
+                        self._CFG_DATA, layer=5, label="Measurement rate"
+                    )
+
+        assert driver.drain_warnings() == []
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_omitted_key_at_flash_warns_without_raising(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        """A partial flash batch response that silently omits the key
+        (rather than NAKing or reporting a wrong value) must still warn."""
+        flash_omitted = SimpleNamespace(identity="CFG-VALGET")  # no attrs at all
+        driver, _reader = _connect_driver(
+            mock_serial_cls,
+            mock_reader_cls,
+            mock_ubx_msg,
+            [
+                _make_ack_response(),
+                self._ram_match(),
+                flash_omitted,
+                _make_ack_response(),
+                self._ram_match(),
+                flash_omitted,
+            ],
+        )
+
+        with driver._lock:  # pyright: ignore[reportPrivateUsage]
+            driver._write_and_verify_locked(  # pyright: ignore[reportPrivateUsage]
+                self._CFG_DATA, layer=5, label="Measurement rate"
+            )
+
+        warnings = driver.drain_warnings()
+        assert len(warnings) == 1
+        assert "omitted" in warnings[0].lower()
+        assert "CFG_RATE_MEAS" in warnings[0]
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_spurious_first_attempt_flash_miss_resolves_on_retry(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        """A flash miss that clears itself by the retry (the async-commit
+        timing risk the helper's docstring calls out) must not warn at
+        all — the existing single retry absorbs it."""
+        flash_mismatch = SimpleNamespace(identity="CFG-VALGET", CFG_RATE_MEAS=1000)
+        driver, _reader = _connect_driver(
+            mock_serial_cls,
+            mock_reader_cls,
+            mock_ubx_msg,
+            [
+                _make_ack_response(),
+                self._ram_match(),
+                flash_mismatch,  # spurious first-attempt miss
+                _make_ack_response(),  # retry
+                self._ram_match(),
+                self._ram_match(),  # flash now agrees too
+            ],
+        )
+
+        with driver._lock:  # pyright: ignore[reportPrivateUsage]
+            driver._write_and_verify_locked(  # pyright: ignore[reportPrivateUsage]
+                self._CFG_DATA, layer=5, label="Measurement rate"
+            )
+
+        assert mock_ubx_msg.config_set.call_count == 2
+        assert driver.drain_warnings() == []
+
+    @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
+    @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
+    @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
+    def test_non_flash_layer_skips_the_flash_check(
+        self,
+        mock_serial_cls: MagicMock,
+        mock_reader_cls: MagicMock,
+        mock_ubx_msg: MagicMock,
+    ) -> None:
+        """A write that doesn't target flash (layer bit 4 unset) has
+        nothing durable to check — only the RAM read-back runs."""
+        driver, reader = _connect_driver(
+            mock_serial_cls,
+            mock_reader_cls,
+            mock_ubx_msg,
+            [_make_ack_response(), self._ram_match()],
+        )
+
+        with driver._lock:  # pyright: ignore[reportPrivateUsage]
+            driver._write_and_verify_locked(  # pyright: ignore[reportPrivateUsage]
+                self._CFG_DATA, layer=1, label="Measurement rate"
+            )
+
+        # 1 read for MON-VER during connect() + 1 for the write's ACK +
+        # 1 RAM read-back — no flash poll was issued.
+        assert reader.read.call_count == 3
         assert driver.drain_warnings() == []
 
 


### PR DESCRIPTION
## Summary

Closes #103.

- `_write_and_verify_locked` now polls the flash layer (gated on the CFG-VALSET flash bit), after its existing single retry, so all seven `layer=5` writers inherit the check — a config that appears correctly set now says whether it will actually survive a power cycle.
- A flash divergence (value differs / NAK / omitted key) never fails the step and never shows up as a field difference in the read-back diff — RAM already matches, so the receiver is correctly configured right now. It queues a warning on `drain_warnings()` naming the affected keys and which of the three shapes occurred.
- `apply_receiver_config`'s existing per-step warning-tagging and skip-exclusion machinery (issue #99) already generically surfaces and re-runs a warned step on the next Apply — no changes needed there.
- `configure_survey_in` and `configure_rtcm_ports` run outside that per-step loop (the only other place that drains warnings), so they now drain and log immediately after their write — otherwise an undrained warning would sit on the driver's shared queue and get misattributed to whatever unrelated Apply step ran next.
- `_flash_divergence_locked` only treats an explicit ACK-NAK as a divergence shape; a genuine transport timeout (no response at all) still propagates as a hard failure rather than being softened into a warning.

## Test plan

- [x] `uv run pytest` — full unit suite (1467 tests), including new coverage for value-differs, NAK, omitted-key, spurious-first-attempt-resolves-on-retry, non-flash-layer-skips-the-check, and transport-timeout-still-raises
- [x] `uv run pyright src/` — strict, clean
- [x] `uv run mypy src/` — clean
- [x] `uv run ruff check` / `ruff format --check` — clean
- [x] Reviewed via `/code-review` (parallel Standards + Spec sub-agents); both findings (NAK/timeout conflation, undrained-warning leak on the two non-Apply call sites) fixed before this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AcBmmcpcJtBBxvDE8M3C6p