### PR TITLE
Throughput advisory becomes a live form-derived advisory

### DIFF
--- a/src/sp_rtk_base/models/profile_models.py
+++ b/src/sp_rtk_base/models/profile_models.py
@@ -617,12 +617,14 @@ class ApplyConfigResult(BaseModel):
     their live state from it whether ``status`` is ``"ok"`` or
     ``"failed"``, since the writes land either way (or didn't run at
     all — a failed or skipped step still leaves ``read_back`` as the
-    truth of what the receiver holds). ``warnings`` carries
-    non-blocking advisories (e.g. the estimated-throughput check) that
-    never affect ``status``. ``steps`` reports every write step's
-    outcome in execution order (issue #99); ``step_warnings`` carries
-    the driver's step-tagged warning channel, distinct from
-    ``warnings`` — see :class:`ApplyStepWarning`.
+    truth of what the receiver holds). ``steps`` reports every write
+    step's outcome in execution order (issue #99); ``step_warnings``
+    carries the driver's step-tagged warning channel — the one thing
+    left in this result's warning channel: a post-write observation
+    the sync check can't express (issue #102 moved the other warning
+    this used to carry, the estimated-throughput advisory, to a live,
+    form-derived caption on the Advanced GPS page instead, since there
+    was no consumer of it here — see :class:`ApplyStepWarning`).
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -630,7 +632,6 @@ class ApplyConfigResult(BaseModel):
     status: Literal["ok", "failed"]
     read_back: ReceiverAssertion
     diff: list[ApplyDiffEntry] = Field(default_factory=lambda: list[ApplyDiffEntry]())
-    warnings: list[str] = Field(default_factory=lambda: list[str]())
     steps: list[ApplyStepResult] = Field(
         default_factory=lambda: list[ApplyStepResult]()
     )

--- a/src/sp_rtk_base/services/device_service.py
+++ b/src/sp_rtk_base/services/device_service.py
@@ -30,7 +30,6 @@ from sp_rtk_base.models.device_models import (
     ReceiverScalarConfig,
     RtcmOutputPort,
     RtcmPortConfig,
-    RtcmRowId,
     SurveyInConfig,
     SurveyInProgress,
     UbxProtocol,
@@ -97,39 +96,6 @@ class ApplyConfigLinkLostError(Exception):
         )
 
 
-# ---------------------------------------------------------------------------
-# Non-blocking RTCM throughput estimate (issue #61)
-#
-# Approximate typical RTCM3 frame sizes in bytes at a moderate satellite
-# count. These are estimates for a heads-up warning only — not exact
-# wire measurements — so precision beyond "roughly right" isn't the
-# goal. MSM4/MSM7 sizes scale with tracked satellite count; the values
-# below assume a typical 8-12 satellites per constellation.
-# ---------------------------------------------------------------------------
-
-_APPROX_RTCM_FRAME_BYTES: dict[RtcmRowId, int] = {
-    RtcmRowId.RTCM_1005: 19,
-    RtcmRowId.RTCM_4072_0: 72,
-    RtcmRowId.RTCM_4072_1: 40,
-    RtcmRowId.RTCM_1074: 150,
-    RtcmRowId.RTCM_1077: 300,
-    RtcmRowId.RTCM_1084: 130,
-    RtcmRowId.RTCM_1087: 260,
-    RtcmRowId.RTCM_1094: 120,
-    RtcmRowId.RTCM_1097: 240,
-    RtcmRowId.RTCM_1124: 130,
-    RtcmRowId.RTCM_1127: 260,
-    RtcmRowId.RTCM_1230: 25,
-}
-
-# 8N1 serial framing: ~10 bits on the wire per payload byte (1 start +
-# 8 data + 1 stop), so baud / 10 approximates byte capacity per second.
-_BITS_PER_BYTE_ON_WIRE = 10.0
-
-# Warn once estimated RTCM throughput crosses this fraction of a
-# data-link port's baud capacity.
-_THROUGHPUT_WARN_THRESHOLD = 0.70
-
 # The built-in profile whose ``ports``/``dyn_model``/``rtcm_stream``
 # values define "the base invariants" for the survey-in pre-flight
 # check (issue #63) and its one-click remedy. There is exactly one
@@ -137,44 +103,6 @@ _THROUGHPUT_WARN_THRESHOLD = 0.70
 # test_imports_cleanly_with_exactly_one_builtin) and it is the base
 # station reference profile.
 _BASE_INVARIANTS_PROFILE_NAME = "ublox-f9p-base-standard"
