### PR TITLE
feat(gps): result surfaces — badge, inline markers, headline, log, warning strip

### DIFF
--- a/src/sp_rtk_base/services/drivers/fake.py
+++ b/src/sp_rtk_base/services/drivers/fake.py
@@ -112,6 +112,15 @@ FAKE_UNKNOWN_HW_PORT: str = "FAKE-UNKNOWN-HW"
 # prompt without real hardware.
 FAKE_FACTORY_PORT: str = "FAKE-FACTORY"
 
+# Sentinel ``port`` value the e2e suite can pass to ``connect()`` to make
+# the fake driver drain a flash-divergence warning after every RTCM
+# matrix write — the write lands (and reads back) fine, but a step
+# warning reports that flash verification is pending, mirroring the
+# real ``UbloxDriver``'s own "flash divergence" warning shape. The only
+# way to reach the GPS page's warning strip (issue #101) without a real
+# producer.
+FAKE_FLASH_DIVERGENCE_PORT: str = "FAKE-FLASH-DIVERGENCE"
+
 
 class FakeGpsDriver(GpsReceiverDriver):
     """In-memory GPS receiver driver for E2E + dev-mode testing.
@@ -130,6 +139,13 @@ class FakeGpsDriver(GpsReceiverDriver):
         self._connected: bool = False
         self._port: str | None = None
         self._baud_rate: int | None = None
+
+        # Flash-divergence sentinel (issue #101) — set by ``connect()``
+        # when the port is ``FAKE_FLASH_DIVERGENCE_PORT``. Queued
+        # warnings are drained (and cleared) by ``drain_warnings()``,
+        # same lifecycle as ``UbloxDriver``'s own warning channel.
+        self._warn_on_rtcm_write: bool = False
+        self._pending_warnings: list[str] = []
 
         # Identity returned by ``connect()`` / ``get_device_info()``.
         # hardware_target/confidence default to a *confirmed* ZED-F9P —
@@ -315,6 +331,8 @@ class FakeGpsDriver(GpsReceiverDriver):
             )
         elif port == FAKE_FACTORY_PORT:
             self._rtcm_ports = RtcmPortConfig()
+        elif port == FAKE_FLASH_DIVERGENCE_PORT:
+            self._warn_on_rtcm_write = True
         return self._device_info
 
     def disconnect(self) -> None:
@@ -482,6 +500,10 @@ class FakeGpsDriver(GpsReceiverDriver):
             cell.setdefault("SPI", 0)
             updated[row] = cell
         self._rtcm_ports = RtcmPortConfig(messages=updated)
+        if self._warn_on_rtcm_write:
+            self._pending_warnings.append(
+                "RTCM matrix write landed in RAM but flash verification is pending"
+            )
 
     def get_uart_baud_rates(self) -> dict[PortId, int]:
         """Return the fixed in-memory UART baud rates."""
@@ -497,9 +519,15 @@ class FakeGpsDriver(GpsReceiverDriver):
             self._uart_baud_rates[PortId.UART2] = uart2
 
     def drain_warnings(self) -> list[str]:
-        """No producer wired up yet — the fake driver never warns (issue #99)."""
+        """Drain and clear queued warnings (issue #99).
+
+        Empty unless connected via :data:`FAKE_FLASH_DIVERGENCE_PORT`,
+        which queues one warning per RTCM matrix write (issue #101).
+        """
         self._ensure_connected()
-        return []
+        drained = self._pending_warnings
+        self._pending_warnings = []
+        return drained
 
     def get_receiver_scalars(self) -> ReceiverScalarConfig:
         """Return the fake driver's in-memory scalar config (issue #97)."""

--- a/src/sp_rtk_base/ui/pages/gps_config.py
+++ b/src/sp_rtk_base/ui/pages/gps_config.py
@@ -509,6 +509,26 @@ def row_slug(row_id: RtcmRowId) -> str:
 # ---------------------------------------------------------------------------
 
 
+def rtcm_diff_path(msg_id: RtcmRowId, port: PortId) -> str:
+    """The :func:`~sp_rtk_base.models.profile_models.diff_receiver_assertions`
+    path for one matrix cell — the single place that format is built, so
+    a mutation handler clearing provenance and the render function
+    marking it can never drift apart."""
+    return f"rtcm.{msg_id.value}.{port.value}"
+
+
+def port_protocol_diff_path(
+    port: PortId, direction: Literal["in", "out"], protocol: UbxProtocol
+) -> str:
+    """The diff path for one port's one protocol, one direction."""
+    return f"ports.{port.value}.{direction}.{protocol.value}"
+
+
+def constellation_diff_path(constellation: GnssConstellation) -> str:
+    """The diff path for one GNSS constellation."""
+    return f"constellations.{constellation.value}"
+
+
 def partition_diff_by_provenance(
     diff: list[ApplyDiffEntry], failed_paths: set[str]
 ) -> tuple[list[ApplyDiffEntry], list[ApplyDiffEntry]]:
@@ -1524,7 +1544,10 @@ def gps_config_page() -> None:
                 return None
 
         def _toggle_port_protocol(
-            port: PortId, direction: str, protocol: UbxProtocol, checked: bool
+            port: PortId,
+            direction: Literal["in", "out"],
+            protocol: UbxProtocol,
+            checked: bool,
         ) -> None:
             protocols = form.ports.setdefault(port, PortProtocolSet())
             target = protocols.in_ if direction == "in" else protocols.out
@@ -1532,7 +1555,7 @@ def gps_config_page() -> None:
                 target.append(protocol)
             elif not checked and protocol in target:
                 target.remove(protocol)
-            _clear_failed(f"ports.{port.value}.{direction}.{protocol.value}")
+            _clear_failed(port_protocol_diff_path(port, direction, protocol))
             _render_ports_view()
             _on_form_changed()
 
@@ -1560,7 +1583,7 @@ def gps_config_page() -> None:
                             )
                             _mark_mismatch(
                                 checkbox,
-                                f"ports.{port_id.value}.in.{protocol.value}",
+                                port_protocol_diff_path(port_id, "in", protocol),
                                 failed_by_path,
                             )
                         ui.label("OUT").classes("text-caption text-grey-5 q-ml-md")
@@ -1576,12 +1599,12 @@ def gps_config_page() -> None:
                             )
                             _mark_mismatch(
                                 checkbox,
-                                f"ports.{port_id.value}.out.{protocol.value}",
+                                port_protocol_diff_path(port_id, "out", protocol),
                                 failed_by_path,
                             )
 
         def _toggle_gnss(constellation: GnssConstellation, checked: bool) -> None:
-            _clear_failed(f"constellations.{constellation.value}")
+            _clear_failed(constellation_diff_path(constellation))
             if checked and constellation not in form.constellations:
                 form.constellations.append(constellation)
             elif not checked and constellation in form.constellations:
@@ -1614,7 +1637,9 @@ def gps_config_page() -> None:
                             c, bool(e.value)
                         ),
                     ).classes(f"gnss-checkbox-{c_val}")
-                    _mark_mismatch(checkbox, f"constellations.{c_val}", failed_by_path)
+                    _mark_mismatch(
+                        checkbox, constellation_diff_path(constellation), failed_by_path
+                    )
 
         def _set_meas_period_ms(period_ms: float | None) -> None:
             if period_ms is None:
@@ -1807,7 +1832,7 @@ def gps_config_page() -> None:
             form.rtcm_stream.matrix[msg_id][port] = not form.rtcm_stream.matrix[msg_id][
                 port
             ]
-            _clear_failed(f"rtcm.{msg_id.value}.{port.value}")
+            _clear_failed(rtcm_diff_path(msg_id, port))
             _render_matrix()
             _on_form_changed()
 
@@ -1879,7 +1904,7 @@ def gps_config_page() -> None:
                                 )
                                 _mark_mismatch(
                                     cell,
-                                    f"rtcm.{msg_id.value}.{port.value}",
+                                    rtcm_diff_path(msg_id, port),
                                     failed_by_path,
                                 )
 
