### PR TITLE
feat(gps): every hardware-section field becomes an editable widget

### DIFF
--- a/src/sp_rtk_base/ui/pages/gps_config.py
+++ b/src/sp_rtk_base/ui/pages/gps_config.py
@@ -75,6 +75,7 @@ from sp_rtk_base.models.device_models import (
     RtcmPortConfig,
     RtcmRowId,
     SurveyInProgress,
+    UbxProtocol,
 )
 from sp_rtk_base.models.device_models import (
     BaseMode as TmodeMode,
@@ -276,13 +277,23 @@ def build_apply_request(
     Apply call, Save-as, and the "modified from X" comparison) passes
     the current ``form`` :class:`ReceiverAssertion` through.
 
+    BeiDou B2 is coerced off here when BeiDou itself is off (issue
+    #100), regardless of what the form's raw ``bds_b2_enabled`` holds —
+    this is the one choke point every caller (Apply, Save-as, the
+    "modified from X" comparison) goes through, so the outgoing assert
+    always agrees with what the firmware would renormalise on its own,
+    pre-empting a permanently unclearable difference.
+
     Raises:
         pydantic.ValidationError: If the resulting request fails a
             context-free rule (e.g. 1005 missing from every chosen
             data-link port) — a client-side pre-write refusal, nothing
             is sent to the receiver.
     """
-    return ReceiverApplyRequest(assertion=form, data_link_port=data_link_port)
+    assertion = form
+    if bds_b2_control_disabled(form.constellations) and form.bds_b2_enabled:
+        assertion = form.model_copy(update={"bds_b2_enabled": False})
+    return ReceiverApplyRequest(assertion=assertion, data_link_port=data_link_port)
 
 
 def receiver_config_from_profile(
@@ -413,33 +424,36 @@ def resolve_gnss_display(constellations: list[GnssConstellation]) -> dict[str, b
     return {c.value: c in wanted for c in GnssConstellation}
 
 
-def hw_extras_display(assertion: ReceiverAssertion) -> list[tuple[str, str, str]]:
-    """(css-class, label, value) triples the "Hardware Section" display
-    renders — every :class:`ReceiverAssertion` field the matrix/ports/GNSS
-    views don't already cover. Every field is always populated (issue
-    #97), so every value shown is real — never a placeholder."""
-    hz = 1000 / assertion.meas_period_ms
-    return [
-        ("hw-field-meas-rate", "Measurement Rate", f"{hz:g} Hz"),
-        (
-            "hw-field-baud",
-            "Baud",
-            f"UART1={assertion.baud.uart1}, UART2={assertion.baud.uart2}",
-        ),
-        ("hw-field-dyn-model", "Dynamics Model", assertion.dyn_model.value),
-        ("hw-field-tmode", "Time Mode", assertion.tmode_mode.value),
-        (
-            "hw-field-elevation-mask",
-            "Elevation Mask",
-            f"{assertion.elevation_mask_deg}°",
-        ),
-        (
-            "hw-field-bds-b2",
-            "BeiDou B2",
-            "on" if assertion.bds_b2_enabled else "off",
-        ),
-        ("hw-field-spi", "SPI", "on" if assertion.spi_enabled else "off"),
-    ]
+#: Base mode states the hardware-section control offers directly.
+#: ``survey_in`` is seedable (a live receiver can be found running one)
+#: but never itself selectable — starting a survey stays the Survey
+#: page's transition, since it's edge-triggered and needs survey
+#: parameters (issue #100).
+SELECTABLE_TMODE_MODES: tuple[TmodeMode, ...] = (TmodeMode.DISABLED, TmodeMode.FIXED)
+
+
+def tmode_mode_locked(mode: TmodeMode) -> bool:
+    """Whether the base-mode control is showing *mode* as a locked,
+    non-selectable current value rather than a normal picker.
+
+    True only for ``survey_in`` — the one state the control must be
+    able to represent (so a receiver mid-survey shows no phantom
+    unapplied change) without offering it as something an operator can
+    pick here.
+    """
+    return mode == TmodeMode.SURVEY_IN
+
+
+def bds_b2_control_disabled(constellations: list[GnssConstellation]) -> bool:
+    """Whether the BeiDou B2 control should be greyed out.
+
+    True whenever BeiDou itself is off — B2 has nothing to modulate
+    without it. Doesn't touch the underlying value; that's
+    :func:`build_apply_request`'s job (see its docstring) so the read
+    can still report the receiver's truth even in the rare case where
+    the two are already inconsistent.
+    """
+    return GnssConstellation.BEIDOU not in constellations
 
 
 def placeholder_assertion() -> ReceiverAssertion:
@@ -769,10 +783,12 @@ def gps_config_page() -> None:
         with config_card:
             ui.label("Receiver Configuration").classes("text-h6 text-white")
             ui.label(
-                "Port protocols, GNSS and the fields below reflect the live "
-                "receiver, or a picked profile once one's selected — this "
-                "display isn't click-to-edit yet. The RTCM matrix and "
-                "data-link port(s) further down are — edit, then Apply."
+                "Every field below is seeded from the live receiver, or a "
+                "picked profile once one's selected, and every field is "
+                "editable — model, firmware, protocol and hardware version "
+                "on the Connection card above are the only genuine "
+                "read-only status fields. Edit anything, then Apply to "
+                "assert the whole form and verify the read-back."
             ).classes("text-grey-4 q-mt-xs text-caption")
             ui.separator()
 
@@ -1321,40 +1337,216 @@ def gps_config_page() -> None:
             except ValidationError:
                 return None
 
+        def _toggle_port_protocol(
+            port: PortId, direction: str, protocol: UbxProtocol, checked: bool
+        ) -> None:
+            protocols = form.ports.setdefault(port, PortProtocolSet())
+            target = protocols.in_ if direction == "in" else protocols.out
+            if checked and protocol not in target:
+                target.append(protocol)
+            elif not checked and protocol in target:
+                target.remove(protocol)
+            _on_form_changed()
+
         def _render_ports_view() -> None:
             ports_view.clear()
             with ports_view:
                 display = resolve_ports_display(form.ports)
                 for port_id in (PortId.UART1, PortId.UART2, PortId.USB):
                     in_names, out_names = display[port_id]
-                    with ui.row().classes("items-center gap-2"):
+                    with ui.row().classes("items-center gap-2 flex-wrap"):
                         ui.label(port_id.value).classes("text-white").style(
                             "width: 60px; flex-shrink: 0"
                         )
                         ui.label("IN").classes("text-caption text-grey-5")
-                        for name in in_names:
-                            ui.badge(name).props("outline color=grey")
+                        for protocol in UbxProtocol:
+                            ui.checkbox(
+                                protocol.value,
+                                value=protocol.value in in_names,
+                                on_change=lambda e, p=port_id, pr=protocol: (
+                                    _toggle_port_protocol(p, "in", pr, bool(e.value))
+                                ),
+                            ).classes(
+                                f"port-protocol-{port_id.value}-in-{protocol.value}"
+                            )
                         ui.label("OUT").classes("text-caption text-grey-5 q-ml-md")
-                        for name in out_names:
-                            ui.badge(name).props("outline color=primary")
+                        for protocol in UbxProtocol:
+                            ui.checkbox(
+                                protocol.value,
+                                value=protocol.value in out_names,
+                                on_change=lambda e, p=port_id, pr=protocol: (
+                                    _toggle_port_protocol(p, "out", pr, bool(e.value))
+                                ),
+                            ).classes(
+                                f"port-protocol-{port_id.value}-out-{protocol.value}"
+                            )
+
+        def _toggle_gnss(constellation: GnssConstellation, checked: bool) -> None:
+            if checked and constellation not in form.constellations:
+                form.constellations.append(constellation)
+            elif not checked and constellation in form.constellations:
+                form.constellations.remove(constellation)
+                if constellation == GnssConstellation.BEIDOU:
+                    # Keep the form's own value consistent with the
+                    # now-greyed-out B2 control the moment BeiDou goes
+                    # off, rather than leaving a stale "on" behind it
+                    # (build_apply_request coerces this too, for the
+                    # case where the two were already inconsistent on
+                    # seed — see its docstring).
+                    form.bds_b2_enabled = False
+            _render_gnss_view()
+            _render_hw_extras_view()
+            _on_form_changed()
 
         def _render_gnss_view() -> None:
             gnss_view.clear()
             with gnss_view:
                 enabled_map = resolve_gnss_display(form.constellations)
                 for c_val, c_name in _GNSS_DISPLAY:
-                    enabled = enabled_map.get(c_val, False)
-                    ui.badge(c_name).props(
-                        "color=positive" if enabled else "outline color=grey"
-                    )
+                    constellation = GnssConstellation(c_val)
+                    ui.checkbox(
+                        c_name,
+                        value=enabled_map.get(c_val, False),
+                        on_change=lambda e, c=constellation: _toggle_gnss(
+                            c, bool(e.value)
+                        ),
+                    ).classes(f"gnss-checkbox-{c_val}")
+
+        def _set_meas_period_ms(period_ms: float | None) -> None:
+            if period_ms is None:
+                return
+            form.meas_period_ms = int(period_ms)
+            _render_hw_extras_view()
+            _on_form_changed()
+
+        def _set_baud(uart: str, value: int | None) -> None:
+            if value is None:
+                return
+            if uart == "uart1":
+                form.baud.uart1 = int(value)
+            else:
+                form.baud.uart2 = int(value)
+            _on_form_changed()
+
+        def _set_dyn_model(value: str | None) -> None:
+            if value is None:
+                return
+            form.dyn_model = DynModel(value)
+            _on_form_changed()
+
+        def _set_tmode_mode(value: str | None) -> None:
+            if value is None:
+                return
+            form.tmode_mode = TmodeMode(value)
+            _render_hw_extras_view()
+            _on_form_changed()
+
+        def _set_elevation_mask(value: float | None) -> None:
+            if value is None:
+                return
+            form.elevation_mask_deg = int(value)
+            _on_form_changed()
+
+        def _toggle_bds_b2(checked: bool) -> None:
+            form.bds_b2_enabled = checked
+            _on_form_changed()
+
+        def _toggle_spi(checked: bool) -> None:
+            form.spi_enabled = checked
+            _on_form_changed()
 
         def _render_hw_extras_view() -> None:
             hw_extras_view.clear()
+            tmode_options = {m.value: m.value for m in SELECTABLE_TMODE_MODES}
             with hw_extras_view:
-                for css_class, label, value in hw_extras_display(form):
-                    with ui.column().classes(f"{css_class} gap-0"):
-                        ui.label(label).classes("text-caption text-grey-5")
-                        ui.label(value).classes("text-white")
+                with ui.column().classes("hw-field-meas-rate gap-0"):
+                    ui.label("Measurement Rate").classes("text-caption text-grey-5")
+                    ui.number(
+                        value=form.meas_period_ms,
+                        min=100,
+                        max=60000,
+                        step=100,
+                        on_change=lambda e: _set_meas_period_ms(e.value),
+                    ).classes("hw-field-meas-rate-input").props(
+                        "dense suffix=ms"
+                    ).style("width: 140px")
+                    hz = 1000 / form.meas_period_ms
+                    ui.label(f"= {hz:g} Hz").classes("text-caption text-grey-5")
+
+                with ui.column().classes("hw-field-baud gap-0"):
+                    ui.label("Baud").classes("text-caption text-grey-5")
+                    with ui.row().classes("gap-2"):
+                        ui.select(
+                            options={r: str(r) for r in BAUD_RATES},
+                            label="UART1",
+                            value=form.baud.uart1,
+                            on_change=lambda e: _set_baud("uart1", e.value),
+                        ).classes("hw-field-baud-uart1").style("width: 110px")
+                        ui.select(
+                            options={r: str(r) for r in BAUD_RATES},
+                            label="UART2",
+                            value=form.baud.uart2,
+                            on_change=lambda e: _set_baud("uart2", e.value),
+                        ).classes("hw-field-baud-uart2").style("width: 110px")
+
+                with ui.column().classes("hw-field-dyn-model gap-0"):
+                    ui.label("Dynamics Model").classes("text-caption text-grey-5")
+                    ui.select(
+                        options={m.value: m.value for m in DynModel},
+                        value=form.dyn_model.value,
+                        on_change=lambda e: _set_dyn_model(e.value),
+                    ).classes("hw-field-dyn-model-select").style("width: 160px")
+
+                with ui.column().classes("hw-field-tmode gap-0"):
+                    ui.label("Time Mode").classes("text-caption text-grey-5")
+                    if tmode_mode_locked(form.tmode_mode):
+                        ui.label(f"{form.tmode_mode.value} (running)").classes(
+                            "hw-field-tmode-note text-white"
+                        )
+                        ui.button("Go to Survey page", icon="open_in_new").classes(
+                            "hw-field-tmode-survey-link"
+                        ).props("outline color=primary dense").on(
+                            "click", lambda: ui.navigate.to("/survey")
+                        )
+                        ui.select(
+                            options=tmode_options,
+                            label="Change to...",
+                            on_change=lambda e: _set_tmode_mode(e.value),
+                        ).classes("hw-field-tmode-select").style("width: 140px")
+                    else:
+                        ui.select(
+                            options=tmode_options,
+                            value=form.tmode_mode.value,
+                            on_change=lambda e: _set_tmode_mode(e.value),
+                        ).classes("hw-field-tmode-select").style("width: 140px")
+
+                with ui.column().classes("hw-field-elevation-mask gap-0"):
+                    ui.label("Elevation Mask").classes("text-caption text-grey-5")
+                    ui.number(
+                        value=form.elevation_mask_deg,
+                        min=0,
+                        max=90,
+                        step=1,
+                        on_change=lambda e: _set_elevation_mask(e.value),
+                    ).classes("hw-field-elevation-mask-input").props(
+                        "dense suffix=°"
+                    ).style("width: 100px")
+
+                with ui.column().classes("hw-field-bds-b2 gap-0"):
+                    ui.label("BeiDou B2").classes("text-caption text-grey-5")
+                    ui.checkbox(
+                        value=form.bds_b2_enabled,
+                        on_change=lambda e: _toggle_bds_b2(bool(e.value)),
+                    ).classes("hw-field-bds-b2-checkbox").set_enabled(
+                        not bds_b2_control_disabled(form.constellations)
+                    )
+
+                with ui.column().classes("hw-field-spi gap-0"):
+                    ui.label("SPI").classes("text-caption text-grey-5")
+                    ui.checkbox(
+                        value=form.spi_enabled,
+                        on_change=lambda e: _toggle_spi(bool(e.value)),
+                    ).classes("hw-field-spi-checkbox")
 
         def _toggle_matrix_cell(msg_id: RtcmRowId, port: PortId) -> None:
             form.rtcm_stream.matrix[msg_id][port] = not form.rtcm_stream.matrix[msg_id][

--- a/tests/e2e/test_gps_hardware_fields.py
+++ b/tests/e2e/test_gps_hardware_fields.py
@@ -1,0 +1,284 @@
+"""E2E tests for the Advanced GPS page's hardware-section controls
+(issue #100).
+
+Prior to this ticket, port protocols, GNSS constellations and the
+"Hardware Section" extras (measurement rate, UART bauds, dynamics
+model, base mode, elevation mask, BeiDou B2, SPI) rendered as
+read-only badges/labels. This suite asserts each is now a real,
+editable widget wired into the same whole-form Apply/out-of-sync
+machinery the RTCM matrix and data-link picker already used (see
+``test_gps_apply.py``), plus the base-mode survey_in lock and the
+BeiDou B2 grey-out.
+
+Locators target the stable CSS class hooks the page renders (see
+``ui/pages/gps_config.py``), matching the existing suite's convention.
+Every editable widget here is a Quasar ``q-checkbox``/``q-select``,
+not a plain HTML form control, so checked/enabled state is asserted
+via its ``aria-checked``/``aria-disabled`` attributes (Playwright's
+``to_be_checked()``/``to_be_disabled()`` assume a native control and
+don't see these) — see :func:`_expect_checked`/:func:`_expect_disabled`.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from playwright.sync_api import Locator, Page, expect
+
+
+def _goto_gps_config(page: Page, base_url: str) -> None:
+    page.goto(f"{base_url}/gps-config")
+    expect(page.locator("text=Advanced GPS Configuration").first).to_be_visible(
+        timeout=15_000
+    )
+
+
+def _expect_checked(checkbox: Locator, *, checked: bool) -> None:
+    expect(checkbox).to_have_attribute("aria-checked", "true" if checked else "false")
+
+
+def _expect_disabled(checkbox: Locator, *, disabled: bool) -> None:
+    if disabled:
+        expect(checkbox).to_have_attribute("aria-disabled", "true")
+    else:
+        expect(checkbox).not_to_have_attribute("aria-disabled", "true")
+
+
+@pytest.mark.e2e
+def test_gnss_checkbox_edits_the_form_and_applies(
+    page: Page,
+    base_url: str,
+    connected_gps: None,
+) -> None:
+    """SBAS is off by default on the fake driver — check it, out of
+    sync fires, Apply clears it and the checkbox stays checked."""
+    _goto_gps_config(page, base_url)
+
+    sync_badge = page.locator(".sync-badge")
+    expect(sync_badge).to_have_text("In sync", timeout=10_000)
+
+    sbas = page.locator(".gnss-checkbox-sbas")
+    _expect_checked(sbas, checked=False)
+    sbas.click()
+    expect(sync_badge).to_have_text("Receiver out of sync")
+
+    page.get_by_role("button", name="Apply").click()
+    expect(page.locator(".apply-result")).to_contain_text(
+        "Applied and verified", timeout=10_000
+    )
+    expect(sync_badge).to_have_text("In sync")
+    _expect_checked(sbas, checked=True)
+
+
+@pytest.mark.e2e
+def test_port_protocol_checkbox_edits_the_form_and_applies(
+    page: Page,
+    base_url: str,
+    connected_gps: None,
+) -> None:
+    """UART2 doesn't speak NMEA-in by default on the fake driver."""
+    _goto_gps_config(page, base_url)
+
+    sync_badge = page.locator(".sync-badge")
+    expect(sync_badge).to_have_text("In sync", timeout=10_000)
+
+    nmea_in = page.locator(".port-protocol-UART2-in-NMEA")
+    _expect_checked(nmea_in, checked=False)
+    nmea_in.click()
+    expect(sync_badge).to_have_text("Receiver out of sync")
+
+    page.get_by_role("button", name="Apply").click()
+    expect(page.locator(".apply-result")).to_contain_text(
+        "Applied and verified", timeout=10_000
+    )
+    expect(sync_badge).to_have_text("In sync")
+    _expect_checked(nmea_in, checked=True)
+
+
+@pytest.mark.e2e
+def test_hardware_extras_are_editable_and_apply(
+    page: Page,
+    base_url: str,
+    connected_gps: None,
+) -> None:
+    """Measurement rate, dynamics model, elevation mask and SPI are
+    real controls, not static text, and Apply asserts every edit."""
+    _goto_gps_config(page, base_url)
+
+    sync_badge = page.locator(".sync-badge")
+    expect(sync_badge).to_have_text("In sync", timeout=10_000)
+
+    meas_rate = page.locator(".hw-field-meas-rate-input input")
+    expect(meas_rate).to_have_value("1000")
+    meas_rate.fill("500")
+    meas_rate.blur()
+
+    dyn_model = page.locator(".hw-field-dyn-model-select")
+    dyn_model.click()
+    page.get_by_role("option", name="stationary", exact=True).click()
+
+    elevation = page.locator(".hw-field-elevation-mask-input input")
+    elevation.fill("10")
+    elevation.blur()
+
+    spi = page.locator(".hw-field-spi-checkbox")
+    _expect_checked(spi, checked=True)  # on by default on the fake driver
+    spi.click()
+
+    expect(sync_badge).to_have_text("Receiver out of sync")
+
+    page.get_by_role("button", name="Apply").click()
+    expect(page.locator(".apply-result")).to_contain_text(
+        "Applied and verified", timeout=10_000
+    )
+    expect(sync_badge).to_have_text("In sync")
+    expect(meas_rate).to_have_value("500")
+    _expect_checked(spi, checked=False)
+
+
+@pytest.mark.e2e
+def test_uart_baud_selects_are_editable_and_apply(
+    page: Page,
+    base_url: str,
+    connected_gps: None,
+) -> None:
+    """UART1/UART2 baud are real selects seeded from the receiver
+    (57600 / 115200 on the fake driver), not static text.
+
+    Only UART2 is actually changed here — a changed UART1 baud
+    reopens this console's own serial link (see
+    ``DeviceService.apply_receiver_config``), which is exercised by
+    its own suite rather than risked here. UART1's select is still
+    proven to be a real, distinct combobox control (not static text)
+    via its role — opening it too would risk racing UART2's identical
+    option labels in the same dropdown-menu layer.
+    """
+    _goto_gps_config(page, base_url)
+
+    sync_badge = page.locator(".sync-badge")
+    expect(sync_badge).to_have_text("In sync", timeout=10_000)
+
+    uart1 = page.locator(".hw-field-baud-uart1")
+    uart2 = page.locator(".hw-field-baud-uart2")
+    expect(uart1).to_contain_text("57600")
+    expect(uart2).to_contain_text("115200")
+    expect(uart1.locator('[role="combobox"]')).to_have_count(1)
+
+    uart2.click()
+    page.get_by_role("option", name="230400", exact=True).click()
+    expect(sync_badge).to_have_text("Receiver out of sync")
+
+    page.get_by_role("button", name="Apply").click()
+    expect(page.locator(".apply-result")).to_contain_text(
+        "Applied and verified", timeout=10_000
+    )
+    expect(sync_badge).to_have_text("In sync")
+    expect(uart2).to_contain_text("230400")
+
+
+@pytest.mark.e2e
+def test_fixed_without_position_shows_named_refusal(
+    page: Page,
+    base_url: str,
+    connected_gps: None,
+) -> None:
+    """The fake driver starts ``disabled`` with no fixed position on
+    record — picking ``fixed`` from the new base-mode select and
+    applying surfaces the existing ``tmode_fixed_requires_coordinates``
+    refusal rather than a silent or generic failure."""
+    _goto_gps_config(page, base_url)
+
+    tmode_select = page.locator(".hw-field-tmode-select")
+    expect(tmode_select).to_be_visible(timeout=10_000)
+    tmode_select.click()
+    page.get_by_role("option", name="fixed", exact=True).click()
+
+    page.get_by_role("button", name="Apply").click()
+
+    result = page.locator(".apply-result")
+    expect(result).to_contain_text("Apply refused", timeout=10_000)
+    expect(result).to_contain_text("tmode_fixed_requires_coordinates")
+    expect(result).to_contain_text("nothing was written")
+
+
+@pytest.mark.e2e
+def test_bds_b2_greys_out_when_beidou_disabled(
+    page: Page,
+    base_url: str,
+    connected_gps: None,
+) -> None:
+    """BeiDou is on by default on the fake driver, so B2 starts
+    enabled; unchecking BeiDou greys B2 out and Apply sends it off."""
+    _goto_gps_config(page, base_url)
+
+    beidou = page.locator(".gnss-checkbox-beidou")
+    bds_b2 = page.locator(".hw-field-bds-b2-checkbox")
+    _expect_checked(beidou, checked=True)
+    _expect_disabled(bds_b2, disabled=False)
+
+    beidou.click()
+    _expect_checked(beidou, checked=False)
+    _expect_disabled(bds_b2, disabled=True)
+
+    page.get_by_role("button", name="Apply").click()
+    expect(page.locator(".apply-result")).to_contain_text(
+        "Applied and verified", timeout=10_000
+    )
+    _expect_checked(bds_b2, checked=False)
+
+
+@pytest.mark.e2e
+def test_base_mode_offers_disabled_and_fixed(
+    page: Page,
+    base_url: str,
+    connected_gps: None,
+) -> None:
+    """The fake driver starts in ``disabled`` — the select offers
+    ``fixed`` as the other choice, and picking it is a normal edit."""
+    _goto_gps_config(page, base_url)
+
+    tmode_select = page.locator(".hw-field-tmode-select")
+    expect(tmode_select).to_be_visible(timeout=10_000)
+    expect(page.locator(".hw-field-tmode-note")).to_have_count(0)
+
+    sync_badge = page.locator(".sync-badge")
+    expect(sync_badge).to_have_text("In sync")
+
+    tmode_select.click()
+    page.get_by_role("option", name="fixed", exact=True).click()
+    expect(sync_badge).to_have_text("Receiver out of sync")
+
+
+@pytest.mark.e2e
+def test_survey_in_shows_as_locked_current_value(
+    page: Page,
+    base_url: str,
+    api_base_url: str,
+    connected_gps: None,
+) -> None:
+    """A receiver mid-survey shows survey_in as the current value —
+    not selectable, no phantom unapplied change — with a pointer to
+    the Survey page. Overriding it with ``disabled``/``fixed`` is a
+    legitimate edit."""
+    resp = httpx.post(
+        f"{api_base_url}/api/device/configure/survey-in",
+        json={},
+        timeout=10.0,
+    )
+    assert resp.status_code == 200, resp.text
+
+    _goto_gps_config(page, base_url)
+
+    expect(page.locator(".hw-field-tmode-note")).to_contain_text(
+        "survey_in", timeout=10_000
+    )
+    expect(page.locator(".hw-field-tmode-survey-link")).to_be_visible()
+    # No selectable option ever reads "survey_in" — seedable, not pickable.
+    expect(page.locator(".hw-field-tmode-select")).to_be_visible()
+
+    sync_badge = page.locator(".sync-badge")
+    expect(sync_badge).to_have_text("In sync")
+
+    page.locator(".hw-field-tmode-select").click()
+    page.get_by_role("option", name="disabled", exact=True).click()
+    expect(sync_badge).to_have_text("Receiver out of sync")

--- a/tests/e2e/test_gps_profile_picker.py
+++ b/tests/e2e/test_gps_profile_picker.py
@@ -125,7 +125,8 @@ def test_form_seeds_matrix_and_gnss_from_live_receiver(
     base_url: str,
     connected_gps: None,
 ) -> None:
-    """The RTCM matrix and GNSS badges reflect the fake driver's live state.
+    """The RTCM matrix and GNSS checkboxes reflect the fake driver's live
+    state.
 
     ``FakeGpsDriver`` enables RTCM 1005/1077/1087/1097/1127/1230 on
     USB+UART1 (not UART2) and enables GPS/GLONASS/Galileo/BeiDou but
@@ -141,9 +142,10 @@ def test_form_seeds_matrix_and_gnss_from_live_receiver(
     # A row with no live data at all stays off everywhere.
     expect(page.locator(".rtcm-cell-1074-UART1")).to_have_text("-")
 
-    config_card = page.locator(".q-card:has(:text('Receiver Configuration'))").first
-    expect(config_card.locator(".q-badge:text-is('GPS')")).to_be_visible()
-    expect(config_card.locator(".q-badge:text-is('SBAS')")).to_be_visible()
+    expect(page.locator(".gnss-checkbox-gps")).to_have_attribute("aria-checked", "true")
+    expect(page.locator(".gnss-checkbox-sbas")).to_have_attribute(
+        "aria-checked", "false"
+    )
 
 
 @pytest.mark.e2e

--- a/tests/unit/test_gps_config_helpers.py
+++ b/tests/unit/test_gps_config_helpers.py
@@ -46,14 +46,15 @@ from sp_rtk_base.services.profile_store import ProfileStore
 from sp_rtk_base.ui.pages.gps_config import (
     MATRIX_PORTS,
     REQUIRED_RTCM_ROW,
+    SELECTABLE_TMODE_MODES,
     apply_blocked_reason,
+    bds_b2_control_disabled,
     build_apply_request,
     build_picker_entries,
     build_saved_profile,
     display_label,
     fixed_position_step_state,
     format_leaf_diff,
-    hw_extras_display,
     i2c_spi_advisory_rows,
     infer_data_link_ports,
     is_modified_from_profile,
@@ -67,6 +68,7 @@ from sp_rtk_base.ui.pages.gps_config import (
     rtcm_config_to_matrix,
     save_as_enabled,
     suggest_profile_name,
+    tmode_mode_locked,
 )
 
 
@@ -334,6 +336,28 @@ class TestBuildApplyRequest:
         with pytest.raises(ValueError, match="1005"):
             build_apply_request(form, [PortId.UART1])
 
+    def test_coerces_bds_b2_off_when_beidou_disabled(self) -> None:
+        """A form left inconsistent (e.g. from a seed that already was)
+        gets its assert coerced — see the docstring on
+        ``build_apply_request``."""
+        form = _minimal_form().model_copy(
+            update={"constellations": [GnssConstellation.GPS], "bds_b2_enabled": True}
+        )
+        request = build_apply_request(form, [PortId.UART1])
+        assert request.assertion.bds_b2_enabled is False
+        # The original form object itself is left untouched.
+        assert form.bds_b2_enabled is True
+
+    def test_leaves_bds_b2_alone_when_beidou_enabled(self) -> None:
+        form = _minimal_form().model_copy(
+            update={
+                "constellations": [GnssConstellation.BEIDOU],
+                "bds_b2_enabled": True,
+            }
+        )
+        request = build_apply_request(form, [PortId.UART1])
+        assert request.assertion.bds_b2_enabled is True
+
 
 class TestFormatLeafDiff:
     def test_names_the_path_and_the_mismatch(self) -> None:
@@ -568,28 +592,27 @@ class TestResolveGnssDisplay:
         assert not any(display.values())
 
 
-class TestHwExtrasDisplay:
-    def test_renders_every_field_concretely(self) -> None:
-        extras = ReceiverAssertion(
-            baud=BaudAssertion(uart1=57600, uart2=115200),
-            meas_period_ms=500,
-            constellations=[],
-            ports={},
-            dyn_model=DynModel.STATIONARY,
-            tmode_mode=TmodeMode.FIXED,
-            elevation_mask_deg=15,
-            bds_b2_enabled=False,
-            spi_enabled=True,
-            rtcm_stream=RtcmStreamConfig(matrix={}),
+class TestTmodeModeLocked:
+    def test_survey_in_is_locked(self) -> None:
+        assert tmode_mode_locked(TmodeMode.SURVEY_IN)
+
+    def test_disabled_and_fixed_are_not_locked(self) -> None:
+        assert not tmode_mode_locked(TmodeMode.DISABLED)
+        assert not tmode_mode_locked(TmodeMode.FIXED)
+
+    def test_selectable_modes_excludes_survey_in(self) -> None:
+        assert TmodeMode.SURVEY_IN not in SELECTABLE_TMODE_MODES
+        assert set(SELECTABLE_TMODE_MODES) == {TmodeMode.DISABLED, TmodeMode.FIXED}
+
+
+class TestBdsB2ControlDisabled:
+    def test_disabled_when_beidou_absent(self) -> None:
+        assert bds_b2_control_disabled([GnssConstellation.GPS])
+
+    def test_enabled_when_beidou_present(self) -> None:
+        assert not bds_b2_control_disabled(
+            [GnssConstellation.GPS, GnssConstellation.BEIDOU]
         )
-        rows = {label: value for _cls, label, value in hw_extras_display(extras)}
-        assert rows["Baud"] == "UART1=57600, UART2=115200"
-        assert rows["Measurement Rate"] == "2 Hz"
-        assert rows["Dynamics Model"] == "stationary"
-        assert rows["Time Mode"] == "fixed"
-        assert rows["Elevation Mask"] == "15°"
-        assert rows["BeiDou B2"] == "off"
-        assert rows["SPI"] == "on"
 
 
 class TestFixedPositionStepState:


### PR DESCRIPTION
## Summary

- Every field in the Advanced GPS page's hardware section — port protocols, GNSS constellations, measurement rate, UART1/UART2 baud, dynamics model, base mode, elevation mask, BeiDou B2, and SPI — is now a real editable widget instead of a read-only badge/label, wired into the same whole-form `ReceiverAssertion` the RTCM matrix and data-link picker already edit.
- Base mode offers `disabled`/`fixed`; `survey_in` shows as a locked current value with a link to the Survey page rather than a pickable option, so a receiver mid-survey shows no phantom unapplied change.
- BeiDou B2 greys out when BeiDou is unchecked and is coerced off at the single `build_apply_request` choke point shared by Apply, Save-as, and the modified-from-profile comparison.
- Model/firmware/protocol/hardware version remain read-only, unchanged.

Closes #100. The backend (whole-form read/apply/diff/no-op/warnings) was already fully built by #97/#98/#99/#103, so this is purely a UI-rendering change.

## Test plan

- [x] `uv run pyright src/` — clean
- [x] `uv run ruff check src/ tests/` / `ruff format --check` — clean
- [x] `uv run pytest` (unit suite, 90% coverage gate) — 1473 passed, 93.79% coverage
- [x] `uv run pytest tests/e2e --no-cov` — full e2e suite green, including 8 new tests in `test_gps_hardware_fields.py` covering GNSS/port-protocol checkboxes, measurement rate/dyn model/elevation/SPI, UART baud selects, BeiDou B2 grey-out, base-mode `disabled`/`fixed` selection, the `survey_in` locked display, and the `fixed`-without-position named refusal
- [x] Ran `/code-review` (Standards + Spec axes) against `main` and closed the two gaps it found (missing baud e2e coverage; unverified "fixed without position" refusal path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AcBmmcpcJtBBxvDE8M3C6p