### PR TITLE
feat(gps): assertive per-constellation enable keys at the durable layer

### DIFF
--- a/src/sp_rtk_base/api/device.py
+++ b/src/sp_rtk_base/api/device.py
@@ -22,6 +22,7 @@ from sp_rtk_base.models.device_models import (
     DeviceStatus,
     FixedBaseConfig,
     GnssConfig,
+    GnssConstellationSelection,
     GpsPosition,
     PortProtocolConfig,
     RtcmPortConfig,
@@ -373,22 +374,25 @@ async def get_gnss_config(
 
 @router.put("/gnss", response_model=DeviceActionResponse)
 async def configure_gnss(
-    config: GnssConfig,
+    selection: GnssConstellationSelection,
     svc: DeviceService = Depends(get_device_service),
 ) -> DeviceActionResponse:
-    """Apply GNSS constellation configuration to the receiver.
+    """Assertively enable/disable satellite constellations on the receiver.
 
-    Enable/disable satellite systems and configure tracking channel allocation.
+    Writes the six per-constellation ``CFG_SIGNAL_*_ENA`` keys at the
+    durable layer (issue #104) — every constellation is written
+    explicitly, on for ``selection.constellations`` and off otherwise.
+    Channel allocation is left to the firmware; there is no channel
+    parameter here.
     """
     try:
-        await svc.configure_gnss(config)
+        await svc.configure_gnss(set(selection.constellations))
     except RuntimeError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 
-    enabled = config.enabled_constellations()
     return DeviceActionResponse(
         status="ok",
-        message=f"GNSS configured: {[c.value for c in enabled]}",
+        message=f"GNSS configured: {[c.value for c in selection.constellations]}",
     )
 
 

--- a/src/sp_rtk_base/models/device_models.py
+++ b/src/sp_rtk_base/models/device_models.py
@@ -406,6 +406,22 @@ class GnssConfig(BaseModel):
         return [s.constellation for s in self.systems if s.enabled]
 
 
+class GnssConstellationSelection(BaseModel):
+    """Wanted constellation set for the assertive enable-key write (issue #104).
+
+    The ``PUT /api/device/gnss`` request body — replaces the old
+    full-``GnssConfig`` payload now that the write targets six
+    ``CFG_SIGNAL_*_ENA`` keys directly rather than a CFG-GNSS block,
+    which carried per-system channel counts the new write never
+    touches (channel allocation is left to the firmware).
+    """
+
+    constellations: list[GnssConstellation] = Field(
+        default_factory=lambda: list[GnssConstellation](),
+        description="Constellations to enable; every other constellation is disabled",
+    )
+
+
 class ReceiverScalarConfig(BaseModel):
     """Every scalar (non-matrix, non-per-port) CFG value the Advanced GPS
     page's full receiver read needs — baud, measurement rate, dynamics
@@ -423,6 +439,12 @@ class ReceiverScalarConfig(BaseModel):
     meas_period_ms: int = Field(description="Measurement period in milliseconds")
     dyn_model: DynModel = Field(description="Dynamics platform model")
     tmode_mode: BaseMode = Field(description="Active base station mode")
+    constellations: list[GnssConstellation] = Field(
+        description=(
+            "Enabled constellations, read from the six CFG_SIGNAL_*_ENA "
+            "keys folded into this same batched poll (issue #104)"
+        )
+    )
     elevation_mask_deg: int = Field(description="Minimum satellite elevation, degrees")
     bds_b2_enabled: bool = Field(description="Whether the BeiDou B2 signal is enabled")
     spi_enabled: bool = Field(description="Whether the SPI interface is enabled")

--- a/src/sp_rtk_base/services/device_service.py
+++ b/src/sp_rtk_base/services/device_service.py
@@ -24,6 +24,7 @@ from sp_rtk_base.models.device_models import (
     DeviceStatus,
     FixedBaseConfig,
     GnssConfig,
+    GnssConstellation,
     GpsPosition,
     PortId,
     PortProtocolConfig,
@@ -108,15 +109,16 @@ _BASE_INVARIANTS_PROFILE_NAME = "ublox-f9p-base-standard"
 def build_receiver_assertion(
     rtcm: RtcmPortConfig,
     ports: PortProtocolConfig,
-    gnss: GnssConfig,
     scalars: ReceiverScalarConfig,
 ) -> ReceiverAssertion:
     """Compose a full live receiver read into one ``ReceiverAssertion``.
 
-    Pure — reshapes the driver's four already-fetched reads (RTCM
-    matrix, port protocols, GNSS constellations, the batched scalar
-    poll) into the schema the Advanced GPS page seeds ``form``/``live``
-    from (issue #97). No device I/O of its own.
+    Pure — reshapes the driver's three already-fetched reads (RTCM
+    matrix, port protocols, the batched scalar poll) into the schema
+    the Advanced GPS page seeds ``form``/``live`` from (issue #97).
+    Constellations come from ``scalars`` — the six ``CFG_SIGNAL_*_ENA``
+    keys folded into the batched poll (issue #104) — rather than a
+    separate GNSS block read. No device I/O of its own.
     """
     matrix = {
         row_id: {
@@ -134,7 +136,7 @@ def build_receiver_assertion(
     return ReceiverAssertion(
         baud=BaudAssertion(uart1=scalars.uart1_baud, uart2=scalars.uart2_baud),
         meas_period_ms=scalars.meas_period_ms,
-        constellations=gnss.enabled_constellations(),
+        constellations=scalars.constellations,
         ports=port_set,
         dyn_model=scalars.dyn_model,
         tmode_mode=scalars.tmode_mode,
@@ -146,23 +148,24 @@ def build_receiver_assertion(
 
 
 class ReceiverAssertionRead(NamedTuple):
-    """One ``get_receiver_assertion()`` read: the sync-set assertion, the
-    raw multi-port RTCM read-back the page's I2C/SPI advisory needs, and
-    the raw GNSS config the constellation apply-step needs (issue #99).
+    """One ``get_receiver_assertion()`` read: the sync-set assertion plus the
+    raw multi-port RTCM read-back the page's I2C/SPI advisory needs (issue #99).
 
     I2C/SPI aren't part of ``assertion.rtcm_stream``'s matrix — that
     mirrors ``ReceiverConfig``'s UART1/UART2/USB-only scope — so the
     advisory display needs the wider read ``rtcm`` already carries.
-    Likewise, ``assertion.constellations`` is just the flat enabled set —
-    writing a constellation change needs each system's channel tuning,
-    which only the raw ``gnss`` read carries. Bundling all three here
-    means one receiver read serves every caller, rather than any of them
-    re-polling RTCM or GNSS a second time.
+    Bundling both here means one receiver read serves every caller,
+    rather than a second one re-polling RTCM.
+
+    A raw ``GnssConfig`` used to ride along here too, for the
+    constellation apply-step's channel-preserving write. Issue #104
+    dropped it: the driver's constellation write no longer takes
+    channel data at all (channel allocation is left to the firmware),
+    so the step only needs ``assertion.constellations``.
     """
 
     assertion: ReceiverAssertion
     rtcm: RtcmPortConfig
-    gnss: GnssConfig
 
 
 class DeviceService:
@@ -325,12 +328,37 @@ class DeviceService:
                 info.model,
                 port,
             )
+            await self._probe_gnss_capability_once(self._driver)
             return info
         except Exception as exc:
             self._state = DeviceConnectionState.ERROR
             self._last_error = str(exc)
             logger.error("Failed to connect to %s: %s", port, exc)
             raise
+
+    @staticmethod
+    async def _probe_gnss_capability_once(driver: GpsReceiverDriver) -> None:
+        """Run the legacy CFG-GNSS block poll once, right after connect (issue #104).
+
+        The block poll's only remaining role is the capability probe
+        ``UbloxDriver.configure_gnss`` re-runs after a constellation
+        write actually executes — this call is what makes that "once
+        per connection, and again after a step that ran" rather than
+        "only ever after a write". Purely diagnostic: the result is
+        logged, never compared or queued as a warning here (that
+        comparison needs a just-written expected set, which only
+        exists inside ``configure_gnss``). Never raises — a driver
+        that can't answer this legacy poll must not fail an otherwise
+        -successful connect.
+        """
+        try:
+            config = await asyncio.to_thread(driver.get_gnss_config)
+            logger.debug(
+                "GNSS capability probe: %s",
+                [c.value for c in config.enabled_constellations()],
+            )
+        except Exception as exc:
+            logger.debug("GNSS capability probe failed at connect: %s", exc)
 
     def set_connecting(self) -> None:
         """Set state to CONNECTING for UI feedback before connect."""
@@ -692,7 +720,13 @@ class DeviceService:
         return await asyncio.to_thread(driver.get_port_protocols)
 
     async def get_gnss_config(self) -> GnssConfig:
-        """Read the current GNSS constellation configuration.
+        """Read the current GNSS constellation configuration from the legacy block.
+
+        This is the capability-probe read (issue #104) — the standalone
+        ``GET /api/device/gnss`` diagnostic endpoint's source, kept for
+        its per-system channel counts. It is no longer how
+        ``ReceiverAssertion.constellations`` gets populated; see
+        ``get_receiver_assertion``.
 
         Returns:
             Current GNSS system configuration.
@@ -718,13 +752,14 @@ class DeviceService:
     async def get_receiver_assertion(self) -> ReceiverAssertionRead:
         """Read the whole receiver in one go as a ``ReceiverAssertion``.
 
-        Four driver reads — RTCM matrix, port protocols, GNSS
-        constellations, and the batched scalar poll (baud, meas rate,
-        dyn model, tmode mode, elevation mask, BeiDou B2, SPI) — landing
-        as three CFG-VALGET polls rather than seven separate round
-        trips, composed by the pure :func:`build_receiver_assertion`
-        (issue #97). Every field the Advanced GPS page seeds ``form``/
-        ``live`` from reflects the receiver's actual value.
+        Three driver reads — RTCM matrix, port protocols, and the
+        batched scalar poll (baud, meas rate, dyn model, tmode mode,
+        enabled constellations, elevation mask, BeiDou B2, SPI) —
+        landing as two CFG-VALGET polls rather than eight separate
+        round trips, composed by the pure :func:`build_receiver_assertion`
+        (issue #97, extended by issue #104). Every field the Advanced
+        GPS page seeds ``form``/``live`` from reflects the receiver's
+        actual value.
 
         Returns the raw RTCM read alongside the assertion — the page's
         I2C/SPI advisory needs it (ports the matrix doesn't claim), and
@@ -741,25 +776,24 @@ class DeviceService:
     async def _read_full_assertion(
         self, driver: GpsReceiverDriver
     ) -> ReceiverAssertionRead:
-        """The four driver reads behind :meth:`get_receiver_assertion`.
+        """The three driver reads behind :meth:`get_receiver_assertion`.
 
         Shared with ``apply_receiver_config``'s pre-write pre-read
         (issue #99) so there's exactly one place composing a full
-        receiver read, rather than the pre-read duplicating this
-        method's body to also get at the raw ``gnss`` config it needs.
+        receiver read.
         """
         rtcm = await asyncio.to_thread(driver.get_rtcm_port_config)
         ports = await asyncio.to_thread(driver.get_port_protocols)
-        gnss = await asyncio.to_thread(driver.get_gnss_config)
         scalars = await asyncio.to_thread(driver.get_receiver_scalars)
-        assertion = build_receiver_assertion(rtcm, ports, gnss, scalars)
-        return ReceiverAssertionRead(assertion=assertion, rtcm=rtcm, gnss=gnss)
+        assertion = build_receiver_assertion(rtcm, ports, scalars)
+        return ReceiverAssertionRead(assertion=assertion, rtcm=rtcm)
 
-    async def configure_gnss(self, config: GnssConfig) -> None:
-        """Write GNSS constellation configuration to the receiver.
+    async def configure_gnss(self, constellations: set[GnssConstellation]) -> None:
+        """Assertive durable write of the enabled-constellation set (issue #104).
 
         Args:
-            config: Desired GNSS system configuration.
+            constellations: Exactly the constellations that should end
+                up enabled; every other constellation is disabled.
 
         Raises:
             RuntimeError: If not connected or relay is running.
@@ -767,11 +801,11 @@ class DeviceService:
         driver = self._require_connected()
         self._state = DeviceConnectionState.CONFIGURING
         try:
-            await asyncio.to_thread(driver.configure_gnss, config)
+            await asyncio.to_thread(driver.configure_gnss, constellations)
             self._state = DeviceConnectionState.CONNECTED
             logger.info(
                 "GNSS constellations configured: %s",
-                [c.value for c in config.enabled_constellations()],
+                sorted(c.value for c in constellations),
             )
         except Exception as exc:
             self._state = DeviceConnectionState.CONNECTED
@@ -984,7 +1018,7 @@ class DeviceService:
                 continue
 
             try:
-                await self._run_apply_step(driver, step_name, assertion, pre_read.gnss)
+                await self._run_apply_step(driver, step_name, assertion)
             except Exception as exc:
                 logger.warning("apply-config step %r failed: %s", step_name, exc)
                 self._last_error = f"apply-config step {step_name!r} failed: {exc}"
@@ -1039,14 +1073,13 @@ class DeviceService:
         driver: GpsReceiverDriver,
         step_name: str,
         assertion: ReceiverAssertion,
-        pre_gnss: GnssConfig,
     ) -> None:
         """Perform one write step's driver call (issue #99).
 
-        *pre_gnss* is the raw pre-read GNSS config — the constellation
-        step needs it (not just ``assertion.constellations``) to
-        preserve each system's channel tuning, which
-        ``ReceiverAssertion`` doesn't carry.
+        The constellation step (issue #104) needs nothing beyond
+        ``assertion.constellations`` — the driver's assertive write
+        takes the wanted set directly and leaves channel allocation to
+        the firmware, so there's no pre-read GNSS state to preserve.
         """
         if step_name == "meas_period_ms":
             await asyncio.to_thread(
@@ -1057,16 +1090,9 @@ class DeviceService:
             out_map = {port: cfg.out for port, cfg in assertion.ports.items()}
             await asyncio.to_thread(driver.configure_port_protocols, in_map, out_map)
         elif step_name == "constellations":
-            wanted = set(assertion.constellations)
-            updated_gnss = GnssConfig(
-                systems=[
-                    system.model_copy(
-                        update={"enabled": system.constellation in wanted}
-                    )
-                    for system in pre_gnss.systems
-                ]
+            await asyncio.to_thread(
+                driver.configure_gnss, set(assertion.constellations)
             )
-            await asyncio.to_thread(driver.configure_gnss, updated_gnss)
         elif step_name == "optimisations":
             await asyncio.to_thread(
                 driver.configure_optimisations,

--- a/src/sp_rtk_base/services/drivers/base.py
+++ b/src/sp_rtk_base/services/drivers/base.py
@@ -17,6 +17,7 @@ from sp_rtk_base.models.device_models import (
     DynModel,
     FixedBaseConfig,
     GnssConfig,
+    GnssConstellation,
     GpsPosition,
     PortId,
     PortProtocolConfig,
@@ -404,11 +405,21 @@ class GpsReceiverDriver(abc.ABC):
         """
 
     @abc.abstractmethod
-    def configure_gnss(self, config: GnssConfig) -> None:
-        """Write GNSS constellation configuration to the receiver.
+    def configure_gnss(self, constellations: set[GnssConstellation]) -> None:
+        """Assertive durable write of the per-constellation enable keys (issue #104).
+
+        Every constellation the vendor-neutral :class:`GnssConstellation`
+        enum knows about is written explicitly — on for the members of
+        ``constellations``, off for every other member — at whatever
+        layer the concrete driver considers durable. Channel allocation
+        is left entirely to the firmware; this call has no channel
+        parameter. IMES and NavIC are never touched — they have no
+        member in :class:`GnssConstellation`, so there is no key for
+        this call to write for them.
 
         Args:
-            config: Desired GNSS system configuration.
+            constellations: Exactly the constellations that should end
+                up enabled.
 
         Raises:
             ConnectionError: If not connected.

--- a/src/sp_rtk_base/services/drivers/fake.py
+++ b/src/sp_rtk_base/services/drivers/fake.py
@@ -538,6 +538,7 @@ class FakeGpsDriver(GpsReceiverDriver):
             meas_period_ms=self._meas_period_ms,
             dyn_model=self._dyn_model,
             tmode_mode=self._base_config.mode,
+            constellations=self._gnss.enabled_constellations(),
             elevation_mask_deg=self._elevation_mask_deg,
             bds_b2_enabled=self._bds_b2_enabled,
             spi_enabled=self._spi_enabled,
@@ -554,14 +555,21 @@ class FakeGpsDriver(GpsReceiverDriver):
     # ------------------------------------------------------------------
 
     def get_gnss_config(self) -> GnssConfig:
-        """Return the most recently stored GNSS configuration."""
+        """Return the most recently stored GNSS configuration (legacy block probe)."""
         self._ensure_connected()
         return self._gnss
 
-    def configure_gnss(self, config: GnssConfig) -> None:
-        """Store the GNSS configuration in memory."""
+    def configure_gnss(self, constellations: set[GnssConstellation]) -> None:
+        """Flip ``enabled`` on the six known systems; channels untouched (issue #104)."""
         self._ensure_connected()
-        self._gnss = config
+        self._gnss = GnssConfig(
+            systems=[
+                system.model_copy(
+                    update={"enabled": system.constellation in constellations}
+                )
+                for system in self._gnss.systems
+            ]
+        )
 
     # ------------------------------------------------------------------
     # Status polling

--- a/src/sp_rtk_base/services/drivers/ublox.py
+++ b/src/sp_rtk_base/services/drivers/ublox.py
@@ -146,8 +146,24 @@ _TMODE_MODE_VALUES: dict[BaseMode, int] = {
 # read-back and ``_parse_cfg_tmode``.
 _TMODE_MODE_NAMES: dict[int, BaseMode] = {v: k for k, v in _TMODE_MODE_VALUES.items()}
 
+# The six per-constellation enable keys (issue #104) — CFG-GNSS SET is
+# deprecated on the F9 config interface in favour of these. GLONASS,
+# Galileo and BeiDou use their three-letter IDs; the rest match the
+# ``GnssConstellation`` member name. IMES and NavIC are deliberately
+# absent — they have no ``GnssConstellation`` member, so there is no
+# key here for a write to ever touch.
+_GNSS_SIGNAL_ENA_KEYS: dict[GnssConstellation, str] = {
+    GnssConstellation.GPS: "CFG_SIGNAL_GPS_ENA",
+    GnssConstellation.GLONASS: "CFG_SIGNAL_GLO_ENA",
+    GnssConstellation.GALILEO: "CFG_SIGNAL_GAL_ENA",
+    GnssConstellation.BEIDOU: "CFG_SIGNAL_BDS_ENA",
+    GnssConstellation.SBAS: "CFG_SIGNAL_SBAS_ENA",
+    GnssConstellation.QZSS: "CFG_SIGNAL_QZSS_ENA",
+}
+
 # The scalar CFG keys ``get_receiver_scalars`` polls in one CFG-VALGET
-# round trip (issue #97) — 8 keys, well under the 64-key poll cap.
+# round trip (issue #97) — 14 keys (8 original + the 6 constellation
+# enable keys added by issue #104), well under the 64-key poll cap.
 _RECEIVER_SCALAR_KEYS: list[str] = [
     "CFG_UART1_BAUDRATE",
     "CFG_UART2_BAUDRATE",
@@ -157,6 +173,7 @@ _RECEIVER_SCALAR_KEYS: list[str] = [
     "CFG_NAVSPG_INFIL_MINELEV",
     "CFG_SIGNAL_BDS_B2_ENA",
     "CFG_SPI_ENABLED",
+    *_GNSS_SIGNAL_ENA_KEYS.values(),
 ]
 
 # Ports the RTCM matrix write covers — deliberately excludes I2C/SPI,
@@ -1068,10 +1085,6 @@ class UbloxDriver(GpsReceiverDriver):
         6: GnssConstellation.GLONASS,
     }
 
-    _GNSS_ID_REVERSE: dict[GnssConstellation, int] = {
-        v: k for k, v in _GNSS_ID_MAP.items()
-    }
-
     def get_gnss_config(self) -> GnssConfig:
         """Poll CFG-GNSS and return current constellation configuration."""
         with self._lock:
@@ -1129,42 +1142,69 @@ class UbloxDriver(GpsReceiverDriver):
 
         return GnssConfig(systems=systems)
 
-    def configure_gnss(self, config: GnssConfig) -> None:
-        """Send CFG-GNSS to configure constellation selection."""
-        # Build CFG-GNSS SET message
-        # We need numTrkChHw, numTrkChUse, numConfigBlocks + per-system data
-        num_blocks = len(config.systems)
+    def configure_gnss(self, constellations: set[GnssConstellation]) -> None:
+        """Assertive durable write of the six per-constellation enable keys (issue #104).
 
-        # Build kwargs for UBXMessage
-        kwargs: dict[str, int] = {
-            "msgVer": 0,
-            "numTrkChHw": 0,  # read-only, set to 0
-            "numTrkChUse": 0xFF,  # use max available
-            "numConfigBlocks": num_blocks,
-        }
+        Replaces the legacy CFG-GNSS SET block write, which has no
+        layer concept and was therefore RAM-only on every unit — a
+        constellation change made through it never survived a power
+        cycle. Every key in :data:`_GNSS_SIGNAL_ENA_KEYS` is written
+        explicitly (on for a wanted constellation, off otherwise) at
+        layer=5 (RAM+Flash) via ``_write_and_verify_locked``, which
+        gives this write the same RAM read-back retry and flash
+        read-back divergence advisory as every other durable writer —
+        including the flash divergence case this method's docstring in
+        ``_write_and_verify_locked`` describes. Channel allocation is
+        untouched: this call has no channel parameter, by design —
+        allocation is left to the firmware.
 
-        for i, sys_cfg in enumerate(config.systems):
-            # pyubx2 always uses 1-indexed suffixes: _01, _02, ...
-            suffix = f"_{i + 1:02d}"
-            gnss_id = self._GNSS_ID_REVERSE.get(sys_cfg.constellation, 0)
-            flags = (1 if sys_cfg.enabled else 0) | (sys_cfg.sig_cfg_mask << 16)
-
-            kwargs[f"gnssId{suffix}"] = gnss_id
-            kwargs[f"resTrkCh{suffix}"] = sys_cfg.min_channels
-            kwargs[f"maxTrkCh{suffix}"] = sys_cfg.max_channels
-            kwargs[f"flags{suffix}"] = flags
-
-        msg = UBXMessage("CFG", "CFG-GNSS", SET, **kwargs)  # type: ignore[arg-type]
+        Immediately after the write lands, the legacy CFG-GNSS block
+        is polled again and compared against ``constellations``. A
+        disagreement — the write ACKed and reads back correctly at
+        both RAM and Flash, but the firmware's own block still
+        disagrees — is queued on ``self._warnings`` rather than
+        raised: this can never show up as a field difference, since
+        ``ReceiverAssertion.constellations`` and this write both read
+        the same six keys and would simply report a match. See
+        ``GpsReceiverDriver.drain_warnings`` for the channel this
+        lands on.
+        """
+        cfg_data = [
+            (key, int(constellation in constellations))
+            for constellation, key in _GNSS_SIGNAL_ENA_KEYS.items()
+        ]
         with self._lock:
-            ser, _ = self._require_connection()
-            ser.reset_input_buffer()
-            ser.write(msg.serialize())
-            self._wait_for_ack("CFG-GNSS")
+            self._write_and_verify_locked(
+                cfg_data, layer=5, label="GNSS constellations"
+            )
+            disagreement = self._gnss_probe_disagreement_locked(constellations)
+            if disagreement is not None:
+                self._warnings.append(f"GNSS constellations: {disagreement}")
 
-        enabled = config.enabled_constellations()
         logger.info(
             "GNSS constellations configured: %s",
-            [c.value for c in enabled],
+            sorted(c.value for c in constellations),
+        )
+
+    def _gnss_probe_disagreement_locked(
+        self, expected: set[GnssConstellation]
+    ) -> str | None:
+        """Poll the legacy CFG-GNSS block and describe any disagreement with ``expected``.
+
+        Must hold ``self._lock``. The block SET is deprecated in
+        favour of the six ``CFG_SIGNAL_*_ENA`` keys (issue #104), but
+        the block POLL survives as a capability probe — the only way
+        to see whether the firmware actually acts on an enable key it
+        ACKed. Returns ``None`` when the block agrees with
+        ``expected``.
+        """
+        probed = set(self._get_gnss_config_locked().enabled_constellations())
+        if probed == expected:
+            return None
+        return (
+            f"legacy CFG-GNSS block reports {sorted(c.value for c in probed)}, "
+            f"enable keys report {sorted(c.value for c in expected)} — the "
+            "write landed but this firmware may not act on it"
         )
 
     # ------------------------------------------------------------------
@@ -1340,23 +1380,33 @@ class UbloxDriver(GpsReceiverDriver):
         return drained
 
     def get_receiver_scalars(self) -> ReceiverScalarConfig:
-        """Batched read of baud, meas rate, dyn model, tmode mode and the
-        three optimisation fields — one CFG-VALGET poll (issue #97).
+        """Batched read of baud, meas rate, dyn model, tmode mode, the
+        enabled constellations and the three optimisation fields — one
+        CFG-VALGET poll (issue #97, extended by issue #104).
 
         Replaces what would otherwise be up to seven separate getters:
         the three that already existed (``get_dyn_model``,
         ``get_uart_baud_rates``, the TMODE portion of ``get_base_config``)
         plus the four that had no standalone getter at all
-        (measurement rate, elevation mask, BeiDou B2, SPI).
+        (measurement rate, elevation mask, BeiDou B2, SPI). The six
+        ``CFG_SIGNAL_*_ENA`` constellation-enable keys (issue #104) fold
+        into this same poll for free — ``ReceiverAssertion.constellations``
+        no longer needs a separate CFG-GNSS block read to populate.
         """
         with self._lock:
             raw = self._read_cfg_keys_locked(_RECEIVER_SCALAR_KEYS)
+        constellations = [
+            constellation
+            for constellation, key in _GNSS_SIGNAL_ENA_KEYS.items()
+            if raw[key]
+        ]
         return ReceiverScalarConfig(
             uart1_baud=raw["CFG_UART1_BAUDRATE"],
             uart2_baud=raw["CFG_UART2_BAUDRATE"],
             meas_period_ms=raw["CFG_RATE_MEAS"],
             dyn_model=_DYN_MODEL_NAMES[raw["CFG_NAVSPG_DYNMODEL"]],
             tmode_mode=_TMODE_MODE_NAMES[raw["CFG_TMODE_MODE"]],
+            constellations=constellations,
             elevation_mask_deg=raw["CFG_NAVSPG_INFIL_MINELEV"],
             bds_b2_enabled=bool(raw["CFG_SIGNAL_BDS_B2_ENA"]),
             spi_enabled=bool(raw["CFG_SPI_ENABLED"]),

--- a/src/sp_rtk_base/ui/pages/gps_config.py
+++ b/src/sp_rtk_base/ui/pages/gps_config.py
@@ -1,16 +1,20 @@
 """Advanced GPS Configuration page — profile picker, live-seeded form, Apply.
 
 Provides the profile-based GPS receiver setup flow (issue #54): a
-profile picker tagged with hardware compatibility, a receiver-
+profile picker tagged with hardware compatibility, and a receiver-
 configuration view seeded from the live device (RTCM matrix, port
-protocols, GNSS constellations), and save-to-flash.
+protocols, GNSS constellations).
 
 Issue #67 dropped Handoff-to-relay from this page (device-session
 concerns live on the Dashboard/Outputs pages, not here). Cancel-
 survey-in and Reset GPS were already Survey-page-only, alongside the
 rest of the positioning workflow, and stay untouched by that issue —
-neither is a profile concern. Save-to-flash stays too: see the
-comment on ``flash_card`` below for why it's still load-bearing.
+neither is a profile concern. Issue #104 dropped the Save-to-Flash
+card too: every profile write, constellations included, is now
+layer=5 (RAM+Flash) via CFG-VALSET, so the card's sole justification
+(a RAM-only constellation write) no longer holds. The underlying
+``save_to_flash`` service/driver/API paths stay — see
+``DeviceService.save_to_flash`` — this page just no longer exposes them.
 
 Issue #64 shipped the read-only shell; issue #65 made the RTCM matrix
 and data-link port(s) editable, wired to
@@ -67,7 +71,6 @@ from sp_rtk_base.models.device_models import (
     ALL_RTCM_MESSAGE_IDS,
     RTCM_MESSAGE_GROUPS,
     CurrentBaseConfig,
-    DeviceCapability,
     DeviceConnectionState,
     DynModel,
     GnssConstellation,
@@ -1154,38 +1157,7 @@ def gps_config_page() -> None:
                 )
 
         # ================================================================
-        # Section D: Save to Flash (hidden until connected + capable)
-        #
-        # Issue #67 removed Handoff-to-relay from this page and looked at
-        # dropping this control too, on the premise (stated in the issue)
-        # that every profile write is already layer=5 (RAM+Flash). That
-        # premise is false for one field: ``apply_receiver_config`` writes
-        # ``ReceiverConfig.constellations`` via ``UbloxDriver.configure_gnss()``,
-        # which sends the legacy UBX-CFG-GNSS SET message — a RAM-only
-        # write with no layer concept, unlike every CFG-VALSET writer
-        # elsewhere in that same apply sequence. (The standalone, UI-less
-        # ``PUT /api/device/gnss`` endpoint shares the same RAM-only
-        # method, so it has the identical gap.) So a constellation change
-        # — made through Apply on this very page — is unpersisted across
-        # a reset or reconnect without an explicit flash, and this
-        # control stays load-bearing until GNSS constellation selection
-        # is migrated to CFG-VALSET (e.g. per-constellation
-        # ``CFG_SIGNAL_*_ENA`` keys).
-        # ================================================================
-        flash_card = ui.card().classes("w-full q-pa-md q-mt-md")
-        flash_card.set_visibility(False)
-
-        with flash_card:
-            with ui.row().classes("items-center gap-4"):
-                save_flash_btn = ui.button("Save to Flash", icon="save").props(
-                    "color=warning"
-                )
-                ui.label(
-                    "Persist current receiver configuration to non-volatile memory"
-                ).classes("text-grey-4")
-
-        # ================================================================
-        # Section E: Fixed Position — three-step Apply -> survey-in ->
+        # Section D: Fixed Position — three-step Apply -> survey-in ->
         # fixed-position card (issue #96). Hidden until connected, like
         # every other card but Connection. Deliberately NOT part of the
         # Profile section above — a profile has no position field, and
@@ -1543,9 +1515,6 @@ def gps_config_page() -> None:
             # Section visibility
             profile_card.set_visibility(connected)
             config_card.set_visibility(connected)
-            flash_card.set_visibility(
-                connected and DeviceCapability.SAVE_TO_FLASH in caps
-            )
             fixed_position_card.set_visibility(connected)
             reload_device_btn.set_visibility(connected)
 
@@ -2386,14 +2355,6 @@ def gps_config_page() -> None:
             ui.notify("Disconnected", type="info")
             _update_ui_state()
 
-        async def _save_flash() -> None:
-            """Save configuration to device flash."""
-            try:
-                await svc.save_to_flash()
-                ui.notify("Saved to flash!", type="positive")
-            except Exception as exc:
-                ui.notify(f"Save failed: {exc}", type="negative")
-
         async def _reload_device_config() -> None:
             """Re-read the profile picker and receiver-config form."""
             if not svc.is_connected:
@@ -2417,7 +2378,6 @@ def gps_config_page() -> None:
         save_as_confirm_btn.on_click(_confirm_save_as)
         rename_confirm_btn.on_click(_confirm_rename)
         delete_confirm_btn.on_click(_confirm_delete)
-        save_flash_btn.on_click(_save_flash)
 
         # ---- Auto-load if already connected (navigated from another page) ----
         async def _on_page_load() -> None:

--- a/tests/e2e/test_gps_config_buttons.py
+++ b/tests/e2e/test_gps_config_buttons.py
@@ -10,9 +10,13 @@ Buttons covered here:
 
 1. **Disconnect** → Quasar ``Disconnected`` toast → REST device
    status flips to disconnected.
-2. **Save to Flash** → Quasar ``Saved to flash!`` toast → REST
-   confirms (the fake driver's ``save_to_flash`` is a no-op that
-   succeeds, so we only assert the toast appears).
+
+Issue #104 removed the Save-to-Flash button from this page (every
+profile write, constellations included, is now durable via
+CFG-VALSET, so the card's sole justification no longer holds) — the
+``save_to_flash`` service/driver/API paths stay, just without a UI
+trigger here, so there is no button-click coverage for it in this file
+any more.
 
 The shave-by-shave RTCM/GNSS editing controls (checkboxes, switches,
 their own Load/Apply buttons) this page used to have were replaced by
@@ -66,28 +70,3 @@ def test_disconnect_button_emits_toast_and_changes_status(
     assert payload.get("state") == "disconnected", (
         f"expected device.state=='disconnected' after click; got {payload!r}"
     )
-
-
-@pytest.mark.e2e
-def test_save_to_flash_button_emits_success_toast(
-    page: Page,
-    base_url: str,
-    connected_gps: None,
-) -> None:
-    """Click **Save to Flash** → ``Saved to flash!`` Quasar toast.
-
-    The fake driver's ``save_to_flash`` is a no-op that returns
-    success, so we only verify the click reaches the handler and the
-    handler emits its positive notification.  REST-level persistence
-    is already covered by ``test_gps_data_flow.py``.
-    """
-    page.goto(f"{base_url}/gps-config")
-    expect(page.locator("text=Advanced GPS Configuration").first).to_be_visible(
-        timeout=15_000
-    )
-
-    save_btn = page.get_by_role("button", name="Save to Flash")
-    expect(save_btn).to_be_visible(timeout=10_000)
-    save_btn.click()
-
-    expect(page.locator("text=Saved to flash!").first).to_be_visible(timeout=10_000)

--- a/tests/e2e/test_gps_data_flow.py
+++ b/tests/e2e/test_gps_data_flow.py
@@ -107,25 +107,27 @@ class TestGnssEndpoint:
         api_base_url: str,
         connected_gps: None,
     ) -> None:
-        """Writing ``galileo.enabled=false`` is reflected by the next GET."""
-        # Get current to use as the base — keeps payload schema-correct
-        # without us reproducing the full default here.
+        """Writing a set that omits Galileo is reflected by the next GET.
+
+        Issue #104: the write is now an assertive enable-key write —
+        the request body names exactly the constellations that should
+        end up enabled, not a full ``GnssConfig`` block replay.
+        """
         current = httpx.get(f"{api_base_url}/api/device/gnss", timeout=5.0).json()
         current_d = cast(dict[str, Any], current)
         systems_list_raw = cast(list[Any], current_d.get("systems", []))
         systems_list: list[dict[str, Any]] = [
             cast(dict[str, Any], s) for s in systems_list_raw if isinstance(s, dict)
         ]
-        for s in systems_list:
-            if str(s.get("constellation", "")).lower() == "galileo":
-                s["enabled"] = False
+        wanted = [
+            str(s.get("constellation", ""))
+            for s in systems_list
+            if bool(s.get("enabled")) and str(s.get("constellation", "")) != "galileo"
+        ]
 
-        # Re-encode and write.  The configuration endpoint is
-        # ``PUT /api/device/gnss`` (it replaces the entire GNSS
-        # config), not the older ``POST /configure/gnss`` shape.
         resp = httpx.put(
             f"{api_base_url}/api/device/gnss",
-            json={"systems": systems_list},
+            json={"constellations": wanted},
             timeout=10.0,
         )
         # We don't enforce 200 vs 204; just no server error.
@@ -216,17 +218,14 @@ def test_gps_config_page_renders_when_connected(
 
     We're not asserting on every widget — that would be brittle —
     just that the top-level page renders its title and that the
-    "Save to Flash" button (a high-signal indicator that the
-    capability gating worked) becomes visible after the device
-    is connected.
+    "Reload Device Config" button (a high-signal indicator that the
+    connected-state UI assembly fired) becomes visible after the
+    device is connected.
     """
     page.goto(f"{base_url}/gps-config")
     expect(page.locator("text=Advanced GPS Configuration").first).to_be_visible(
         timeout=15_000
     )
-    # The Save to Flash button is gated on the SAVE_TO_FLASH capability,
-    # which the FakeGpsDriver claims.  Its visibility proves the
-    # capability-driven UI assembly fired.
-    expect(page.get_by_role("button", name="Save to Flash")).to_be_visible(
+    expect(page.get_by_role("button", name="Reload Device Config")).to_be_visible(
         timeout=10_000
     )

--- a/tests/unit/test_device_service.py
+++ b/tests/unit/test_device_service.py
@@ -15,9 +15,7 @@ from sp_rtk_base.models.device_models import (
     DeviceInfo,
     DynModel,
     FixedBaseConfig,
-    GnssConfig,
     GnssConstellation,
-    GnssSystemConfig,
     PortId,
     PortProtocolConfig,
     ReceiverScalarConfig,
@@ -176,6 +174,36 @@ class TestConnection:
         assert svc.is_connected is True
         assert svc.device_info is not None
         driver.connect.assert_called_once_with("/dev/ttyACM0", 115200)
+
+    @pytest.mark.asyncio()
+    async def test_connect_probes_legacy_gnss_block_once(self) -> None:
+        """Issue #104: the legacy CFG-GNSS block poll runs once per
+        connection, established here — ``configure_gnss`` re-runs it
+        again whenever a constellation step actually executes."""
+        from sp_rtk_base.models.device_models import GnssConfig
+
+        svc = DeviceService()
+        driver = _make_mock_driver()
+        driver.get_gnss_config.return_value = GnssConfig()
+        svc.set_driver(driver)
+
+        await svc.connect("/dev/ttyACM0", 115200)
+
+        driver.get_gnss_config.assert_called_once()
+
+    @pytest.mark.asyncio()
+    async def test_connect_survives_gnss_probe_failure(self) -> None:
+        """A driver that can't answer the legacy poll must not fail
+        an otherwise-successful connect — the probe is diagnostic-only."""
+        svc = DeviceService()
+        driver = _make_mock_driver()
+        driver.get_gnss_config.side_effect = RuntimeError("no legacy support")
+        svc.set_driver(driver)
+
+        info = await svc.connect("/dev/ttyACM0", 115200)
+
+        assert info.vendor == "MockVendor"
+        assert svc.state == DeviceConnectionState.CONNECTED
 
     @pytest.mark.asyncio()
     async def test_connect_no_driver_raises(self) -> None:
@@ -391,6 +419,7 @@ def _scalars(**overrides: object) -> ReceiverScalarConfig:
         "meas_period_ms": 250,
         "dyn_model": DynModel.STATIONARY,
         "tmode_mode": BaseMode.FIXED,
+        "constellations": [GnssConstellation.GPS],
         "elevation_mask_deg": 15,
         "bds_b2_enabled": False,
         "spi_enabled": True,
@@ -400,7 +429,7 @@ def _scalars(**overrides: object) -> ReceiverScalarConfig:
 
 
 class TestBuildReceiverAssertion:
-    """Pure composition of four driver reads into one ``ReceiverAssertion``."""
+    """Pure composition of three driver reads into one ``ReceiverAssertion``."""
 
     def test_composes_every_field(self) -> None:
         rtcm = RtcmPortConfig(
@@ -410,15 +439,9 @@ class TestBuildReceiverAssertion:
             in_protocols={PortId.UART1: [UbxProtocol.UBX]},
             out_protocols={PortId.UART1: [UbxProtocol.RTCM3X]},
         )
-        gnss = GnssConfig(
-            systems=[
-                GnssSystemConfig(constellation=GnssConstellation.GPS, enabled=True),
-                GnssSystemConfig(constellation=GnssConstellation.SBAS, enabled=False),
-            ]
-        )
         scalars = _scalars()
 
-        assertion = build_receiver_assertion(rtcm, ports, gnss, scalars)
+        assertion = build_receiver_assertion(rtcm, ports, scalars)
 
         assert assertion.rtcm_stream.matrix[RtcmRowId.RTCM_1005][PortId.UART1] is True
         assert assertion.rtcm_stream.matrix[RtcmRowId.RTCM_1005][PortId.UART2] is False
@@ -436,7 +459,7 @@ class TestBuildReceiverAssertion:
 
     def test_matrix_covers_every_catalog_row_and_matrix_port(self) -> None:
         assertion = build_receiver_assertion(
-            RtcmPortConfig(), PortProtocolConfig(), GnssConfig(), _scalars()
+            RtcmPortConfig(), PortProtocolConfig(), _scalars()
         )
         assert set(assertion.rtcm_stream.matrix.keys()) == set(RtcmRowId)
         for row in assertion.rtcm_stream.matrix.values():
@@ -444,7 +467,7 @@ class TestBuildReceiverAssertion:
 
     def test_ports_covers_all_three_ports_even_when_unset(self) -> None:
         assertion = build_receiver_assertion(
-            RtcmPortConfig(), PortProtocolConfig(), GnssConfig(), _scalars()
+            RtcmPortConfig(), PortProtocolConfig(), _scalars()
         )
         assert set(assertion.ports.keys()) == {PortId.UART1, PortId.UART2, PortId.USB}
 
@@ -458,7 +481,6 @@ class TestGetReceiverAssertion:
             messages={RtcmRowId.RTCM_1005: {"UART1": 1}}
         )
         driver.get_port_protocols.return_value = PortProtocolConfig()
-        driver.get_gnss_config.return_value = GnssConfig()
         driver.get_receiver_scalars.return_value = _scalars()
         svc.set_driver(driver)
         svc._state = DeviceConnectionState.CONNECTED
@@ -466,7 +488,7 @@ class TestGetReceiverAssertion:
         return svc
 
     @pytest.mark.asyncio()
-    async def test_composes_the_four_driver_reads(
+    async def test_composes_the_three_driver_reads(
         self, connected_svc: DeviceService
     ) -> None:
         read = await connected_svc.get_receiver_assertion()
@@ -479,7 +501,6 @@ class TestGetReceiverAssertion:
         assert driver is not None
         driver.get_rtcm_port_config.assert_called_once()  # type: ignore[union-attr]
         driver.get_port_protocols.assert_called_once()  # type: ignore[union-attr]
-        driver.get_gnss_config.assert_called_once()  # type: ignore[union-attr]
         driver.get_receiver_scalars.assert_called_once()  # type: ignore[union-attr]
 
     @pytest.mark.asyncio()
@@ -564,6 +585,7 @@ def _scalars_for(assertion: ReceiverAssertion) -> ReceiverScalarConfig:
         meas_period_ms=assertion.meas_period_ms,
         dyn_model=assertion.dyn_model,
         tmode_mode=assertion.tmode_mode,
+        constellations=assertion.constellations,
         elevation_mask_deg=assertion.elevation_mask_deg,
         bds_b2_enabled=assertion.bds_b2_enabled,
         spi_enabled=assertion.spi_enabled,
@@ -592,13 +614,6 @@ def _mock_read_back_matches(driver: MagicMock, assertion: ReceiverAssertion) -> 
         in_protocols={port: cfg.in_ for port, cfg in assertion.ports.items()},
         out_protocols={port: cfg.out for port, cfg in assertion.ports.items()},
     )
-    wanted = set(assertion.constellations)
-    driver.get_gnss_config.return_value = GnssConfig(
-        systems=[
-            GnssSystemConfig(constellation=c, enabled=c in wanted)
-            for c in GnssConstellation
-        ]
-    )
     driver.get_receiver_scalars.return_value = _scalars_for(assertion)
 
 
@@ -610,7 +625,6 @@ class TestApplyReceiverConfig:
         svc = DeviceService()
         driver = _make_mock_driver()
         driver.get_base_config.return_value = CurrentBaseConfig(mode=BaseMode.DISABLED)
-        driver.get_gnss_config.return_value = GnssConfig(systems=[])
         # Matches ``_minimal_assertion()`` exactly by default, so tests
         # that don't care about the read-back diff see status="ok" and
         # the meas-rate/baud unchanged-skip fires for anything that
@@ -1011,40 +1025,19 @@ class TestApplyReceiverConfig:
         )
 
     @pytest.mark.asyncio()
-    async def test_constellations_flip_enabled_and_preserve_channels(
+    async def test_constellations_step_writes_the_wanted_set(
         self, connected_svc: DeviceService
     ) -> None:
+        """Issue #104: the constellation step passes the wanted set
+        straight through — no channel data survives to preserve, since
+        the assertive enable-key write has no channel parameter at all."""
         driver = connected_svc.driver
         assert isinstance(driver, MagicMock)
-        driver.get_gnss_config.return_value = GnssConfig(
-            systems=[
-                GnssSystemConfig(
-                    constellation=GnssConstellation.GPS,
-                    enabled=True,
-                    min_channels=8,
-                    max_channels=16,
-                ),
-                GnssSystemConfig(
-                    constellation=GnssConstellation.GALILEO,
-                    enabled=False,
-                    min_channels=4,
-                    max_channels=12,
-                ),
-            ]
-        )
         request = _minimal_request(constellations=[GnssConstellation.GALILEO])
 
         await connected_svc.apply_receiver_config(request)
 
-        written: GnssConfig = driver.configure_gnss.call_args[0][0]
-        by_constellation: dict[GnssConstellation, GnssSystemConfig] = {
-            s.constellation: s for s in written.systems
-        }
-        assert by_constellation[GnssConstellation.GPS].enabled is False
-        assert by_constellation[GnssConstellation.GALILEO].enabled is True
-        # Channel tuning is preserved from the live read, not clobbered.
-        assert by_constellation[GnssConstellation.GALILEO].min_channels == 4
-        assert by_constellation[GnssConstellation.GALILEO].max_channels == 12
+        driver.configure_gnss.assert_called_once_with({GnssConstellation.GALILEO})
 
     @pytest.mark.asyncio()
     async def test_dyn_model_and_tmode_mode_skip_when_unchanged(
@@ -1428,13 +1421,13 @@ class TestBaseInvariants:
         # regression that used the built-in's value instead of live (or
         # vice versa) is caught by ``test_apply_delegates_...`` below.
         driver.get_port_protocols.return_value = PortProtocolConfig()
-        driver.get_gnss_config.return_value = GnssConfig(systems=[])
         driver.get_receiver_scalars.return_value = ReceiverScalarConfig(
             uart1_baud=9600,
             uart2_baud=9600,
             meas_period_ms=250,
             dyn_model=DynModel.PORTABLE,
             tmode_mode=BaseMode.SURVEY_IN,
+            constellations=[],
             elevation_mask_deg=45,
             bds_b2_enabled=True,
             spi_enabled=False,

--- a/tests/unit/test_driver_registry.py
+++ b/tests/unit/test_driver_registry.py
@@ -12,6 +12,7 @@ from sp_rtk_base.models.device_models import (
     DynModel,
     FixedBaseConfig,
     GnssConfig,
+    GnssConstellation,
     GpsPosition,
     PortId,
     PortProtocolConfig,
@@ -75,7 +76,7 @@ class StubDriver(GpsReceiverDriver):
     def get_gnss_config(self) -> GnssConfig:
         return GnssConfig()
 
-    def configure_gnss(self, config: GnssConfig) -> None:
+    def configure_gnss(self, constellations: set[GnssConstellation]) -> None:
         pass
 
     def save_to_flash(self) -> None:
@@ -139,6 +140,7 @@ class StubDriver(GpsReceiverDriver):
             meas_period_ms=1000,
             dyn_model=DynModel.PORTABLE,
             tmode_mode=BaseMode.DISABLED,
+            constellations=[],
             elevation_mask_deg=0,
             bds_b2_enabled=False,
             spi_enabled=False,

--- a/tests/unit/test_fake_driver.py
+++ b/tests/unit/test_fake_driver.py
@@ -42,9 +42,7 @@ from sp_rtk_base.models.device_models import (
     DeviceCapability,
     DynModel,
     FixedBaseConfig,
-    GnssConfig,
     GnssConstellation,
-    GnssSystemConfig,
     GpsFixType,
     PortId,
     RtcmPortConfig,
@@ -217,7 +215,7 @@ class TestDisconnectedGuards:
 
     def test_configure_gnss_requires_connection(self, driver: FakeGpsDriver) -> None:
         with pytest.raises(ConnectionError):
-            driver.configure_gnss(GnssConfig())
+            driver.configure_gnss(set())
 
     def test_get_position_requires_connection(self, driver: FakeGpsDriver) -> None:
         with pytest.raises(ConnectionError):
@@ -328,19 +326,33 @@ class TestConfigurationRoundTrips:
         assert out.messages[RtcmRowId.RTCM_1005]["USB"] == 0
 
     def test_gnss_round_trip(self, connected_driver: FakeGpsDriver) -> None:
-        cfg = GnssConfig(
-            systems=[
-                GnssSystemConfig(constellation=GnssConstellation.GPS, enabled=True),
-                GnssSystemConfig(
-                    constellation=GnssConstellation.GALILEO, enabled=False
-                ),
-            ]
-        )
-        connected_driver.configure_gnss(cfg)
+        connected_driver.configure_gnss({GnssConstellation.GPS})
+
         out = connected_driver.get_gnss_config()
         assert {s.constellation for s in out.systems if s.enabled} == {
             GnssConstellation.GPS
         }
+        scalars = connected_driver.get_receiver_scalars()
+        assert scalars.constellations == [GnssConstellation.GPS]
+
+    def test_gnss_write_preserves_channel_tuning(
+        self, connected_driver: FakeGpsDriver
+    ) -> None:
+        """Issue #104: the assertive write has no channel parameter —
+        whatever channel tuning the fake started with survives untouched."""
+        before = {
+            s.constellation: s for s in connected_driver.get_gnss_config().systems
+        }
+
+        connected_driver.configure_gnss({GnssConstellation.GALILEO})
+
+        after = {s.constellation: s for s in connected_driver.get_gnss_config().systems}
+        assert after[GnssConstellation.GPS].min_channels == (
+            before[GnssConstellation.GPS].min_channels
+        )
+        assert after[GnssConstellation.GPS].max_channels == (
+            before[GnssConstellation.GPS].max_channels
+        )
 
     def test_default_rtcm_port_config_has_six_messages(
         self, connected_driver: FakeGpsDriver
@@ -492,6 +504,12 @@ class TestConfigurationRoundTrips:
         assert scalars.meas_period_ms == 1000
         assert scalars.dyn_model == DynModel.PORTABLE
         assert scalars.tmode_mode == BaseMode.DISABLED
+        assert set(scalars.constellations) == {
+            GnssConstellation.GPS,
+            GnssConstellation.GLONASS,
+            GnssConstellation.GALILEO,
+            GnssConstellation.BEIDOU,
+        }
         assert scalars.elevation_mask_deg == 15
         assert scalars.bds_b2_enabled is False
         assert scalars.spi_enabled is True
@@ -504,12 +522,14 @@ class TestConfigurationRoundTrips:
         connected_driver.configure_tmode_mode(BaseMode.FIXED)
         connected_driver.configure_optimisations(5, True, False)
         connected_driver.configure_baud(9600, 9600)
+        connected_driver.configure_gnss({GnssConstellation.QZSS})
 
         scalars = connected_driver.get_receiver_scalars()
 
         assert scalars.meas_period_ms == 250
         assert scalars.dyn_model == DynModel.STATIONARY
         assert scalars.tmode_mode == BaseMode.FIXED
+        assert scalars.constellations == [GnssConstellation.QZSS]
         assert scalars.elevation_mask_deg == 5
         assert scalars.bds_b2_enabled is True
         assert scalars.spi_enabled is False

--- a/tests/unit/test_gnss_config.py
+++ b/tests/unit/test_gnss_config.py
@@ -12,7 +12,7 @@ and API endpoints for GNSS constellation selection.
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -218,7 +218,7 @@ class TestUbloxParseCfgGnss:
 
 
 class TestUbloxGnssDriver:
-    """Tests for get_gnss_config and configure_gnss on UbloxDriver."""
+    """Tests for get_gnss_config (legacy probe) on UbloxDriver."""
 
     @pytest.fixture()
     def connected_driver(self) -> UbloxDriver:
@@ -255,49 +255,164 @@ class TestUbloxGnssDriver:
         with pytest.raises(ConnectionError):
             driver.get_gnss_config()
 
-    def test_configure_gnss_success(self, connected_driver: UbloxDriver) -> None:
-        # Mock ACK response
-        ack = SimpleNamespace(identity="ACK-ACK")
-        connected_driver._reader.read.return_value = (b"raw", ack)  # pyright: ignore[reportPrivateUsage]
-
-        config = GnssConfig(
-            systems=[
-                GnssSystemConfig(constellation=GnssConstellation.GPS, enabled=True),
-                GnssSystemConfig(
-                    constellation=GnssConstellation.GLONASS, enabled=False
-                ),
-            ]
-        )
-        connected_driver.configure_gnss(config)
-        # Should have written something to serial
-        connected_driver._serial.write.assert_called()  # pyright: ignore[reportPrivateUsage]
-
-    def test_configure_gnss_nak(self, connected_driver: UbloxDriver) -> None:
-        nak = SimpleNamespace(identity="ACK-NAK")
-        connected_driver._reader.read.return_value = (b"raw", nak)  # pyright: ignore[reportPrivateUsage]
-
-        config = GnssConfig(
-            systems=[
-                GnssSystemConfig(constellation=GnssConstellation.GPS, enabled=True),
-            ]
-        )
-        with pytest.raises(RuntimeError, match="NAK"):
-            connected_driver.configure_gnss(config)
-
-    def test_configure_gnss_not_connected(self) -> None:
-        driver = UbloxDriver()
-        config = GnssConfig(
-            systems=[
-                GnssSystemConfig(constellation=GnssConstellation.GPS, enabled=True),
-            ]
-        )
-        with pytest.raises(ConnectionError):
-            driver.configure_gnss(config)
-
     def test_gnss_select_in_capabilities(self) -> None:
         driver = UbloxDriver()
         caps = driver.get_capabilities()
         assert DeviceCapability.GNSS_SELECT in caps
+
+
+# ---------------------------------------------------------------------------
+# UbloxDriver.configure_gnss() tests (issue #104) — assertive durable write
+# of the six CFG_SIGNAL_*_ENA keys, plus the legacy-block probe-disagreement
+# warning.
+# ---------------------------------------------------------------------------
+
+
+_GNSS_SIGNAL_ENA_KEYS: dict[GnssConstellation, str] = {
+    GnssConstellation.GPS: "CFG_SIGNAL_GPS_ENA",
+    GnssConstellation.GLONASS: "CFG_SIGNAL_GLO_ENA",
+    GnssConstellation.GALILEO: "CFG_SIGNAL_GAL_ENA",
+    GnssConstellation.BEIDOU: "CFG_SIGNAL_BDS_ENA",
+    GnssConstellation.SBAS: "CFG_SIGNAL_SBAS_ENA",
+    GnssConstellation.QZSS: "CFG_SIGNAL_QZSS_ENA",
+}
+
+_GNSS_ID_BY_CONSTELLATION: dict[GnssConstellation, int] = {
+    v: k
+    for k, v in UbloxDriver._GNSS_ID_MAP.items()  # pyright: ignore[reportPrivateUsage]
+}
+
+
+def _make_ack_response() -> SimpleNamespace:
+    return SimpleNamespace(identity="ACK-ACK")
+
+
+def _make_nak_response() -> SimpleNamespace:
+    return SimpleNamespace(identity="ACK-NAK")
+
+
+def _make_signal_ena_readback(enabled: set[GnssConstellation]) -> SimpleNamespace:
+    """A CFG-VALGET response for the six enable keys reflecting *enabled*."""
+    return SimpleNamespace(
+        identity="CFG-VALGET",
+        **{
+            key: int(constellation in enabled)
+            for constellation, key in _GNSS_SIGNAL_ENA_KEYS.items()
+        },
+    )
+
+
+def _make_gnss_block_probe(enabled: set[GnssConstellation]) -> SimpleNamespace:
+    """A legacy CFG-GNSS block POLL response reflecting *enabled*."""
+    kwargs: dict[str, object] = {"numConfigBlocks": len(GnssConstellation)}
+    for i, constellation in enumerate(GnssConstellation, start=1):
+        suffix = f"_{i:02d}"
+        kwargs[f"gnssId{suffix}"] = _GNSS_ID_BY_CONSTELLATION[constellation]
+        kwargs[f"enable{suffix}"] = int(constellation in enabled)
+    return _make_cfg_gnss(**kwargs)
+
+
+class TestUbloxConfigureGnss:
+    """Tests for ``UbloxDriver.configure_gnss`` (issue #104)."""
+
+    @pytest.fixture()
+    def connected_driver(self) -> UbloxDriver:
+        driver = UbloxDriver()
+        mock_serial = MagicMock()
+        mock_serial.is_open = True
+        mock_reader = MagicMock()
+        driver._serial = mock_serial  # pyright: ignore[reportPrivateUsage]
+        driver._reader = mock_reader  # pyright: ignore[reportPrivateUsage]
+        return driver
+
+    def test_writes_all_six_keys_assertively(
+        self, connected_driver: UbloxDriver
+    ) -> None:
+        wanted = {GnssConstellation.GPS, GnssConstellation.GLONASS}
+        connected_driver._reader.read.side_effect = [  # pyright: ignore[reportPrivateUsage]
+            (b"", _make_ack_response()),
+            (b"", _make_signal_ena_readback(wanted)),
+            (b"", _make_signal_ena_readback(wanted)),
+            (b"", _make_gnss_block_probe(wanted)),
+        ]
+
+        connected_driver.configure_gnss(wanted)
+
+        connected_driver._serial.write.assert_called()  # pyright: ignore[reportPrivateUsage]
+        assert connected_driver.drain_warnings() == []
+
+    def test_write_nak_raises(self, connected_driver: UbloxDriver) -> None:
+        connected_driver._reader.read.return_value = (  # pyright: ignore[reportPrivateUsage]
+            b"",
+            _make_nak_response(),
+        )
+
+        with pytest.raises(RuntimeError, match="NAK"):
+            connected_driver.configure_gnss({GnssConstellation.GPS})
+
+    def test_never_touches_imes_or_navic(self, connected_driver: UbloxDriver) -> None:
+        """No ``GnssConstellation`` member exists for IMES/NavIC, so there
+        is no key for this write to ever include."""
+        wanted = set(GnssConstellation)
+        connected_driver._reader.read.side_effect = [  # pyright: ignore[reportPrivateUsage]
+            (b"", _make_ack_response()),
+            (b"", _make_signal_ena_readback(wanted)),
+            (b"", _make_signal_ena_readback(wanted)),
+            (b"", _make_gnss_block_probe(wanted)),
+        ]
+
+        with patch("sp_rtk_base.services.drivers.ublox.UBXMessage") as mock_ubx_msg:
+            mock_ubx_msg.config_set.return_value.serialize.return_value = b"\x00"
+            connected_driver.configure_gnss(wanted)
+            _layer, _reserved, cfg_data = mock_ubx_msg.config_set.call_args[0]
+
+        written_keys = {key for key, _ in cfg_data}
+        assert "CFG_SIGNAL_IMES_ENA" not in written_keys
+        assert "CFG_SIGNAL_NAVIC_ENA" not in written_keys
+        assert written_keys == set(_GNSS_SIGNAL_ENA_KEYS.values())
+
+    def test_probe_disagreement_queues_warning_not_a_raise(
+        self, connected_driver: UbloxDriver
+    ) -> None:
+        """The write ACKs and both RAM/flash read-backs match, but the
+        legacy block still reports something else — the honest signal is
+        a warning, never a failed step."""
+        wanted = {GnssConstellation.GALILEO}
+        probed = {GnssConstellation.GPS}
+        connected_driver._reader.read.side_effect = [  # pyright: ignore[reportPrivateUsage]
+            (b"", _make_ack_response()),
+            (b"", _make_signal_ena_readback(wanted)),
+            (b"", _make_signal_ena_readback(wanted)),
+            (b"", _make_gnss_block_probe(probed)),
+        ]
+
+        connected_driver.configure_gnss(wanted)
+
+        warnings = connected_driver.drain_warnings()
+        assert len(warnings) == 1
+        assert "galileo" in warnings[0]
+        assert "gps" in warnings[0]
+
+    def test_ram_mismatch_after_retry_raises(
+        self, connected_driver: UbloxDriver
+    ) -> None:
+        wanted = {GnssConstellation.GPS}
+        never_took = _make_signal_ena_readback(set())
+        connected_driver._reader.read.side_effect = [  # pyright: ignore[reportPrivateUsage]
+            (b"", _make_ack_response()),  # first write
+            (b"", never_took),  # RAM read-back — mismatch
+            (b"", never_took),  # flash read-back — runs regardless (issue #103)
+            (b"", _make_ack_response()),  # retry write
+            (b"", never_took),  # RAM read-back — still mismatched, raises
+        ]
+
+        with pytest.raises(RuntimeError, match="GNSS constellations"):
+            connected_driver.configure_gnss(wanted)
+
+    def test_not_connected(self) -> None:
+        driver = UbloxDriver()
+        with pytest.raises(ConnectionError):
+            driver.configure_gnss({GnssConstellation.GPS})
 
 
 # ---------------------------------------------------------------------------
@@ -337,13 +452,9 @@ class TestDeviceServiceGnss:
 
     @pytest.mark.asyncio()
     async def test_configure_gnss(self, service_with_driver: DeviceService) -> None:
-        config = GnssConfig(
-            systems=[
-                GnssSystemConfig(constellation=GnssConstellation.GPS, enabled=True),
-            ]
-        )
-        await service_with_driver.configure_gnss(config)
-        service_with_driver._driver.configure_gnss.assert_called_once_with(config)  # pyright: ignore[reportPrivateUsage]
+        wanted = {GnssConstellation.GPS}
+        await service_with_driver.configure_gnss(wanted)
+        service_with_driver._driver.configure_gnss.assert_called_once_with(wanted)  # pyright: ignore[reportPrivateUsage]
         assert service_with_driver.state == DeviceConnectionState.CONNECTED
 
     @pytest.mark.asyncio()
@@ -351,13 +462,8 @@ class TestDeviceServiceGnss:
         self, service_with_driver: DeviceService
     ) -> None:
         service_with_driver._driver.configure_gnss.side_effect = RuntimeError("fail")  # pyright: ignore[reportPrivateUsage]
-        config = GnssConfig(
-            systems=[
-                GnssSystemConfig(constellation=GnssConstellation.GPS, enabled=True),
-            ]
-        )
         with pytest.raises(RuntimeError, match="fail"):
-            await service_with_driver.configure_gnss(config)
+            await service_with_driver.configure_gnss({GnssConstellation.GPS})
         # State should be restored to CONNECTED (not stuck in CONFIGURING)
         assert service_with_driver.state == DeviceConnectionState.CONNECTED
 
@@ -419,16 +525,13 @@ class TestGnssApiEndpoints:
         self, client: TestClient, mock_device_service: MagicMock
     ) -> None:
         mock_device_service.configure_gnss = AsyncMock()
-        payload = {
-            "systems": [
-                {"constellation": "gps", "enabled": True},
-                {"constellation": "glonass", "enabled": False},
-            ]
-        }
+        payload = {"constellations": ["gps", "glonass"]}
         resp = client.put("/api/device/gnss", json=payload)
         assert resp.status_code == 200
         assert resp.json()["status"] == "ok"
-        mock_device_service.configure_gnss.assert_called_once()
+        mock_device_service.configure_gnss.assert_called_once_with(
+            {GnssConstellation.GPS, GnssConstellation.GLONASS}
+        )
 
     def test_put_gnss_config_not_connected(
         self, client: TestClient, mock_device_service: MagicMock
@@ -436,7 +539,7 @@ class TestGnssApiEndpoints:
         mock_device_service.configure_gnss = AsyncMock(
             side_effect=RuntimeError("Device not connected")
         )
-        payload = {"systems": [{"constellation": "gps", "enabled": True}]}
+        payload = {"constellations": ["gps"]}
         resp = client.put("/api/device/gnss", json=payload)
         assert resp.status_code == 409
 
@@ -458,9 +561,12 @@ class TestUbloxGnssIdMapping:
         assert GnssConstellation.SBAS in mapped
         assert GnssConstellation.QZSS in mapped
 
-    def test_reverse_map_roundtrip(self) -> None:
-        for gnss_id, constellation in UbloxDriver._GNSS_ID_MAP.items():  # pyright: ignore[reportPrivateUsage]
-            assert UbloxDriver._GNSS_ID_REVERSE[constellation] == gnss_id  # pyright: ignore[reportPrivateUsage]
+    def test_forward_map_is_injective(self) -> None:
+        """Every gnssId maps to a distinct constellation — the legacy
+        block probe's parse (issue #104) relies on this to describe a
+        disagreement unambiguously."""
+        mapped = list(UbloxDriver._GNSS_ID_MAP.values())  # pyright: ignore[reportPrivateUsage]
+        assert len(mapped) == len(set(mapped))
 
     def test_known_ublox_ids(self) -> None:
         m = UbloxDriver._GNSS_ID_MAP  # pyright: ignore[reportPrivateUsage]

--- a/tests/unit/test_ublox_driver.py
+++ b/tests/unit/test_ublox_driver.py
@@ -23,6 +23,7 @@ from sp_rtk_base.models.device_models import (
     DeviceCapability,
     DynModel,
     FixedBaseConfig,
+    GnssConstellation,
     PortId,
     RtcmRowId,
     SurveyInConfig,
@@ -2210,6 +2211,12 @@ class TestGetReceiverScalars:
             CFG_NAVSPG_INFIL_MINELEV=15,
             CFG_SIGNAL_BDS_B2_ENA=0,
             CFG_SPI_ENABLED=1,
+            CFG_SIGNAL_GPS_ENA=1,
+            CFG_SIGNAL_GLO_ENA=0,
+            CFG_SIGNAL_GAL_ENA=1,
+            CFG_SIGNAL_BDS_ENA=0,
+            CFG_SIGNAL_SBAS_ENA=1,
+            CFG_SIGNAL_QZSS_ENA=0,
         )
         driver, _reader = _connect_driver(
             mock_serial_cls, mock_reader_cls, mock_ubx_msg, [read_back]
@@ -2222,6 +2229,11 @@ class TestGetReceiverScalars:
         assert result.meas_period_ms == 250
         assert result.dyn_model == DynModel.STATIONARY
         assert result.tmode_mode == BaseMode.FIXED
+        assert set(result.constellations) == {
+            GnssConstellation.GPS,
+            GnssConstellation.GALILEO,
+            GnssConstellation.SBAS,
+        }
         assert result.elevation_mask_deg == 15
         assert result.bds_b2_enabled is False
         assert result.spi_enabled is True
@@ -2229,7 +2241,7 @@ class TestGetReceiverScalars:
     @patch("sp_rtk_base.services.drivers.ublox.UBXMessage")
     @patch("sp_rtk_base.services.drivers.ublox.UBXReader")
     @patch("sp_rtk_base.services.drivers.ublox.serial.Serial")
-    def test_polls_all_eight_keys_in_a_single_message(
+    def test_polls_all_fourteen_keys_in_a_single_message(
         self,
         mock_serial_cls: MagicMock,
         mock_reader_cls: MagicMock,
@@ -2245,6 +2257,12 @@ class TestGetReceiverScalars:
             CFG_NAVSPG_INFIL_MINELEV=5,
             CFG_SIGNAL_BDS_B2_ENA=1,
             CFG_SPI_ENABLED=0,
+            CFG_SIGNAL_GPS_ENA=1,
+            CFG_SIGNAL_GLO_ENA=1,
+            CFG_SIGNAL_GAL_ENA=1,
+            CFG_SIGNAL_BDS_ENA=1,
+            CFG_SIGNAL_SBAS_ENA=1,
+            CFG_SIGNAL_QZSS_ENA=1,
         )
         driver, _reader = _connect_driver(
             mock_serial_cls, mock_reader_cls, mock_ubx_msg, [read_back]
@@ -2263,6 +2281,12 @@ class TestGetReceiverScalars:
             "CFG_NAVSPG_INFIL_MINELEV",
             "CFG_SIGNAL_BDS_B2_ENA",
             "CFG_SPI_ENABLED",
+            "CFG_SIGNAL_GPS_ENA",
+            "CFG_SIGNAL_GLO_ENA",
+            "CFG_SIGNAL_GAL_ENA",
+            "CFG_SIGNAL_BDS_ENA",
+            "CFG_SIGNAL_SBAS_ENA",
+            "CFG_SIGNAL_QZSS_ENA",
         }
 
 


### PR DESCRIPTION
## Summary

Closes #104. Migrates GNSS constellation writes from the legacy CFG-GNSS SET block (RAM-only, no layer concept) to the six per-constellation `CFG_SIGNAL_*_ENA` keys, written assertively via CFG-VALSET at layer=5 (RAM+Flash) through the existing write-and-verify/flash-divergence machinery. A constellation change made through Apply now survives a power cycle for the first time.

- `UbloxDriver.configure_gnss` now takes a `set[GnssConstellation]` instead of a full `GnssConfig`; channel allocation is left to the firmware (no channel parameter, by design). IMES/NavIC are never touched — they have no `GnssConstellation` member.
- `ReceiverAssertion.constellations` is now populated from the same six keys, folded into the existing batched scalar read for free — no separate GNSS block read on the assertion path.
- The legacy CFG-GNSS block poll survives only as a capability probe: `DeviceService.connect()` runs it once per connection (diagnostic-only, never fails connect), and `UbloxDriver.configure_gnss` re-runs it after a constellation write actually executes. A probe-vs-keys disagreement is queued on the driver's warning channel, never raised and never a read-back field diff.
- `PUT /api/device/gnss` now takes a `GnssConstellationSelection` (a bare wanted set) instead of a full `GnssConfig` body, fixing the identical RAM-only gap that endpoint had.
- Removes the GPS Config page's Save-to-Flash card — its sole justification was the RAM-only constellation write; the underlying `save_to_flash` service/driver/API paths are untouched.

## Test plan

- [x] `uv run pytest` (unit suite, `--cov-fail-under=90`) — 1519 passed, 93.8% coverage
- [x] `uv run pytest tests/e2e --no-cov` — 80 passed (Playwright, fake driver)
- [x] `uv run pytest tests/integration --no-cov` — passes except 4 pre-existing, unrelated failures in `test_destination_management.py` (verified present on `main` too)
- [x] `uv run ruff check src/ tests/` / `uv run ruff format --check src/ tests/` — clean
- [x] `uv run pyright src/` (strict, canonical) — 0 errors
- [x] Two-axis code review (Standards + Spec vs. issue #104) run via parallel sub-agents; the one real gap found (the "once per connection" legacy-probe trigger) was fixed and re-verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVYMZRfrCSQF7UHkW46hA6