@@ -1987,7 +2012,10 @@ def gps_config_page() -> None:
 
         def _render_warning_strip(lines: list[str]) -> None:
             """Replace the strip whole with *lines* — one ``⚠`` label per
-            warning, never a string-joined blob (issue #101)."""
+            warning, never a string-joined blob (issue #101). No remedy
+            button — the remedy is the Apply button already in the
+            action row, named explicitly so the operator doesn't have
+            to guess it."""
             warning_strip_view.clear()
             if not lines:
                 warning_strip_card.set_visibility(False)
@@ -1998,6 +2026,9 @@ def gps_config_page() -> None:
                     ui.label(f"⚠ {line}").classes(
                         "warning-strip-line text-warning text-caption"
                     )
+                ui.label("Press Apply to retry.").classes(
+                    "warning-strip-remedy text-warning text-caption"
+                )
 
         def _render_step_log() -> None:
             """Re-render the whole append-only log from ``step_log``."""

--- a/src/sp_rtk_base/ui/pages/gps_config.py
+++ b/src/sp_rtk_base/ui/pages/gps_config.py
@@ -57,6 +57,7 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass
+from typing import Literal
 
 from nicegui import ui
 from pydantic import ValidationError
@@ -94,6 +95,8 @@ from sp_rtk_base.models.hardware_identity import (
 from sp_rtk_base.models.profile_models import (
     MATRIX_PORTS,
     ApplyDiffEntry,
+    ApplyStepResult,
+    ApplyStepWarning,
     BaudAssertion,
     PortProtocolSet,
     Profile,
@@ -499,6 +502,119 @@ def row_slug(row_id: RtcmRowId) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Result surfaces (issue #101) — the three-state badge, inline-marker
+# provenance split, headline verdict, step log and warning strip that
+# turn Apply's already-rich ``ApplyConfigResult`` (issue #99) into
+# something the operator can read at a glance.
+# ---------------------------------------------------------------------------
+
+
+def partition_diff_by_provenance(
+    diff: list[ApplyDiffEntry], failed_paths: set[str]
+) -> tuple[list[ApplyDiffEntry], list[ApplyDiffEntry]]:
+    """Split *diff* (form vs. live) into ``(failed, pending)`` by provenance.
+
+    A leaf is *failed* when it appears in the last apply's diff and
+    hasn't been edited since — *failed_paths* is exactly that set, and
+    every mutation handler on the page drops a path from it the moment
+    the operator edits that field. Anything else that currently
+    differs is a *pending* edit — the resting state of an editable
+    form, never a fault.
+    """
+    failed = [d for d in diff if d.path in failed_paths]
+    pending = [d for d in diff if d.path not in failed_paths]
+    return failed, pending
+
+
+@dataclass(frozen=True)
+class ResultBadgeState:
+    """One badge, three states — see :func:`result_badge_state`."""
+
+    kind: Literal["in_sync", "pending", "failed"]
+    count: int
+
+
+def result_badge_state(
+    failed: list[ApplyDiffEntry], pending: list[ApplyDiffEntry]
+) -> ResultBadgeState:
+    """The one-badge, three-state verdict.
+
+    Verification failure takes priority over pending edits — the badge
+    never shows both — and either count covers exactly the leaves
+    :func:`partition_diff_by_provenance` produced, which is exactly
+    the set Apply itself asserts: no carve-outs.
+    """
+    if failed:
+        return ResultBadgeState(kind="failed", count=len(failed))
+    if pending:
+        return ResultBadgeState(kind="pending", count=len(pending))
+    return ResultBadgeState(kind="in_sync", count=0)
+
+
+def _plural(count: int, noun: str) -> str:
+    return noun if count == 1 else f"{noun}s"
+
+
+def badge_label(state: ResultBadgeState) -> str:
+    """The badge's text for *state*."""
+    if state.kind == "in_sync":
+        return "In sync"
+    if state.kind == "failed":
+        return f"{state.count} {_plural(state.count, 'field')} failed verification"
+    return f"{state.count} unapplied {_plural(state.count, 'change')}"
+
+
+#: Quasar colour per badge state. ``pending`` stays a neutral grey —
+#: the resting state of an editable form shouldn't train the operator
+#: to read amber as trouble; only a genuine verification failure does.
+_BADGE_COLOR: dict[str, str] = {
+    "in_sync": "positive",
+    "pending": "grey-7",
+    "failed": "warning",
+}
+
+
+def badge_color(state: ResultBadgeState) -> str:
+    """The Quasar colour name for *state*."""
+    return _BADGE_COLOR[state.kind]
+
+
+def apply_headline(status: Literal["ok", "failed"], warning_count: int) -> str:
+    """The headline verdict line — the outcome without reading, plus a
+    neutral warning count when warnings are present so a green verdict
+    never sits directly above an amber strip the operator has no
+    reason to read."""
+    verdict = (
+        "Applied and verified ✓"
+        if status == "ok"
+        else "Applied, but verification found mismatches — nothing was rolled back."
+    )
+    if not warning_count:
+        return verdict
+    return f"{verdict} ({warning_count} {_plural(warning_count, 'warning')})"
+
+
+def apply_warning_lines(
+    warnings: list[str], step_warnings: list[ApplyStepWarning]
+) -> list[str]:
+    """One line per warning for the strip — never joined into a single
+    string. Step warnings are prefixed with the step that produced
+    them; the non-blocking throughput warnings need no prefix."""
+    return [*warnings, *(f"{w.step}: {w.message}" for w in step_warnings)]
+
+
+#: Icon per :class:`~sp_rtk_base.models.profile_models.ApplyStepResult`
+#: status, for the step log's append-only line.
+_STEP_STATUS_ICON: dict[str, str] = {"ok": "✓", "failed": "✗", "skipped": "—"}
+
+
+def format_step_log_entry(step: ApplyStepResult) -> str:
+    """One step-log line. Order and partial application are the two
+    things only this surface can express."""
+    return f"{_STEP_STATUS_ICON[step.status]} {step.step}: {step.status}"
+
+
+# ---------------------------------------------------------------------------
 # Fixed Position three-step card (issue #96) — deliberately separate from
 # the profile-form helpers above. This card's state is derived entirely
 # from live receiver polls (``CurrentBaseConfig`` + ``SurveyInProgress``),
@@ -843,7 +959,31 @@ def gps_config_page() -> None:
                 .style("border: 1px solid #333; border-radius: 4px")
             )
             apply_result_label.set_visibility(False)
-            apply_diff_list = ui.column().classes("apply-diff-list q-mt-xs gap-0")
+
+            # Warning strip (issue #101) — the Survey page's amber-card
+            # idiom for pre-flight advisories, reused here for Apply's
+            # non-blocking step warnings. One ``⚠`` label per warning,
+            # never a string-joined blob; replaced whole on every Apply
+            # attempt and cleared on disconnect. No remedy button — the
+            # remedy is the Apply button already in this action row.
+            warning_strip_card = (
+                ui.card()
+                .classes("warning-strip w-full q-pa-sm q-mt-sm")
+                .style("background-color: #3a2a10")
+            )
+            warning_strip_card.set_visibility(False)
+            with warning_strip_card:
+                warning_strip_view = ui.column().classes("gap-0")
+
+            # Session-only, append-only step log (issue #101) — the only
+            # surface that can express ordering and partial application.
+            # Grows across every Apply this connection makes; cleared on
+            # disconnect, because a surviving log would narrate a
+            # possibly-detached receiver.
+            ui.label("Apply Step Log").classes(
+                "step-log-label text-subtitle2 text-white q-mt-md"
+            )
+            step_log_view = ui.column().classes("step-log q-mt-xs gap-0")
 
         # ---- Save-as dialog ----
         with ui.dialog() as save_as_dialog, ui.card().classes("q-pa-md"):
@@ -1111,6 +1251,9 @@ def gps_config_page() -> None:
             selected_profile = profile
             form = merge_profile_into_assertion(profile, live)
             form_data_link_ports = list(profile.data_link_port)
+            # A profile pick is a bulk edit of every field it touches —
+            # same provenance rule as any other edit (issue #101).
+            failed_paths.clear()
 
             _render_matrix()
             _render_ports_view()
@@ -1321,13 +1464,56 @@ def gps_config_page() -> None:
         delete_target: str | None = None
         delete_target_label: str = ""
 