-
-
-def _throughput_warnings(
-    assertion: ReceiverAssertion,
-    data_link_port: list[PortId],
-    baud_rates: dict[PortId, int],
-) -> list[str]:
-    """Non-blocking advisories when estimated RTCM output nears port capacity.
-
-    Takes the whole ``ReceiverAssertion`` plus *data_link_port*
-    separately — ``data_link_port`` has no CFG key and isn't part of
-    the assertion (issue #98), but the check still needs it alongside
-    ``rtcm_stream.matrix`` and ``meas_period_ms``.
-    """
-    matrix = assertion.rtcm_stream.matrix
-    hz = 1000.0 / assertion.meas_period_ms
-    warnings: list[str] = []
-    for port in data_link_port:
-        baud = baud_rates.get(port)
-        if not baud:
-            continue
-        bytes_per_sec = (
-            sum(
-                _APPROX_RTCM_FRAME_BYTES.get(row, 0)
-                for row, ports in matrix.items()
-                if ports.get(port, False)
-            )
-            * hz
-        )
-        capacity_bytes_per_sec = baud / _BITS_PER_BYTE_ON_WIRE
-        fraction = bytes_per_sec / capacity_bytes_per_sec
-        if fraction > _THROUGHPUT_WARN_THRESHOLD:
-            warnings.append(
-                f"Estimated RTCM throughput on {port.value} is "
-                f"~{round(fraction * 100)}% of its {baud} baud capacity "
-                "— consider a higher baud rate or fewer messages."
-            )
-    return warnings
 
 
 def build_receiver_assertion(
@@ -970,9 +898,8 @@ class DeviceService:
         changed UART2 baud never triggers a reopen — it isn't the port
         this console is on.
 
-        After the writes land, a non-blocking throughput estimate
-        checks each ``data_link_port`` against its live baud rate, and
-        a fresh full read-back (:meth:`get_receiver_assertion`) is
+        After the writes land, a fresh full read-back
+        (:meth:`get_receiver_assertion`) is
         diffed per-leaf against *request.assertion*
         (:func:`profile_models.diff_receiver_assertions`) to decide
         ``status``: any mismatch returns ``status="failed"`` with the
@@ -1085,9 +1012,6 @@ class DeviceService:
         if new_uart1 is not None:
             await self._reopen_after_baud_write(driver, new_uart1)
 
-        baud_rates = await asyncio.to_thread(driver.get_uart_baud_rates)
-        warnings = _throughput_warnings(assertion, request.data_link_port, baud_rates)
-
         read = await self.get_receiver_assertion()
         diff = diff_receiver_assertions(assertion, read.assertion)
         if diff:
@@ -1098,7 +1022,6 @@ class DeviceService:
                 status="failed",
                 read_back=read.assertion,
                 diff=diff,
-                warnings=warnings,
                 steps=steps,
                 step_warnings=step_warnings,
             )
@@ -1107,7 +1030,6 @@ class DeviceService:
         return ApplyConfigResult(
             status="ok",
             read_back=read.assertion,
-            warnings=warnings,
             steps=steps,
             step_warnings=step_warnings,
         )