-        def _out_of_sync() -> bool:
-            """Whole-form comparison (issue #98) — the same per-leaf
-            ``diff_receiver_assertions`` call Apply's read-back verify
-            uses, applied here to form vs. live. Never mentions
-            ``data_link_port`` (it isn't part of either operand), so a
-            data-link-port-only change never shows as out of sync."""
-            return bool(diff_receiver_assertions(form, live))
+        # Provenance for the three-state badge and inline markers (issue
+        # #101): paths that appeared in the *last* Apply's read-back diff
+        # and haven't been edited since. Every form-mutating handler
+        # below drops its own path(s) out of this set the moment the
+        # operator edits that field — see ``_clear_failed``. Reset
+        # wholesale by a fresh Apply, a profile pick, or a live reseed.
+        failed_paths: set[str] = set()
+
+        # Session-only, append-only step log (issue #101) — every Apply
+        # this connection makes extends it; ``_disconnect``/reconnect
+        # clear it (see ``_clear_session_state``).
+        step_log: list[ApplyStepResult] = []
+
+        def _partitioned_diff() -> tuple[list[ApplyDiffEntry], list[ApplyDiffEntry]]:
+            """(failed, pending) leaves — the whole-form ``form`` vs.
+            ``live`` comparison (issue #98's ``diff_receiver_assertions``
+            call, same one Apply's own read-back verify uses), split by
+            provenance (issue #101). Never mentions ``data_link_port``
+            (it isn't part of either operand), so a data-link-port-only
+            change never shows as out of sync."""
+            diff = diff_receiver_assertions(form, live)
+            return partition_diff_by_provenance(diff, failed_paths)
+
+        def _failed_by_path() -> dict[str, ApplyDiffEntry]:
+            """The currently-failed leaves, keyed by path — what the
+            inline markers highlight."""
+            failed, _pending = _partitioned_diff()
+            return {d.path: d for d in failed}
+
+        def _mark_mismatch(
+            element: ui.element, path: str, failed_by_path: dict[str, ApplyDiffEntry]
+        ) -> None:
+            """Ring *element* amber and attach the mismatch detail as a
+            tooltip when *path* is currently failed — the persistent
+            mismatch truth an inline marker gives instead of prose the
+            operator has to hunt a widget down to match (issue #101)."""
+            entry = failed_by_path.get(path)
+            if entry is None:
+                return
+            element.classes("field-failed")
+            element.style(
+                "outline: 2px solid #F2C037; outline-offset: 2px; border-radius: 4px"
+            )
+            element.tooltip(format_leaf_diff(entry))
+
+        def _clear_failed(*paths: str) -> None:
+            """Editing a field after a failed verification moves it from
+            failed to pending (issue #101) — every mutation handler
+            calls this with its own path(s) before re-rendering."""
+            failed_paths.difference_update(paths)
 
         def _current_form_request() -> ReceiverApplyRequest | None:
             """The form as a ``ReceiverApplyRequest``, or ``None`` if it
@@ -1346,10 +1532,13 @@ def gps_config_page() -> None:
                 target.append(protocol)
             elif not checked and protocol in target:
                 target.remove(protocol)
+            _clear_failed(f"ports.{port.value}.{direction}.{protocol.value}")
+            _render_ports_view()
             _on_form_changed()
 
         def _render_ports_view() -> None:
             ports_view.clear()
+            failed_by_path = _failed_by_path()
             with ports_view:
                 display = resolve_ports_display(form.ports)
                 for port_id in (PortId.UART1, PortId.UART2, PortId.USB):
@@ -1360,7 +1549,7 @@ def gps_config_page() -> None:
                         )
                         ui.label("IN").classes("text-caption text-grey-5")
                         for protocol in UbxProtocol:
-                            ui.checkbox(
+                            checkbox = ui.checkbox(
                                 protocol.value,
                                 value=protocol.value in in_names,
                                 on_change=lambda e, p=port_id, pr=protocol: (
@@ -1369,9 +1558,14 @@ def gps_config_page() -> None:
                             ).classes(
                                 f"port-protocol-{port_id.value}-in-{protocol.value}"
                             )
+                            _mark_mismatch(
+                                checkbox,
+                                f"ports.{port_id.value}.in.{protocol.value}",
+                                failed_by_path,
+                            )
                         ui.label("OUT").classes("text-caption text-grey-5 q-ml-md")
                         for protocol in UbxProtocol:
-                            ui.checkbox(
+                            checkbox = ui.checkbox(
                                 protocol.value,
                                 value=protocol.value in out_names,
                                 on_change=lambda e, p=port_id, pr=protocol: (
@@ -1380,8 +1574,14 @@ def gps_config_page() -> None:
                             ).classes(
                                 f"port-protocol-{port_id.value}-out-{protocol.value}"
                             )
+                            _mark_mismatch(
+                                checkbox,
+                                f"ports.{port_id.value}.out.{protocol.value}",
+                                failed_by_path,
+                            )
 
         def _toggle_gnss(constellation: GnssConstellation, checked: bool) -> None:
+            _clear_failed(f"constellations.{constellation.value}")
             if checked and constellation not in form.constellations:
                 form.constellations.append(constellation)
             elif not checked and constellation in form.constellations:
@@ -1392,30 +1592,35 @@ def gps_config_page() -> None:
                     # off, rather than leaving a stale "on" behind it
                     # (build_apply_request coerces this too, for the
                     # case where the two were already inconsistent on
-                    # seed — see its docstring).
+                    # seed — see its docstring). Counts as an edit to
+                    # bds_b2_enabled too (issue #101).
                     form.bds_b2_enabled = False
+                    _clear_failed("bds_b2_enabled")
             _render_gnss_view()
             _render_hw_extras_view()
             _on_form_changed()
 
         def _render_gnss_view() -> None:
             gnss_view.clear()
+            failed_by_path = _failed_by_path()
             with gnss_view:
                 enabled_map = resolve_gnss_display(form.constellations)
                 for c_val, c_name in _GNSS_DISPLAY:
                     constellation = GnssConstellation(c_val)
-                    ui.checkbox(
+                    checkbox = ui.checkbox(
                         c_name,
                         value=enabled_map.get(c_val, False),
                         on_change=lambda e, c=constellation: _toggle_gnss(
                             c, bool(e.value)
                         ),
                     ).classes(f"gnss-checkbox-{c_val}")
+                    _mark_mismatch(checkbox, f"constellations.{c_val}", failed_by_path)
 
         def _set_meas_period_ms(period_ms: float | None) -> None:
             if period_ms is None:
                 return
             form.meas_period_ms = int(period_ms)
+            _clear_failed("meas_period_ms")
             _render_hw_extras_view()
             _on_form_changed()
 
@@ -1426,18 +1631,23 @@ def gps_config_page() -> None:
                 form.baud.uart1 = int(value)
             else:
                 form.baud.uart2 = int(value)
+            _clear_failed(f"baud.{uart}")
+            _render_hw_extras_view()
             _on_form_changed()
 
         def _set_dyn_model(value: str | None) -> None:
             if value is None:
                 return
             form.dyn_model = DynModel(value)
+            _clear_failed("dyn_model")
+            _render_hw_extras_view()
             _on_form_changed()
 
         def _set_tmode_mode(value: str | None) -> None:
             if value is None:
                 return
             form.tmode_mode = TmodeMode(value)
+            _clear_failed("tmode_mode")
             _render_hw_extras_view()
             _on_form_changed()
 
@@ -1445,57 +1655,83 @@ def gps_config_page() -> None:
             if value is None:
                 return
             form.elevation_mask_deg = int(value)
+            _clear_failed("elevation_mask_deg")
+            _render_hw_extras_view()
             _on_form_changed()
 
         def _toggle_bds_b2(checked: bool) -> None:
             form.bds_b2_enabled = checked
+            _clear_failed("bds_b2_enabled")
+            _render_hw_extras_view()
             _on_form_changed()
 
         def _toggle_spi(checked: bool) -> None:
             form.spi_enabled = checked
+            _clear_failed("spi_enabled")
+            _render_hw_extras_view()
             _on_form_changed()
 
         def _render_hw_extras_view() -> None:
             hw_extras_view.clear()
             tmode_options = {m.value: m.value for m in SELECTABLE_TMODE_MODES}
+            failed_by_path = _failed_by_path()
             with hw_extras_view:
                 with ui.column().classes("hw-field-meas-rate gap-0"):
                     ui.label("Measurement Rate").classes("text-caption text-grey-5")
-                    ui.number(
-                        value=form.meas_period_ms,
-                        min=100,
-                        max=60000,
-                        step=100,
-                        on_change=lambda e: _set_meas_period_ms(e.value),
-                    ).classes("hw-field-meas-rate-input").props(
-                        "dense suffix=ms"
-                    ).style("width: 140px")
+                    meas_input = (
+                        ui.number(
+                            value=form.meas_period_ms,
+                            min=100,
+                            max=60000,
+                            step=100,
+                            on_change=lambda e: _set_meas_period_ms(e.value),
+                        )
+                        .classes("hw-field-meas-rate-input")
+                        .props("dense suffix=ms")
+                        .style("width: 140px")
+                    )
+                    _mark_mismatch(meas_input, "meas_period_ms", failed_by_path)
                     hz = 1000 / form.meas_period_ms
                     ui.label(f"= {hz:g} Hz").classes("text-caption text-grey-5")
 
                 with ui.column().classes("hw-field-baud gap-0"):
                     ui.label("Baud").classes("text-caption text-grey-5")
                     with ui.row().classes("gap-2"):
-                        ui.select(
-                            options={r: str(r) for r in BAUD_RATES},
-                            label="UART1",
-                            value=form.baud.uart1,
-                            on_change=lambda e: _set_baud("uart1", e.value),
-                        ).classes("hw-field-baud-uart1").style("width: 110px")
-                        ui.select(
-                            options={r: str(r) for r in BAUD_RATES},
-                            label="UART2",
-                            value=form.baud.uart2,
-                            on_change=lambda e: _set_baud("uart2", e.value),
-                        ).classes("hw-field-baud-uart2").style("width: 110px")
+                        uart1_select = (
+                            ui.select(
+                                options={r: str(r) for r in BAUD_RATES},
+                                label="UART1",
+                                value=form.baud.uart1,
+                                on_change=lambda e: _set_baud("uart1", e.value),
+                            )
+                            .classes("hw-field-baud-uart1")
+                            .style("width: 110px")
+                        )
+                        _mark_mismatch(uart1_select, "baud.uart1", failed_by_path)
+                        uart2_select = (
+                            ui.select(
+                                options={r: str(r) for r in BAUD_RATES},
+                                label="UART2",
+                                value=form.baud.uart2,
+                                on_change=lambda e: _set_baud("uart2", e.value),
+                            )
+                            .classes("hw-field-baud-uart2")
+                            .style("width: 110px")
+                        )
+                        _mark_mismatch(uart2_select, "baud.uart2", failed_by_path)
 
                 with ui.column().classes("hw-field-dyn-model gap-0"):
                     ui.label("Dynamics Model").classes("text-caption text-grey-5")
-                    ui.select(
-                        options={m.value: m.value for m in DynModel},
-                        value=form.dyn_model.value,
-                        on_change=lambda e: _set_dyn_model(e.value),
-                    ).classes("hw-field-dyn-model-select").style("width: 160px")
+                    dyn_model_select = (
+                        ui.select(
+                            options={m.value: m.value for m in DynModel},
+                            value=form.dyn_model.value,
+                            on_change=lambda e: _set_dyn_model(e.value),
+                        )
+                        .classes("hw-field-dyn-model-select")
+                        .style("width: 160px")
+                    )
+                    _mark_mismatch(dyn_model_select, "dyn_model", failed_by_path)
 
                 with ui.column().classes("hw-field-tmode gap-0"):
                     ui.label("Time Mode").classes("text-caption text-grey-5")
@@ -1508,55 +1744,76 @@ def gps_config_page() -> None:
                         ).props("outline color=primary dense").on(
                             "click", lambda: ui.navigate.to("/survey")
                         )
-                        ui.select(
-                            options=tmode_options,
-                            label="Change to...",
-                            on_change=lambda e: _set_tmode_mode(e.value),
-                        ).classes("hw-field-tmode-select").style("width: 140px")
+                        tmode_select = (
+                            ui.select(
+                                options=tmode_options,
+                                label="Change to...",
+                                on_change=lambda e: _set_tmode_mode(e.value),
+                            )
+                            .classes("hw-field-tmode-select")
+                            .style("width: 140px")
+                        )
                     else:
-                        ui.select(
-                            options=tmode_options,
-                            value=form.tmode_mode.value,
-                            on_change=lambda e: _set_tmode_mode(e.value),
-                        ).classes("hw-field-tmode-select").style("width: 140px")
+                        tmode_select = (
+                            ui.select(
+                                options=tmode_options,
+                                value=form.tmode_mode.value,
+                                on_change=lambda e: _set_tmode_mode(e.value),
+                            )
+                            .classes("hw-field-tmode-select")
+                            .style("width: 140px")
+                        )
+                    _mark_mismatch(tmode_select, "tmode_mode", failed_by_path)
 
                 with ui.column().classes("hw-field-elevation-mask gap-0"):
                     ui.label("Elevation Mask").classes("text-caption text-grey-5")
-                    ui.number(
-                        value=form.elevation_mask_deg,
-                        min=0,
-                        max=90,
-                        step=1,
-                        on_change=lambda e: _set_elevation_mask(e.value),
-                    ).classes("hw-field-elevation-mask-input").props(
-                        "dense suffix=°"
-                    ).style("width: 100px")
+                    elevation_input = (
+                        ui.number(
+                            value=form.elevation_mask_deg,
+                            min=0,
+                            max=90,
+                            step=1,
+                            on_change=lambda e: _set_elevation_mask(e.value),
+                        )
+                        .classes("hw-field-elevation-mask-input")
+                        .props("dense suffix=°")
+                        .style("width: 100px")
+                    )
+                    _mark_mismatch(
+                        elevation_input, "elevation_mask_deg", failed_by_path
+                    )
 
                 with ui.column().classes("hw-field-bds-b2 gap-0"):
                     ui.label("BeiDou B2").classes("text-caption text-grey-5")
-                    ui.checkbox(
-                        value=form.bds_b2_enabled,
-                        on_change=lambda e: _toggle_bds_b2(bool(e.value)),
-                    ).classes("hw-field-bds-b2-checkbox").set_enabled(
-                        not bds_b2_control_disabled(form.constellations)
+                    bds_b2_checkbox = (
+                        ui.checkbox(
+                            value=form.bds_b2_enabled,
+                            on_change=lambda e: _toggle_bds_b2(bool(e.value)),
+                        )
+                        .classes("hw-field-bds-b2-checkbox")
+                        .set_enabled(not bds_b2_control_disabled(form.constellations))
                     )
+                    _mark_mismatch(bds_b2_checkbox, "bds_b2_enabled", failed_by_path)
 
                 with ui.column().classes("hw-field-spi gap-0"):
                     ui.label("SPI").classes("text-caption text-grey-5")
-                    ui.checkbox(
+                    spi_checkbox = ui.checkbox(
                         value=form.spi_enabled,
                         on_change=lambda e: _toggle_spi(bool(e.value)),
                     ).classes("hw-field-spi-checkbox")
+                    _mark_mismatch(spi_checkbox, "spi_enabled", failed_by_path)
 
         def _toggle_matrix_cell(msg_id: RtcmRowId, port: PortId) -> None:
             form.rtcm_stream.matrix[msg_id][port] = not form.rtcm_stream.matrix[msg_id][
                 port
             ]
+            _clear_failed(f"rtcm.{msg_id.value}.{port.value}")
             _render_matrix()
             _on_form_changed()
 
         def _render_matrix() -> None:
             matrix_view.clear()
+            failed_by_path = _failed_by_path()
             with matrix_view:
                 # Header row
                 with (
@@ -1609,13 +1866,21 @@ def gps_config_page() -> None:
                                     "text-center cursor-pointer"
                                     + (" text-positive" if on else " text-grey-7")
                                 )
-                                ui.label("✓" if on else "-").classes(
-                                    cell_classes
-                                ).style("width: 70px; flex-shrink: 0").on(
-                                    "click",
-                                    lambda _, m=msg_id, p=port: _toggle_matrix_cell(
-                                        m, p
-                                    ),
+                                cell = (
+                                    ui.label("✓" if on else "-")
+                                    .classes(cell_classes)
+                                    .style("width: 70px; flex-shrink: 0")
+                                    .on(
+                                        "click",
+                                        lambda _, m=msg_id, p=port: _toggle_matrix_cell(
+                                            m, p
+                                        ),
+                                    )
+                                )
+                                _mark_mismatch(
+                                    cell,
+                                    f"rtcm.{msg_id.value}.{port.value}",
+                                    failed_by_path,
                                 )
 
         def _render_data_link_picker() -> None:
@@ -1646,12 +1911,14 @@ def gps_config_page() -> None:
             _on_form_changed()
 
         def _render_sync_indicator() -> None:
-            if _out_of_sync():
-                sync_badge.text = "Receiver out of sync"
-                sync_badge.props("color=warning")
-            else:
-                sync_badge.text = "In sync"
-                sync_badge.props("color=positive")
+            """The one-badge, three-state result surface (issue #101):
+            ``In sync`` / ``n unapplied change(s)`` (neutral — the resting
+            state of an editable form) / ``n field(s) failed verification``
+            (warning colour, priority over pending)."""
+            failed, pending = _partitioned_diff()
+            state = result_badge_state(failed, pending)
+            sync_badge.text = badge_label(state)
+            sync_badge.props(f"color={badge_color(state)}")
 
         def _render_apply_gate() -> None:
             reason = apply_blocked_reason(form_data_link_ports)
@@ -1704,7 +1971,6 @@ def gps_config_page() -> None:
             _render_save_as_gate()
 
         def _set_apply_result(text: str, *, ok: bool) -> None:
-            apply_diff_list.clear()
             apply_result_label.text = text
             apply_result_label.classes(
                 remove="text-negative" if ok else "text-positive",
@@ -1714,15 +1980,43 @@ def gps_config_page() -> None:
 
         def _clear_apply_result() -> None:
             apply_result_label.set_visibility(False)
-            apply_diff_list.clear()
 
-        def _show_apply_diff(diff: list[ApplyDiffEntry]) -> None:
-            apply_diff_list.clear()
-            with apply_diff_list:
-                for leaf in diff:
-                    ui.label(format_leaf_diff(leaf)).classes(
-                        "text-caption text-warning"
+        def _clear_warning_strip() -> None:
+            warning_strip_card.set_visibility(False)
+            warning_strip_view.clear()
+
+        def _render_warning_strip(lines: list[str]) -> None:
+            """Replace the strip whole with *lines* — one ``⚠`` label per
+            warning, never a string-joined blob (issue #101)."""
+            warning_strip_view.clear()
+            if not lines:
+                warning_strip_card.set_visibility(False)
+                return
+            warning_strip_card.set_visibility(True)
+            with warning_strip_view:
+                for line in lines:
+                    ui.label(f"⚠ {line}").classes(
+                        "warning-strip-line text-warning text-caption"
                     )
+
+        def _render_step_log() -> None:
+            """Re-render the whole append-only log from ``step_log``."""
+            step_log_view.clear()
+            with step_log_view:
+                for step in step_log:
+                    ui.label(format_step_log_entry(step)).classes(
+                        f"step-log-entry step-log-entry-{step.status} "
+                        "text-caption text-grey-4"
+                    )
+
+        def _clear_session_state() -> None:
+            """Session-only surfaces cleared on disconnect (issue #101) —
+            a surviving log or strip would narrate a possibly-detached
+            receiver."""
+            failed_paths.clear()
+            step_log.clear()
+            _render_step_log()
+            _clear_warning_strip()
 
         async def _apply() -> None:
             """Push the whole current form to the receiver (issue #98).
@@ -1736,8 +2030,17 @@ def gps_config_page() -> None:
             — rather than patched field-by-field, so every display
             (matrix, ports, GNSS, hardware section) stays honest after
             both a clean apply and a partial-mismatch one.
+
+            Issue #101: the warning strip is replaced (or cleared) on
+            every Apply attempt, including a pre-write refusal — ``live``
+            and ``failed_paths`` are untouched by a refusal since nothing
+            was written. A completed Apply reseeds ``failed_paths`` from
+            ``result.diff`` (empty on a clean apply) and extends the
+            session's step log with ``result.steps``.
             """
             nonlocal live
+            _clear_warning_strip()
+
             try:
                 request = build_apply_request(form, form_data_link_ports)
             except ValidationError as exc:
@@ -1764,22 +2067,25 @@ def gps_config_page() -> None:
                 return
 
             live = result.read_back
+            failed_paths.clear()
+            failed_paths.update(d.path for d in result.diff)
+            step_log.extend(result.steps)
+            _render_step_log()
 
-            if result.status == "ok":
-                _set_apply_result("Applied and verified ✓", ok=True)
-                ui.notify("Applied and verified ✓", type="positive")
-            else:
-                _set_apply_result(
-                    "Applied, but verification found mismatches — nothing "
-                    "was rolled back.",
-                    ok=False,
-                )
-                _show_apply_diff(result.diff)
-                ui.notify("Verification found mismatches", type="warning")
+            warning_lines = apply_warning_lines(result.warnings, result.step_warnings)
+            _render_warning_strip(warning_lines)
 
-            if result.warnings:
-                ui.notify(" ".join(result.warnings), type="warning")
+            headline = apply_headline(result.status, len(warning_lines))
+            _set_apply_result(headline, ok=(result.status == "ok"))
+            ui.notify(
+                headline,
+                type="positive" if result.status == "ok" else "warning",
+            )
 
+            _render_matrix()
+            _render_ports_view()
+            _render_gnss_view()
+            _render_hw_extras_view()
             _on_form_changed()
 
         def _render_advisory(rtcm: RtcmPortConfig) -> None:
@@ -1862,6 +2168,9 @@ def gps_config_page() -> None:
             form = live.model_copy(deep=True)
             form_data_link_ports = infer_data_link_ports(live.rtcm_stream.matrix)
             selected_profile = None
+            # A full reseed makes form == live by construction, so no
+            # path can still differ — reset provenance defensively too.
+            failed_paths.clear()
 
             # The I2C/SPI advisory (rows enabled on a port the matrix
             # doesn't manage) needs the raw multi-port read-back, which
@@ -1893,6 +2202,7 @@ def gps_config_page() -> None:
             try:
                 if svc.is_connected:
                     await svc.disconnect()
+                    _clear_session_state()
 
                 driver = create_driver(vendor)
                 svc.set_driver(driver)
@@ -1928,6 +2238,7 @@ def gps_config_page() -> None:
         async def _disconnect() -> None:
             """Disconnect from device."""
             await svc.disconnect()
+            _clear_session_state()
             ui.notify("Disconnected", type="info")
             _update_ui_state()
 

--- a/tests/e2e/test_gps_apply.py
+++ b/tests/e2e/test_gps_apply.py
@@ -5,9 +5,10 @@ read-only shell from #64). This ticket makes the RTCM matrix and
 data-link port(s) editable and wires them to
 ``POST /api/device/apply-config``:
 
-- Toggling a matrix cell flips the "In sync" badge to "Receiver out of
-  sync"; a successful Apply clears it back to "In sync" (usage path 2
-  — tweak one cell, apply, iterate).
+- Toggling a matrix cell flips the "In sync" badge to "1 unapplied
+  change" (issue #101's neutral pending state); a successful Apply
+  clears it back to "In sync" (usage path 2 — tweak one cell, apply,
+  iterate).
 - A factory-fresh receiver (no RTCM anywhere) can't infer a data-link
   port — Apply is disabled with a clear prompt until the operator
   checks at least one UART box.
@@ -83,7 +84,7 @@ def test_toggle_cell_then_apply_clears_out_of_sync(
     expect(cell).to_have_text("-")
     cell.click()
     expect(cell).to_have_text("✓")
-    expect(sync_badge).to_have_text("Receiver out of sync")
+    expect(sync_badge).to_contain_text("unapplied change")
 
     apply_btn = page.get_by_role("button", name="Apply")
     expect(apply_btn).to_be_enabled()
@@ -149,4 +150,4 @@ def test_breaking_1005_rule_shows_named_refusal_and_writes_nothing(
 
     # Nothing was written — the receiver-out-of-sync badge is untouched
     # by the refusal (still reflects the pending, unwritten edit).
-    expect(page.locator(".sync-badge")).to_have_text("Receiver out of sync")
+    expect(page.locator(".sync-badge")).to_contain_text("unapplied change")

--- a/tests/e2e/test_gps_hardware_fields.py
+++ b/tests/e2e/test_gps_hardware_fields.py
@@ -60,7 +60,7 @@ def test_gnss_checkbox_edits_the_form_and_applies(
     sbas = page.locator(".gnss-checkbox-sbas")
     _expect_checked(sbas, checked=False)
     sbas.click()
-    expect(sync_badge).to_have_text("Receiver out of sync")
+    expect(sync_badge).to_contain_text("unapplied change")
 
     page.get_by_role("button", name="Apply").click()
     expect(page.locator(".apply-result")).to_contain_text(
@@ -85,7 +85,7 @@ def test_port_protocol_checkbox_edits_the_form_and_applies(
     nmea_in = page.locator(".port-protocol-UART2-in-NMEA")
     _expect_checked(nmea_in, checked=False)
     nmea_in.click()
-    expect(sync_badge).to_have_text("Receiver out of sync")
+    expect(sync_badge).to_contain_text("unapplied change")
 
     page.get_by_role("button", name="Apply").click()
     expect(page.locator(".apply-result")).to_contain_text(
@@ -125,7 +125,7 @@ def test_hardware_extras_are_editable_and_apply(
     _expect_checked(spi, checked=True)  # on by default on the fake driver
     spi.click()
 
-    expect(sync_badge).to_have_text("Receiver out of sync")
+    expect(sync_badge).to_contain_text("unapplied change")
 
     page.get_by_role("button", name="Apply").click()
     expect(page.locator(".apply-result")).to_contain_text(
@@ -166,7 +166,7 @@ def test_uart_baud_selects_are_editable_and_apply(
 
     uart2.click()
     page.get_by_role("option", name="230400", exact=True).click()
-    expect(sync_badge).to_have_text("Receiver out of sync")
+    expect(sync_badge).to_contain_text("unapplied change")
 
     page.get_by_role("button", name="Apply").click()
     expect(page.locator(".apply-result")).to_contain_text(
@@ -246,7 +246,7 @@ def test_base_mode_offers_disabled_and_fixed(
 
     tmode_select.click()
     page.get_by_role("option", name="fixed", exact=True).click()
-    expect(sync_badge).to_have_text("Receiver out of sync")
+    expect(sync_badge).to_contain_text("unapplied change")
 
 
 @pytest.mark.e2e
@@ -281,4 +281,4 @@ def test_survey_in_shows_as_locked_current_value(
 
     page.locator(".hw-field-tmode-select").click()
     page.get_by_role("option", name="disabled", exact=True).click()
-    expect(sync_badge).to_have_text("Receiver out of sync")
+    expect(sync_badge).to_contain_text("unapplied change")

--- a/tests/e2e/test_gps_result_surfaces.py
+++ b/tests/e2e/test_gps_result_surfaces.py
@@ -1,0 +1,207 @@
+"""E2E tests for the Advanced GPS page's result surfaces (issue #101).
+
+Covers what's reachable without hardware:
+
+- The warning strip renders one line per warning (never a joined blob),
+  is replaced by the next Apply, and clears on disconnect — driven by
+  ``FakeGpsDriver.FAKE_FLASH_DIVERGENCE_PORT``, the sentinel that
+  queues a step warning after every RTCM matrix write.
+- The headline verdict line carries a neutral warning count alongside
+  the "Applied and verified" verdict when warnings are present.
+- The step log is append-only across successive Apply presses within
+  one connection, and clears on disconnect.
+- The three-state badge's neutral "pending" wording (the "failed
+  verification" state itself needs a genuinely dishonest read-back,
+  which the fake driver doesn't simulate — that logic is covered at
+  the unit level in ``test_gps_config_helpers.py``).
+
+Locators target the stable CSS class hooks the page renders (see
+``ui/pages/gps_config.py``), matching the existing suite's convention.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+from sp_rtk_base.services.drivers.fake import FAKE_FLASH_DIVERGENCE_PORT
+
+
+@pytest.fixture()
+def connected_gps_flash_divergence(api_base_url: str) -> Iterator[None]:
+    """Connect the fake driver in its flash-divergence state.
+
+    Uses ``FakeGpsDriver.FAKE_FLASH_DIVERGENCE_PORT`` — the sentinel
+    that makes every RTCM matrix write queue a step warning, the only
+    way to reach the GPS page's warning strip without a real producer.
+    """
+    try:
+        httpx.post(f"{api_base_url}/api/device/disconnect", timeout=5.0)
+    except Exception:
+        pass
+
+    payload = {
+        "vendor": "fake",
+        "port": FAKE_FLASH_DIVERGENCE_PORT,
+        "baud_rate": 115200,
+    }
+    resp = httpx.post(f"{api_base_url}/api/device/connect", json=payload, timeout=10.0)
+    if resp.status_code not in (200, 409):
+        raise RuntimeError(
+            f"Could not connect FakeGpsDriver (flash-divergence): "
+            f"HTTP {resp.status_code} — {resp.text}"
+        )
+    try:
+        yield
+    finally:
+        try:
+            httpx.post(f"{api_base_url}/api/device/disconnect", timeout=5.0)
+        except Exception:
+            pass
+
+
+def _goto_gps_config(page: Page, base_url: str) -> None:
+    page.goto(f"{base_url}/gps-config")
+    expect(page.locator("text=Advanced GPS Configuration").first).to_be_visible(
+        timeout=15_000
+    )
+
+
+@pytest.mark.e2e
+def test_warning_strip_shows_one_line_per_warning_and_headline_counts_it(
+    page: Page,
+    base_url: str,
+    connected_gps_flash_divergence: None,
+) -> None:
+    _goto_gps_config(page, base_url)
+
+    # Toggle a matrix cell so the rtcm_matrix step actually runs.
+    page.locator(".rtcm-cell-1077-UART2").click()
+    page.get_by_role("button", name="Apply").click()
+
+    expect(page.locator(".warning-strip")).to_be_visible(timeout=10_000)
+    lines = page.locator(".warning-strip-line")
+    expect(lines).to_have_count(1)
+    expect(lines.first).to_contain_text("flash")
+
+    headline = page.locator(".apply-result")
+    expect(headline).to_contain_text("Applied and verified", timeout=10_000)
+    expect(headline).to_contain_text("1 warning")
+
+
+@pytest.mark.e2e
+def test_warning_strip_is_replaced_not_accumulated(
+    page: Page,
+    base_url: str,
+    connected_gps_flash_divergence: None,
+) -> None:
+    """A step that warned on the previous Apply retries (rather than
+    being skipped) and so warns again — the strip still shows exactly
+    one line, proving it was replaced rather than appended to."""
+    _goto_gps_config(page, base_url)
+
+    page.locator(".rtcm-cell-1077-UART2").click()
+    page.get_by_role("button", name="Apply").click()
+    lines = page.locator(".warning-strip-line")
+    expect(lines).to_have_count(1, timeout=10_000)
+
+    page.get_by_role("button", name="Apply").click()
+    expect(page.locator(".apply-result")).to_contain_text(
+        "Applied and verified", timeout=10_000
+    )
+    expect(lines).to_have_count(1)
+
+
+@pytest.mark.e2e
+def test_warning_strip_clears_on_disconnect(
+    page: Page,
+    base_url: str,
+    connected_gps_flash_divergence: None,
+) -> None:
+    _goto_gps_config(page, base_url)
+
+    page.locator(".rtcm-cell-1077-UART2").click()
+    page.get_by_role("button", name="Apply").click()
+    expect(page.locator(".warning-strip-line")).to_have_count(1, timeout=10_000)
+
+    # Disconnect alone proves the clear — the elements are actually
+    # removed from the DOM (``.clear()``), not merely hidden behind
+    # ``config_card``'s visibility toggle. Reconnecting through the UI
+    # port dropdown is deliberately avoided elsewhere in this suite
+    # (see ``test_gps_config_buttons.py``) as brittle and no extra
+    # coverage over what the REST-driven fixtures already exercise.
+    page.get_by_role("button", name="Disconnect").click()
+    expect(page.locator("text=Disconnected").first).to_be_visible(timeout=10_000)
+    expect(page.locator(".warning-strip-line")).to_have_count(0)
+
+
+@pytest.mark.e2e
+def test_step_log_is_append_only_across_applies(
+    page: Page,
+    base_url: str,
+    connected_gps: None,
+) -> None:
+    _goto_gps_config(page, base_url)
+
+    page.locator(".rtcm-cell-1077-UART2").click()
+    page.get_by_role("button", name="Apply").click()
+    expect(page.locator(".apply-result")).to_contain_text(
+        "Applied and verified", timeout=10_000
+    )
+
+    # ``APPLY_STEPS`` is a fixed 8-step sequence — every Apply appends
+    # exactly one ``ApplyStepResult`` per step, whatever its outcome.
+    steps_per_apply = 8
+    log = page.locator(".step-log")
+    expect(log.locator(".step-log-entry")).to_have_count(steps_per_apply)
+
+    page.locator(".rtcm-cell-1077-UART1").click()
+    page.get_by_role("button", name="Apply").click()
+    expect(page.locator(".apply-result")).to_contain_text(
+        "Applied and verified", timeout=10_000
+    )
+
+    # Append-only: the second Apply's steps land on top of the first's,
+    # never replacing them.
+    expect(log.locator(".step-log-entry")).to_have_count(steps_per_apply * 2)
+
+
+@pytest.mark.e2e
+def test_step_log_clears_on_disconnect(
+    page: Page,
+    base_url: str,
+    connected_gps: None,
+) -> None:
+    _goto_gps_config(page, base_url)
+
+    page.locator(".rtcm-cell-1077-UART2").click()
+    page.get_by_role("button", name="Apply").click()
+    expect(page.locator(".apply-result")).to_contain_text(
+        "Applied and verified", timeout=10_000
+    )
+    expect(page.locator(".step-log-entry").first).to_be_visible(timeout=10_000)
+
+    page.get_by_role("button", name="Disconnect").click()
+    expect(page.locator("text=Disconnected").first).to_be_visible(timeout=10_000)
+    expect(page.locator(".step-log-entry")).to_have_count(0)
+
+
+@pytest.mark.e2e
+def test_pending_badge_pluralises_with_multiple_edits(
+    page: Page,
+    base_url: str,
+    connected_gps: None,
+) -> None:
+    """Two independent edits -> "2 unapplied changes", neutral colour."""
+    _goto_gps_config(page, base_url)
+
+    sync_badge = page.locator(".sync-badge")
+    expect(sync_badge).to_have_text("In sync", timeout=10_000)
+
+    page.locator(".rtcm-cell-1077-UART2").click()
+    page.locator(".gnss-checkbox-sbas").click()
+
+    expect(sync_badge).to_have_text("2 unapplied changes")

--- a/tests/e2e/test_gps_result_surfaces.py
+++ b/tests/e2e/test_gps_result_surfaces.py
@@ -87,6 +87,13 @@ def test_warning_strip_shows_one_line_per_warning_and_headline_counts_it(
     expect(lines).to_have_count(1)
     expect(lines.first).to_contain_text("flash")
 
+    # The remedy is the Apply button already in the action row — named
+    # explicitly, and no second button anywhere in the strip.
+    expect(page.locator(".warning-strip-remedy")).to_contain_text(
+        "Press Apply to retry"
+    )
+    expect(page.locator(".warning-strip button")).to_have_count(0)
+
     headline = page.locator(".apply-result")
     expect(headline).to_contain_text("Applied and verified", timeout=10_000)
     expect(headline).to_contain_text("1 warning")

--- a/tests/unit/test_fake_driver.py
+++ b/tests/unit/test_fake_driver.py
@@ -54,6 +54,7 @@ from sp_rtk_base.models.device_models import (
 )
 from sp_rtk_base.services.drivers.base import GpsReceiverDriver
 from sp_rtk_base.services.drivers.fake import (
+    FAKE_FLASH_DIVERGENCE_PORT,
     FAKE_PORT_LABEL,
     FakeGpsDriver,
 )
@@ -456,7 +457,9 @@ class TestConfigurationRoundTrips:
     def test_drain_warnings_is_always_empty(
         self, connected_driver: FakeGpsDriver
     ) -> None:
-        """No producer is wired up on the fake driver yet (issue #99)."""
+        """No producer is wired up by default (issue #99) — only the
+        flash-divergence sentinel (issue #101, see
+        ``TestFlashDivergenceSentinel``) queues anything."""
         assert connected_driver.drain_warnings() == []
         connected_driver.configure_baud(115200, None)
         assert connected_driver.drain_warnings() == []
@@ -518,6 +521,53 @@ class TestConfigurationRoundTrips:
     ) -> None:
         with pytest.raises(ConnectionError):
             driver.get_receiver_scalars()
+
+
+# ---------------------------------------------------------------------------
+# Flash-divergence sentinel (issue #101)
+# ---------------------------------------------------------------------------
+
+
+class TestFlashDivergenceSentinel:
+    """``FAKE_FLASH_DIVERGENCE_PORT`` — the only way to reach the GPS
+    page's warning strip without a real warning producer."""
+
+    def test_normal_connect_never_warns_on_rtcm_write(
+        self, driver: FakeGpsDriver
+    ) -> None:
+        driver.connect(FAKE_PORT_LABEL, 115200)
+        driver.apply_rtcm_matrix({RtcmRowId.RTCM_1005: {PortId.UART1: True}})
+        assert driver.drain_warnings() == []
+
+    def test_sentinel_connect_queues_a_warning_on_rtcm_write(
+        self, driver: FakeGpsDriver
+    ) -> None:
+        driver.connect(FAKE_FLASH_DIVERGENCE_PORT, 115200)
+        driver.apply_rtcm_matrix({RtcmRowId.RTCM_1005: {PortId.UART1: True}})
+        warnings = driver.drain_warnings()
+        assert len(warnings) == 1
+        assert "flash" in warnings[0].lower()
+
+    def test_drain_clears_the_queue(self, driver: FakeGpsDriver) -> None:
+        driver.connect(FAKE_FLASH_DIVERGENCE_PORT, 115200)
+        driver.apply_rtcm_matrix({RtcmRowId.RTCM_1005: {PortId.UART1: True}})
+        assert driver.drain_warnings() != []
+        assert driver.drain_warnings() == []
+
+    def test_every_write_queues_another_warning(self, driver: FakeGpsDriver) -> None:
+        driver.connect(FAKE_FLASH_DIVERGENCE_PORT, 115200)
+        driver.apply_rtcm_matrix({RtcmRowId.RTCM_1005: {PortId.UART1: True}})
+        driver.apply_rtcm_matrix({RtcmRowId.RTCM_1005: {PortId.UART1: False}})
+        assert len(driver.drain_warnings()) == 2
+
+    def test_writes_other_than_rtcm_still_round_trip_cleanly(
+        self, driver: FakeGpsDriver
+    ) -> None:
+        """The sentinel only taints RTCM matrix writes — other writes
+        stay honest."""
+        driver.connect(FAKE_FLASH_DIVERGENCE_PORT, 115200)
+        driver.configure_baud(115200, None)
+        assert driver.drain_warnings() == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_gps_config_helpers.py
+++ b/tests/unit/test_gps_config_helpers.py
@@ -34,6 +34,8 @@ from sp_rtk_base.models.hardware_identity import (
 )
 from sp_rtk_base.models.profile_models import (
     ApplyDiffEntry,
+    ApplyStepResult,
+    ApplyStepWarning,
     BaudAssertion,
     PortProtocolSet,
     Profile,
@@ -47,7 +49,12 @@ from sp_rtk_base.ui.pages.gps_config import (
     MATRIX_PORTS,
     REQUIRED_RTCM_ROW,
     SELECTABLE_TMODE_MODES,
+    ResultBadgeState,
     apply_blocked_reason,
+    apply_headline,
+    apply_warning_lines,
+    badge_color,
+    badge_label,
     bds_b2_control_disabled,
     build_apply_request,
     build_picker_entries,
@@ -55,15 +62,18 @@ from sp_rtk_base.ui.pages.gps_config import (
     display_label,
     fixed_position_step_state,
     format_leaf_diff,
+    format_step_log_entry,
     i2c_spi_advisory_rows,
     infer_data_link_ports,
     is_modified_from_profile,
     matrix_cell_on,
+    partition_diff_by_provenance,
     receiver_config_from_profile,
     resolve_gnss_display,
     resolve_identity,
     resolve_ports_display,
     resolve_save_hardware,
+    result_badge_state,
     row_slug,
     rtcm_config_to_matrix,
     save_as_enabled,
@@ -677,3 +687,159 @@ class TestFixedPositionStepState:
             SurveyInProgress(active=True, valid=False),
         )
         assert state.current_step == 3
+
+
+def _diff(path: str) -> ApplyDiffEntry:
+    return ApplyDiffEntry(path=path, expected=True, actual=False)
+
+
+class TestPartitionDiffByProvenance:
+    """Issue #101: failed = in the last apply's diff and not edited since."""
+
+    def test_empty_diff_is_empty_both_ways(self) -> None:
+        failed, pending = partition_diff_by_provenance([], {"meas_period_ms"})
+        assert failed == []
+        assert pending == []
+
+    def test_path_in_failed_set_is_failed(self) -> None:
+        diff = [_diff("meas_period_ms")]
+        failed, pending = partition_diff_by_provenance(diff, {"meas_period_ms"})
+        assert failed == diff
+        assert pending == []
+
+    def test_path_not_in_failed_set_is_pending(self) -> None:
+        diff = [_diff("meas_period_ms")]
+        failed, pending = partition_diff_by_provenance(diff, set())
+        assert failed == []
+        assert pending == diff
+
+    def test_mixed_diff_splits_by_path(self) -> None:
+        failed_entry = _diff("meas_period_ms")
+        pending_entry = _diff("elevation_mask_deg")
+        failed, pending = partition_diff_by_provenance(
+            [failed_entry, pending_entry], {"meas_period_ms"}
+        )
+        assert failed == [failed_entry]
+        assert pending == [pending_entry]
+
+    def test_a_path_no_longer_in_the_diff_is_simply_absent(self) -> None:
+        """Editing a field back to match live removes its diff entry
+        entirely — it doesn't linger as failed just because the path is
+        still in ``failed_paths``."""
+        failed, pending = partition_diff_by_provenance([], {"meas_period_ms"})
+        assert failed == []
+        assert pending == []
+
+
+class TestResultBadgeState:
+    def test_no_diff_is_in_sync(self) -> None:
+        state = result_badge_state([], [])
+        assert state == ResultBadgeState(kind="in_sync", count=0)
+
+    def test_pending_only_is_neutral(self) -> None:
+        state = result_badge_state([], [_diff("a"), _diff("b")])
+        assert state == ResultBadgeState(kind="pending", count=2)
+
+    def test_failed_only_is_warning(self) -> None:
+        state = result_badge_state([_diff("a")], [])
+        assert state == ResultBadgeState(kind="failed", count=1)
+
+    def test_failed_takes_priority_over_pending(self) -> None:
+        """Verification failure takes priority — the badge never shows
+        the pending count once any field has failed."""
+        state = result_badge_state([_diff("a")], [_diff("b"), _diff("c")])
+        assert state == ResultBadgeState(kind="failed", count=1)
+
+
+class TestBadgeLabel:
+    def test_in_sync(self) -> None:
+        assert badge_label(ResultBadgeState(kind="in_sync", count=0)) == "In sync"
+
+    def test_pending_singular(self) -> None:
+        text = badge_label(ResultBadgeState(kind="pending", count=1))
+        assert text == "1 unapplied change"
+
+    def test_pending_plural(self) -> None:
+        text = badge_label(ResultBadgeState(kind="pending", count=3))
+        assert text == "3 unapplied changes"
+
+    def test_failed_singular(self) -> None:
+        text = badge_label(ResultBadgeState(kind="failed", count=1))
+        assert text == "1 field failed verification"
+
+    def test_failed_plural(self) -> None:
+        text = badge_label(ResultBadgeState(kind="failed", count=2))
+        assert text == "2 fields failed verification"
+
+
+class TestBadgeColor:
+    def test_in_sync_is_positive(self) -> None:
+        assert badge_color(ResultBadgeState(kind="in_sync", count=0)) == "positive"
+
+    def test_pending_is_neutral_not_amber(self) -> None:
+        color = badge_color(ResultBadgeState(kind="pending", count=1))
+        assert color == "grey-7"
+        assert color != "warning"
+
+    def test_failed_is_warning(self) -> None:
+        assert badge_color(ResultBadgeState(kind="failed", count=1)) == "warning"
+
+
+class TestApplyHeadline:
+    def test_ok_with_no_warnings(self) -> None:
+        assert apply_headline("ok", 0) == "Applied and verified ✓"
+
+    def test_failed_with_no_warnings(self) -> None:
+        text = apply_headline("failed", 0)
+        assert "verification found mismatches" in text
+        assert "warning" not in text
+
+    def test_ok_carries_a_neutral_warning_count(self) -> None:
+        text = apply_headline("ok", 1)
+        assert text.startswith("Applied and verified ✓")
+        assert "1 warning" in text
+
+    def test_warning_count_pluralises(self) -> None:
+        assert "2 warnings" in apply_headline("ok", 2)
+
+
+class TestApplyWarningLines:
+    def test_no_warnings_is_empty(self) -> None:
+        assert apply_warning_lines([], []) == []
+
+    def test_plain_warnings_pass_through_unprefixed(self) -> None:
+        lines = apply_warning_lines(["estimated throughput exceeds baud"], [])
+        assert lines == ["estimated throughput exceeds baud"]
+
+    def test_step_warnings_are_prefixed_with_their_step(self) -> None:
+        lines = apply_warning_lines(
+            [], [ApplyStepWarning(step="rtcm_matrix", message="flash mismatch")]
+        )
+        assert lines == ["rtcm_matrix: flash mismatch"]
+
+    def test_never_joins_into_one_string(self) -> None:
+        """One line per warning — never a string-joined toast blob."""
+        lines = apply_warning_lines(
+            ["a"],
+            [
+                ApplyStepWarning(step="ports", message="b"),
+                ApplyStepWarning(step="baud", message="c"),
+            ],
+        )
+        assert lines == ["a", "ports: b", "baud: c"]
+
+
+class TestFormatStepLogEntry:
+    def test_ok_step(self) -> None:
+        text = format_step_log_entry(ApplyStepResult(step="dyn_model", status="ok"))
+        assert text == "✓ dyn_model: ok"
+
+    def test_failed_step(self) -> None:
+        text = format_step_log_entry(ApplyStepResult(step="baud", status="failed"))
+        assert text == "✗ baud: failed"
+
+    def test_skipped_step(self) -> None:
+        text = format_step_log_entry(
+            ApplyStepResult(step="constellations", status="skipped")
+        )
+        assert text == "— constellations: skipped"

--- a/tests/unit/test_gps_config_helpers.py
+++ b/tests/unit/test_gps_config_helpers.py
@@ -25,6 +25,7 @@ from sp_rtk_base.models.device_models import (
     RtcmPortConfig,
     RtcmRowId,
     SurveyInProgress,
+    UbxProtocol,
 )
 from sp_rtk_base.models.hardware_identity import (
     HARDWARE_ANY,
@@ -42,6 +43,7 @@ from sp_rtk_base.models.profile_models import (
     ReceiverApplyRequest,
     ReceiverAssertion,
     RtcmStreamConfig,
+    diff_receiver_assertions,
     merge_profile_into_assertion,
 )
 from sp_rtk_base.services.profile_store import ProfileStore
@@ -59,6 +61,7 @@ from sp_rtk_base.ui.pages.gps_config import (
     build_apply_request,
     build_picker_entries,
     build_saved_profile,
+    constellation_diff_path,
     display_label,
     fixed_position_step_state,
     format_leaf_diff,
@@ -68,6 +71,7 @@ from sp_rtk_base.ui.pages.gps_config import (
     is_modified_from_profile,
     matrix_cell_on,
     partition_diff_by_provenance,
+    port_protocol_diff_path,
     receiver_config_from_profile,
     resolve_gnss_display,
     resolve_identity,
@@ -76,6 +80,7 @@ from sp_rtk_base.ui.pages.gps_config import (
     result_badge_state,
     row_slug,
     rtcm_config_to_matrix,
+    rtcm_diff_path,
     save_as_enabled,
     suggest_profile_name,
     tmode_mode_locked,
@@ -729,6 +734,59 @@ class TestPartitionDiffByProvenance:
         failed, pending = partition_diff_by_provenance([], {"meas_period_ms"})
         assert failed == []
         assert pending == []
+
+
+class TestDiffPathBuildersMatchDiffReceiverAssertions:
+    """The three path builders that back every ``_clear_failed``/
+    ``_mark_mismatch`` call site for enum-keyed fields (issue #101) must
+    build exactly the path ``diff_receiver_assertions`` itself emits —
+    a mismatch here would silently leave a mutation handler unable to
+    clear its own field's failed marker. Round-tripped through the real
+    diff function rather than hand-asserted, so a future change to
+    either side is caught."""
+
+    def test_rtcm_cell_path_matches(self) -> None:
+        expected = _minimal_form()
+        actual = expected.model_copy(deep=True)
+        actual.rtcm_stream.matrix[RtcmRowId.RTCM_1077][PortId.UART2] = True
+
+        diff = diff_receiver_assertions(expected, actual)
+        assert len(diff) == 1
+        assert diff[0].path == rtcm_diff_path(RtcmRowId.RTCM_1077, PortId.UART2)
+
+    def test_port_protocol_in_path_matches(self) -> None:
+        expected = _minimal_form()
+        actual = expected.model_copy(deep=True)
+        actual.ports[PortId.UART1] = PortProtocolSet(
+            **{"in": [UbxProtocol.RTCM3X], "out": []}
+        )
+
+        diff = diff_receiver_assertions(expected, actual)
+        assert len(diff) == 1
+        assert diff[0].path == port_protocol_diff_path(
+            PortId.UART1, "in", UbxProtocol.RTCM3X
+        )
+
+    def test_port_protocol_out_path_matches(self) -> None:
+        expected = _minimal_form()
+        actual = expected.model_copy(deep=True)
+        actual.ports[PortId.UART2] = PortProtocolSet(
+            **{"in": [], "out": [UbxProtocol.NMEA]}
+        )
+
+        diff = diff_receiver_assertions(expected, actual)
+        assert len(diff) == 1
+        assert diff[0].path == port_protocol_diff_path(
+            PortId.UART2, "out", UbxProtocol.NMEA
+        )
+
+    def test_constellation_path_matches(self) -> None:
+        expected = _minimal_form()
+        actual = expected.model_copy(update={"constellations": [GnssConstellation.GPS]})
+
+        diff = diff_receiver_assertions(expected, actual)
+        assert len(diff) == 1
+        assert diff[0].path == constellation_diff_path(GnssConstellation.GPS)
 
 
 class TestResultBadgeState:


### PR DESCRIPTION
## Summary

Closes #101. The Advanced GPS page's result surfaces so the operator can tell what the receiver holds and what just happened:

- **Three-state badge**: `In sync` / `n unapplied change(s)` (neutral — the resting state of an editable form) / `n field(s) failed verification` (warning, takes priority). Split by provenance: a field is *failed* only if it appears in the last Apply's diff and hasn't been edited since; anything else that differs is a *pending* edit. The badge's count always covers exactly the set Apply asserts.
- **Inline markers**: failed fields get an amber ring + tooltip on their own widget (matrix cells, checkboxes, selects), replacing the old prose diff list.
- **Headline verdict line** with a neutral warning count alongside it.
- **Session-only, append-only step log** rendering every Apply's per-step outcomes in order.
- **Warning strip** (Survey page's amber-card idiom) — one `⚠` line per warning, replaced whole on each Apply, "Press Apply to retry." remedy text, no second button. Both the log and the strip clear on disconnect.
- `FakeGpsDriver` gains a `FAKE_FLASH_DIVERGENCE_PORT` sentinel so the strip is e2e-testable without a real warning producer, mirroring `UbloxDriver`'s own flash-divergence warning shape.

A follow-up commit addresses two gaps a `/code-review` pass caught: missing "press Apply to retry" remedy copy on the strip, and diff-path strings that were hand-built and duplicated at ~12 call sites with no verification they matched `diff_receiver_assertions`'s own format — now three shared path-builder functions, round-tripped against the real diff function in unit tests.

## Test plan

- [x] `uv run pytest` — 1510 unit tests pass, 93.8% coverage (gate is 90%)
- [x] `uv run pyright src/` — 0 errors (strict)
- [x] `uv run mypy src/` — 0 errors (strict)
- [x] `uv run ruff check` / `ruff format --check` — clean
- [x] `SP_RTK_BASE_FAKE_GPS=1 uv run pytest tests/e2e -k gps` — 48 passed
- [ ] Manual smoke test in a browser (not run this session)

Note: `test_gps_apply.py::test_factory_receiver_blocks_apply_until_data_link_port_chosen` flakes at ~20% under heavy parallel-browser load in this dev sandbox. It's untouched by this diff and passes reliably standalone (confirmed both before and after these changes) — looks like pre-existing environmental flakiness, not a regression, but worth knowing about if CI shows it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AcBmmcpcJtBBxvDE8M3C6p