--- a/src/sp_rtk_base/ui/pages/gps_config.py
+++ b/src/sp_rtk_base/ui/pages/gps_config.py
@@ -147,6 +147,40 @@ _ADVISORY_PORTS: tuple[RtcmOutputPort, ...] = (RtcmOutputPort.I2C, RtcmOutputPor
 #: The one row every base profile must carry on a data-link port.
 REQUIRED_RTCM_ROW: RtcmRowId = RtcmRowId.RTCM_1005
 
+# ---------------------------------------------------------------------------
+# Live throughput advisory (issue #102, formerly a post-Apply toast —
+# see issue #61 for the original placement).
+#
+# Approximate typical RTCM3 frame sizes in bytes at a moderate satellite
+# count. These are estimates for a heads-up warning only — not exact
+# wire measurements — so precision beyond "roughly right" isn't the
+# goal. MSM4/MSM7 sizes scale with tracked satellite count; the values
+# below assume a typical 8-12 satellites per constellation.
+# ---------------------------------------------------------------------------
+
+_APPROX_RTCM_FRAME_BYTES: dict[RtcmRowId, int] = {
+    RtcmRowId.RTCM_1005: 19,
+    RtcmRowId.RTCM_4072_0: 72,
+    RtcmRowId.RTCM_4072_1: 40,
+    RtcmRowId.RTCM_1074: 150,
+    RtcmRowId.RTCM_1077: 300,
+    RtcmRowId.RTCM_1084: 130,
+    RtcmRowId.RTCM_1087: 260,
+    RtcmRowId.RTCM_1094: 120,
+    RtcmRowId.RTCM_1097: 240,
+    RtcmRowId.RTCM_1124: 130,
+    RtcmRowId.RTCM_1127: 260,
+    RtcmRowId.RTCM_1230: 25,
+}
+
+# 8N1 serial framing: ~10 bits on the wire per payload byte (1 start +
+# 8 data + 1 stop), so baud / 10 approximates byte capacity per second.
+_BITS_PER_BYTE_ON_WIRE = 10.0
+
+# Warn once estimated RTCM throughput crosses this fraction of a
+# data-link port's baud capacity.
+_THROUGHPUT_WARN_THRESHOLD = 0.70
+
 
 # ---------------------------------------------------------------------------
 # Pure helpers — extracted for unit testing (see test_gps_config_helpers.py).
@@ -225,6 +259,51 @@ def i2c_spi_advisory_rows(rtcm: RtcmPortConfig) -> list[RtcmRowId]:
         for row_id in ALL_RTCM_MESSAGE_IDS
         if any(rtcm.is_enabled(row_id, p) for p in _ADVISORY_PORTS)
     ]
+
+
+def throughput_advisory_lines(
+    form: ReceiverAssertion, data_link_port: list[PortId]
+) -> list[str]:
+    """Non-blocking advisories when the form's estimated RTCM output nears
+    a data-link port's capacity (issue #102).
+
+    Live, form-derived sibling of :func:`i2c_spi_advisory_rows` — same
+    idiom (pure predicate here, a render helper plus a caption near the
+    matrix in the page closure), recomputed on every form edit rather
+    than only at seed. Reads the matrix and measurement rate straight
+    off *form*, and the baud off ``form.baud`` — the rate the operator
+    intends, not whatever the receiver's live baud happens to be. This
+    used to run post-Apply against a driver read of the just-written
+    baud (issue #61); that told the operator to undo something they'd
+    already committed. *data_link_port* has no CFG key and isn't part
+    of the assertion (issue #98), so it's still taken separately, same
+    as the RTCM-matrix code that infers it.
+    """
+    matrix = form.rtcm_stream.matrix
+    hz = 1000.0 / form.meas_period_ms
+    baud_by_port = {PortId.UART1: form.baud.uart1, PortId.UART2: form.baud.uart2}
+    lines: list[str] = []
+    for port in data_link_port:
+        baud = baud_by_port.get(port)
+        if not baud:
+            continue
+        bytes_per_sec = (
+            sum(
+                _APPROX_RTCM_FRAME_BYTES.get(row, 0)
+                for row, ports in matrix.items()
+                if ports.get(port, False)
+            )
+            * hz
+        )
+        capacity_bytes_per_sec = baud / _BITS_PER_BYTE_ON_WIRE
+        fraction = bytes_per_sec / capacity_bytes_per_sec
+        if fraction > _THROUGHPUT_WARN_THRESHOLD:
+            lines.append(
+                f"Estimated RTCM throughput on {port.value} is "
+                f"~{round(fraction * 100)}% of its {baud} baud capacity "
+                "— consider a higher baud rate or fewer messages."
+            )
+    return lines
 
 
 def rtcm_config_to_matrix(
@@ -614,13 +693,15 @@ def apply_headline(status: Literal["ok", "failed"], warning_count: int) -> str:
     return f"{verdict} ({warning_count} {_plural(warning_count, 'warning')})"
 
 
-def apply_warning_lines(
-    warnings: list[str], step_warnings: list[ApplyStepWarning]
-) -> list[str]:
+def apply_warning_lines(step_warnings: list[ApplyStepWarning]) -> list[str]:
     """One line per warning for the strip — never joined into a single
-    string. Step warnings are prefixed with the step that produced
-    them; the non-blocking throughput warnings need no prefix."""
-    return [*warnings, *(f"{w.step}: {w.message}" for w in step_warnings)]
+    string. Each line is prefixed with the step that produced it.
+
+    Issue #102 removed the apply result's other, unprefixed warning
+    channel (the estimated-throughput advisory, now a live caption on
+    the form instead) — ``step_warnings`` is the only source left.
+    """
+    return [f"{w.step}: {w.message}" for w in step_warnings]
 
 
 #: Icon per :class:`~sp_rtk_base.models.profile_models.ApplyStepResult`
@@ -951,6 +1032,18 @@ def gps_config_page() -> None:
                 .style("border: 1px solid #5a4520; border-radius: 4px")
             )
             advisory_label.set_visibility(False)
+
+            # Live throughput advisory (issue #102) — form-derived, so it
+            # can hold more than one line (one per data-link port nearing
+            # capacity), unlike the single-line I2C/SPI advisory above.
+            throughput_advisory_card = (
+                ui.card()
+                .classes("throughput-advisory w-full q-pa-sm q-mt-sm")
+                .style("background-color: #3a2a10")
+            )
+            throughput_advisory_card.set_visibility(False)
+            with throughput_advisory_card:
+                throughput_advisory_view = ui.column().classes("gap-0")
 
             ui.label("Data-Link Port(s)").classes("text-subtitle2 text-white q-mt-md")
             data_link_hint = ui.label("").classes(
@@ -1982,18 +2075,38 @@ def gps_config_page() -> None:
                 save_as_enabled(_current_form_request(), selected_profile, live)
             )
 
+        def _render_throughput_advisory() -> None:
+            """The live counterpart to ``_render_advisory`` (issue #102) —
+            purely form-derived, so (unlike the I2C/SPI advisory) it can
+            run from ``_on_form_changed`` on every edit, not just at seed."""
+            lines = throughput_advisory_lines(form, form_data_link_ports)
+            throughput_advisory_view.clear()
+            if not lines:
+                throughput_advisory_card.set_visibility(False)
+                return
+            throughput_advisory_card.set_visibility(True)
+            with throughput_advisory_view:
+                for line in lines:
+                    ui.label(line).classes(
+                        "throughput-advisory-line text-warning text-caption"
+                    )
+
         def _on_form_changed() -> None:
             """Recompute every reactive bit of the form after an edit.
 
             Includes the data-link picker so its "inferred from current
             RTCM state" hint stays current after a matrix toggle, not
-            just after a reseed.
+            just after a reseed. Also includes the throughput advisory
+            (issue #102) — it reacts to the same edits (matrix toggle,
+            meas-rate change, baud change, data-link-port toggle) as
+            everything else recomputed here.
             """
             _render_data_link_picker()
             _render_sync_indicator()
             _render_apply_gate()
             _render_modified_indicator()
             _render_save_as_gate()
+            _render_throughput_advisory()
 
         def _set_apply_result(text: str, *, ok: bool) -> None:
             apply_result_label.text = text
@@ -2103,7 +2216,7 @@ def gps_config_page() -> None:
             step_log.extend(result.steps)
             _render_step_log()
 
-            warning_lines = apply_warning_lines(result.warnings, result.step_warnings)
+            warning_lines = apply_warning_lines(result.step_warnings)
             _render_warning_strip(warning_lines)
 
             headline = apply_headline(result.status, len(warning_lines))

--- a/tests/unit/test_device_service.py
+++ b/tests/unit/test_device_service.py
@@ -620,10 +620,6 @@ class TestApplyReceiverConfig:
         )
         driver.get_port_protocols.return_value = PortProtocolConfig()
         driver.get_receiver_scalars.return_value = _scalars_for(_minimal_assertion())
-        driver.get_uart_baud_rates.return_value = {
-            PortId.UART1: 57600,
-            PortId.UART2: 115200,
-        }
         driver.drain_warnings.return_value = []
         # ``_make_mock_driver()`` defaults survey-in to active — most of
         # this class doesn't care, and an active survey would refuse
@@ -1130,49 +1126,6 @@ class TestApplyReceiverConfig:
         assert leaf.expected is True
         assert leaf.actual is False
 
-    @pytest.mark.asyncio()
-    async def test_throughput_warning_when_over_threshold(
-        self, connected_svc: DeviceService
-    ) -> None:
-        assert connected_svc.driver is not None
-        connected_svc.driver.get_uart_baud_rates.return_value = {  # type: ignore[union-attr]
-            PortId.UART1: 9600,
-            PortId.UART2: 115200,
-        }
-        heavy_matrix = RtcmStreamConfig(
-            matrix={
-                RtcmRowId.RTCM_1005: {PortId.UART1: True},
-                RtcmRowId.RTCM_1077: {PortId.UART1: True},
-                RtcmRowId.RTCM_1087: {PortId.UART1: True},
-                RtcmRowId.RTCM_1097: {PortId.UART1: True},
-            }
-        )
-        connected_svc.driver.get_rtcm_port_config.return_value = RtcmPortConfig(  # type: ignore[union-attr]
-            messages={
-                row: {"UART1": 1 if ports.get(PortId.UART1) else 0}
-                for row, ports in heavy_matrix.matrix.items()
-            }
-        )
-        request = _minimal_request(rtcm_stream=heavy_matrix)
-
-        result = await connected_svc.apply_receiver_config(request)
-
-        assert result.status == "ok"
-        assert len(result.warnings) == 1
-        assert "UART1" in result.warnings[0]
-
-    @pytest.mark.asyncio()
-    async def test_no_throughput_warning_under_threshold(
-        self, connected_svc: DeviceService
-    ) -> None:
-        assert connected_svc.driver is not None
-        connected_svc.driver.get_uart_baud_rates.return_value = {  # type: ignore[union-attr]
-            PortId.UART1: 115200,
-            PortId.UART2: 115200,
-        }
-        result = await connected_svc.apply_receiver_config(_minimal_request())
-        assert result.warnings == []
-
     # ------------------------------------------------------------------
     # Per-step outcomes, the service-side no-op, and the warning
     # channel (issue #99)
@@ -1588,10 +1541,6 @@ class TestBaseInvariants:
         per-step skip actually sees it as unchanged."""
         driver = connected_svc.driver
         assert driver is not None
-        driver.get_uart_baud_rates.return_value = {  # type: ignore[union-attr]
-            PortId.UART1: 9600,
-            PortId.UART2: 9600,
-        }
         driver.drain_warnings.return_value = []  # type: ignore[union-attr]
         # The built-in profile doesn't mention USB, so the merged
         # request's USB ports fall back to live — which must keep UBX

--- a/tests/unit/test_gps_config_helpers.py
+++ b/tests/unit/test_gps_config_helpers.py
@@ -83,6 +83,7 @@ from sp_rtk_base.ui.pages.gps_config import (
     rtcm_diff_path,
     save_as_enabled,
     suggest_profile_name,
+    throughput_advisory_lines,
     tmode_mode_locked,
 )
 
@@ -331,6 +332,69 @@ def _minimal_form() -> ReceiverAssertion:
             )
         ),
     )
+
+
+class TestThroughputAdvisoryLines:
+    """Live, form-derived counterpart to :func:`i2c_spi_advisory_rows`
+    (issue #102) — computed straight from the form the operator is
+    editing, never from a driver read. There is no receiver-read
+    parameter to fake here at all, which is the point."""
+
+    def _heavy_form(self, *, uart1_baud: int = 9600) -> ReceiverAssertion:
+        heavy_matrix = rtcm_config_to_matrix(
+            RtcmPortConfig(
+                messages={
+                    RtcmRowId.RTCM_1005: {"UART1": 1},
+                    RtcmRowId.RTCM_1077: {"UART1": 1},
+                    RtcmRowId.RTCM_1087: {"UART1": 1},
+                    RtcmRowId.RTCM_1097: {"UART1": 1},
+                }
+            )
+        )
+        return _minimal_form().model_copy(
+            update={
+                "baud": BaudAssertion(uart1=uart1_baud, uart2=115200),
+                "rtcm_stream": RtcmStreamConfig(matrix=heavy_matrix),
+            }
+        )
+
+    def test_no_data_link_ports_means_no_advisory(self) -> None:
+        assert throughput_advisory_lines(_minimal_form(), []) == []
+
+    def test_warns_when_estimated_output_exceeds_threshold(self) -> None:
+        lines = throughput_advisory_lines(self._heavy_form(), [PortId.UART1])
+        assert len(lines) == 1
+        assert "UART1" in lines[0]
+
+    def test_silent_under_threshold(self) -> None:
+        lines = throughput_advisory_lines(
+            self._heavy_form(uart1_baud=115200), [PortId.UART1]
+        )
+        assert lines == []
+
+    def test_computed_against_the_forms_baud(self) -> None:
+        """Same heavy matrix, only the form's intended baud changes —
+        proves the estimate tracks what the operator is about to send,
+        not some receiver state this function never reads."""
+        low_baud = throughput_advisory_lines(
+            self._heavy_form(uart1_baud=9600), [PortId.UART1]
+        )
+        high_baud = throughput_advisory_lines(
+            self._heavy_form(uart1_baud=921600), [PortId.UART1]
+        )
+        assert low_baud != []
+        assert high_baud == []
+
+    def test_port_not_carrying_rtcm_is_silent(self) -> None:
+        form = self._heavy_form()
+        assert throughput_advisory_lines(form, [PortId.UART2]) == []
+
+    def test_non_uart_port_with_no_baud_is_skipped(self) -> None:
+        """Mirrors USB's exclusion in the previous driver-baud version
+        (issue #61) — a port the form's ``BaudAssertion`` doesn't cover
+        is skipped rather than treated as zero-capacity."""
+        form = self._heavy_form()
+        assert throughput_advisory_lines(form, [PortId.USB]) == []
 
 
 class TestBuildApplyRequest:
@@ -862,29 +926,29 @@ class TestApplyHeadline:
 
 
 class TestApplyWarningLines:
-    def test_no_warnings_is_empty(self) -> None:
-        assert apply_warning_lines([], []) == []
+    """Issue #102 narrowed this to ``step_warnings`` alone — the apply
+    result's warning channel used to also carry the plain, unprefixed
+    estimated-throughput advisory, now a live caption on the form
+    instead (:func:`throughput_advisory_lines`)."""
 
-    def test_plain_warnings_pass_through_unprefixed(self) -> None:
-        lines = apply_warning_lines(["estimated throughput exceeds baud"], [])
-        assert lines == ["estimated throughput exceeds baud"]
+    def test_no_warnings_is_empty(self) -> None:
+        assert apply_warning_lines([]) == []
 
     def test_step_warnings_are_prefixed_with_their_step(self) -> None:
         lines = apply_warning_lines(
-            [], [ApplyStepWarning(step="rtcm_matrix", message="flash mismatch")]
+            [ApplyStepWarning(step="rtcm_matrix", message="flash mismatch")]
         )
         assert lines == ["rtcm_matrix: flash mismatch"]
 
     def test_never_joins_into_one_string(self) -> None:
         """One line per warning — never a string-joined toast blob."""
         lines = apply_warning_lines(
-            ["a"],
             [
                 ApplyStepWarning(step="ports", message="b"),
                 ApplyStepWarning(step="baud", message="c"),
             ],
         )
-        assert lines == ["a", "ports: b", "baud: c"]
+        assert lines == ["ports: b", "baud: c"]
 
 
 class TestFormatStepLogEntry:

--- a/tests/unit/test_profile_models.py
+++ b/tests/unit/test_profile_models.py
@@ -722,10 +722,9 @@ class TestDiffReceiverAssertions:
 
 
 class TestApplyConfigResult:
-    def test_ok_result_defaults_diff_and_warnings_empty(self) -> None:
+    def test_ok_result_defaults_diff_empty(self) -> None:
         result = ApplyConfigResult(status="ok", read_back=_base_assertion())
         assert result.diff == []
-        assert result.warnings == []
 
     def test_failed_result_carries_the_diff(self) -> None:
         entry = ApplyDiffEntry(path="meas_period_ms", expected=1000, actual=200)


### PR DESCRIPTION
## Summary
- The estimated-throughput advisory moves off the apply result and becomes a live, form-derived caption rendered near the RTCM matrix, following the same idiom as the existing I2C/SPI advisory (pure predicate at module level, small render helper, caption near the matrix).
- It recomputes on every form edit (matrix toggle, measurement-rate change, baud change) via the existing `_on_form_changed()` closure, instead of only appearing as a post-Apply toast — and it's computed against the baud the form holds (the operator's intent), not the receiver's live baud read back after the write already landed.
- `ApplyConfigResult.warnings` is removed entirely (no consumer left to move it to), leaving the apply result's warning channel carrying only `step_warnings` — a post-write observation the sync check can't express.

Closes #102

## Test plan
- [x] New pure-function unit tests: `TestThroughputAdvisoryLines` (6 cases) in `tests/unit/test_gps_config_helpers.py`
- [x] Updated `TestApplyWarningLines` and `TestApplyConfigResult` for the narrowed `warnings` channel
- [x] Removed obsolete `_throughput_warnings`-based tests in `tests/unit/test_device_service.py`
- [x] Full unit suite: 1513 passed, 93.81% coverage (gate: 90%)
- [x] `ruff check` / `ruff format --check`: clean
- [x] `pyright src/` (strict): 0 errors
- [x] `mypy` on changed files: clean
- [x] Code review (Standards + Spec axes, parallel sub-agents): 0 hard violations, 0 spec gaps

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AcBmmcpcJtBBxvDE8M3C6p