### PR TITLE
feat(gps): saving a profile becomes a first-class action

### DIFF
--- a/src/sp_rtk_base/ui/pages/gps_config.py
+++ b/src/sp_rtk_base/ui/pages/gps_config.py
@@ -121,7 +121,11 @@ from sp_rtk_base.services.device_service import (
 )
 from sp_rtk_base.services.drivers import create_driver, list_drivers
 from sp_rtk_base.services.drivers.base import GpsReceiverDriver
-from sp_rtk_base.services.profile_store import ProfileStore, ProfileStoreError
+from sp_rtk_base.services.profile_store import (
+    ProfileConflictError,
+    ProfileStore,
+    ProfileStoreError,
+)
 from sp_rtk_base.ui.layout import page_layout
 
 logger = logging.getLogger(__name__)
@@ -416,12 +420,21 @@ def is_modified_from_profile(
 
 
 def save_as_enabled(form_request: ReceiverApplyRequest | None) -> bool:
-    """Save-as (and every other save control) is available whenever the
+    """Whether the action-row Save-as button is available: whenever the
     form is valid — full stop (issue #106). There is no suppression for
     an unmodified copy of the selected profile any more: the dialog
     itself explains that case with a note (see
-    :func:`save_as_unmodified_note`) rather than a page-level control
-    going dead, since a prominent dead button is the bug this replaced."""
+    :func:`save_as_unmodified_note`) rather than this control going
+    dead, since a prominent dead button is the bug this replaced.
+
+    No control on the page is ever *greyed* for any other reason
+    either, though the other two save entry points express that
+    differently: the picker's persistent row and the post-apply prompt
+    are simply never disabled (an invalid form surfaces as an error on
+    submit instead), and the in-place ``Save profile`` control is
+    hidden rather than gated on validity at all — see
+    :func:`save_profile_visible`.
+    """
     return form_request is not None
 
 
@@ -1639,26 +1652,37 @@ def gps_config_page() -> None:
             _on_form_changed()
 
         def _confirm_save_as() -> None:
-            """Create-only path. A slug collision is keyed on the store,
-            never guessed from exception text (issue #106): a built-in
-            collision is rejected outright, a custom collision reveals
-            the explicit overwrite button instead of silently
-            overwriting or merely erroring."""
+            """Create-only path. A slug collision is keyed on the store's
+            own conflict detection — never guessed from exception text,
+            never re-implemented here — with only the *branch* (reject
+            outright vs. offer overwrite) decided in the UI, since only
+            the UI cares which is which (issue #106).
+
+            Every attempt starts by discarding whatever overwrite state
+            a *previous* attempt left behind: without this, editing the
+            name after a collision and re-confirming with a name that
+            fails validation (blank, or pure punctuation) would return
+            early and leave a stale "Overwrite it" wired to the earlier,
+            no-longer-current colliding profile.
+            """
             nonlocal pending_overwrite_profile
+            pending_overwrite_profile = None
+            save_as_overwrite_btn.set_visibility(False)
+
             profile = _build_pending_save_as_profile()
             if profile is None:
                 return
 
-            if profile_store.is_builtin(profile.name):
-                save_as_error_label.text = (
-                    f"'{profile.name}' collides with a built-in profile — "
-                    "choose another name."
-                )
-                save_as_error_label.set_visibility(True)
-                save_as_overwrite_btn.set_visibility(False)
-                return
-
-            if profile_store.get_profile(profile.name) is not None:
+            try:
+                created = profile_store.create_profile(profile)
+            except ProfileConflictError:
+                if profile_store.is_builtin(profile.name):
+                    save_as_error_label.text = (
+                        f"'{profile.name}' collides with a built-in profile — "
+                        "choose another name."
+                    )
+                    save_as_error_label.set_visibility(True)
+                    return
                 save_as_error_label.text = (
                     f"A custom profile named '{profile.name}' already exists."
                 )
@@ -1666,9 +1690,6 @@ def gps_config_page() -> None:
                 pending_overwrite_profile = profile
                 save_as_overwrite_btn.set_visibility(True)
                 return
-
-            try:
-                created = profile_store.create_profile(profile)
             except ProfileStoreError as exc:
                 save_as_error_label.text = str(exc)
                 save_as_error_label.set_visibility(True)

--- a/src/sp_rtk_base/ui/pages/gps_config.py
+++ b/src/sp_rtk_base/ui/pages/gps_config.py
@@ -60,6 +60,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from dataclasses import dataclass
 from typing import Literal
 
@@ -414,16 +415,75 @@ def is_modified_from_profile(
     return form_request != receiver_config_from_profile(profile, live)
 
 
-def save_as_enabled(
+def save_as_enabled(form_request: ReceiverApplyRequest | None) -> bool:
+    """Save-as (and every other save control) is available whenever the
+    form is valid — full stop (issue #106). There is no suppression for
+    an unmodified copy of the selected profile any more: the dialog
+    itself explains that case with a note (see
+    :func:`save_as_unmodified_note`) rather than a page-level control
+    going dead, since a prominent dead button is the bug this replaced."""
+    return form_request is not None
+
+
+def should_offer_save_after_apply(
     form_request: ReceiverApplyRequest | None,
     profile: Profile | None,
     live: ReceiverAssertion,
 ) -> bool:
-    """Save-as is available whenever the form is valid, suppressed only when
-    a *selected* profile still exactly equals the form."""
+    """Whether a successful Apply should offer to save a profile (issue
+    #106): whenever the form differs from the selected profile, or no
+    profile is selected. ``False`` when the form doesn't currently
+    validate — there is nothing to offer to save."""
     if form_request is None:
         return False
     return profile is None or is_modified_from_profile(form_request, profile, live)
+
+
+def save_as_unmodified_note(profile: Profile | None, is_modified: bool) -> str | None:
+    """The explanatory note the Save-as dialog shows in place of blocking
+    (issue #106) when it's opened on a form that still exactly equals the
+    *selected* profile — ``None`` when there's nothing to explain (no
+    profile selected, or the form has already diverged)."""
+    if profile is None or is_modified:
+        return None
+    return (
+        f"The form still matches '{display_label(profile)}' exactly — "
+        "saving now will create a new copy of it."
+    )
+
+
+def save_profile_visible(profile: Profile | None, is_builtin: bool) -> bool:
+    """Whether the in-place ``Save profile`` control should render at all
+    (issue #106). Hidden — not greyed — for a built-in or no selection:
+    both are genuinely inapplicable, not merely temporarily unavailable."""
+    return profile is not None and not is_builtin
+
+
+def has_custom_profiles(entries: list[ProfilePickerEntry]) -> bool:
+    """Whether the picker has at least one custom (non-built-in) entry —
+    drives the picker's empty-state guidance (issue #106)."""
+    return any(not entry.is_builtin for entry in entries)
+
+
+_SLUG_INVALID_CHARS_RE = re.compile(r"[^a-z0-9_-]+")
+_SLUG_REPEATED_DASH_RE = re.compile(r"-{2,}")
+
+
+def slugify_profile_name(display_name: str) -> str:
+    """Derive a filesystem-/URL-safe profile slug from a human display
+    name (issue #106) — the Save-as dialog shows this live as the
+    operator types.
+
+    Lowercases, collapses any run of characters outside
+    ``profile_store._SAFE_NAME_RE``'s charset (``^[A-Za-z0-9_-]+$``)
+    into a single hyphen, and trims leading/trailing hyphens. A name
+    with no ASCII alphanumeric characters at all (blank, or pure
+    punctuation) derives an empty slug — the caller treats that as
+    "name required", the same as a blank input.
+    """
+    lowered = display_name.strip().lower()
+    collapsed = _SLUG_INVALID_CHARS_RE.sub("-", lowered)
+    return _SLUG_REPEATED_DASH_RE.sub("-", collapsed).strip("-")
 
 
 def suggest_profile_name(profile: Profile | None, hardware_target: str) -> str:
@@ -467,14 +527,20 @@ def build_saved_profile(
     form_request: ReceiverApplyRequest,
     hardware: str,
     forked_from: str | None,
+    display_name: str | None = None,
 ) -> Profile:
-    """Construct the ``Profile`` document Save-as persists.
+    """Construct the ``Profile`` document Save-as (and the in-place
+    ``Save profile`` update) persists.
 
     Flattens *form_request*'s envelope — ``assertion``'s fields plus
     ``data_link_port`` — onto ``Profile``'s own field layout (issue
     #98: ``data_link_port`` moved off ``ReceiverConfig``, so it's no
     longer part of ``assertion.model_dump()`` and must be passed
-    separately).
+    separately). *name* is always the immutable slug; *display_name*
+    (issue #106) is the human label the Save-as dialog derived it
+    from — omitted when it's identical to the slug, so
+    :func:`display_label`'s fallback-to-slug rule stays the single
+    source of truth rather than storing the same string twice.
     """
     return Profile(
         **form_request.assertion.model_dump(),
@@ -483,6 +549,7 @@ def build_saved_profile(
         version=1,
         hardware=hardware,
         forked_from=forked_from,
+        display_name=display_name if display_name != name else None,
     )
 
 
@@ -993,6 +1060,29 @@ def gps_config_page() -> None:
                 )
                 modified_badge.set_visibility(False)
 
+            # Empty-state guidance (issue #106) — shown only while no
+            # custom profile exists yet, so a first run isn't a picker
+            # with nothing but built-ins and no clue how to change that.
+            no_customs_hint = ui.label(
+                "No custom profiles yet — save your current configuration "
+                "below to create one."
+            ).classes("no-customs-hint text-caption text-grey-4 q-mt-xs")
+            no_customs_hint.set_visibility(False)
+
+            # Entry point 1 of 3 (issue #106): a persistent row at the
+            # bottom of the picker, beside its sibling verbs
+            # (rename/delete/export above) — the discoverable home for
+            # saving, rather than something buried in the action row
+            # below the fold. Every save control names "profile" so it
+            # never reads as a bare "save" that could mean the receiver.
+            with (
+                ui.row()
+                .classes("save-as-picker-row items-center gap-2 q-mt-sm cursor-pointer")
+                .on("click", lambda: _open_save_as_dialog())
+            ):
+                ui.icon("add").classes("text-primary")
+                ui.label("Save current config as a profile…").classes("text-primary")
+
         # ================================================================
         # Section C: Receiver configuration — read-only, seeded from the
         # live receiver (hidden until connected)
@@ -1063,11 +1153,36 @@ def gps_config_page() -> None:
             with ui.row().classes("items-center gap-3 q-mt-md"):
                 apply_btn = ui.button("Apply", icon="bolt").props("color=primary")
                 sync_badge = ui.badge("").classes("sync-badge").props("color=positive")
+                # Entry point 2 of 3 (issue #106): "the moment I just
+                # proved this works" — catches an operator who scrolled
+                # down to Apply without going back up to the picker.
+                # Every save control names "profile", never a bare
+                # "save" that could be mistaken for writing the receiver.
                 save_as_btn = (
-                    ui.button("Save as…", icon="save")
+                    ui.button("Save as new profile…", icon="save")
                     .classes("save-as-btn")
                     .props("color=secondary outline")
                 )
+                # Distinct in-place update — hidden (not greyed) unless a
+                # *custom* profile is selected, since a built-in or no
+                # selection is genuinely inapplicable rather than merely
+                # unavailable (issue #106). No name typing: it always
+                # overwrites the selected custom's own slug.
+                save_profile_btn = (
+                    ui.button("Save profile", icon="save")
+                    .classes("save-profile-btn")
+                    .props("color=primary outline")
+                )
+                save_profile_btn.set_visibility(False)
+
+            # The Apply-versus-Save distinction, stated rather than
+            # inferred (issue #106) — every save control on this page
+            # names "profile" precisely so this caption is the only
+            # place the two verbs are spelled out side by side.
+            ui.label(
+                "Apply writes to the receiver. Save stores the form as a "
+                "profile on this machine."
+            ).classes("apply-save-caption text-caption text-grey-5 q-mt-xs")
 
             apply_result_label = (
                 ui.label("")
@@ -1075,6 +1190,22 @@ def gps_config_page() -> None:
                 .style("border: 1px solid #333; border-radius: 4px")
             )
             apply_result_label.set_visibility(False)
+
+            # Entry point 3 of 3 (issue #106): an inline prompt in the
+            # post-apply result panel, offered whenever the form differs
+            # from the selected profile or none is selected — the moment
+            # an Apply just confirmed a configuration works is exactly
+            # the moment worth asking whether to keep it.
+            with ui.row().classes(
+                "post-apply-save-row items-center gap-2 q-mt-xs"
+            ) as post_apply_save_row:
+                ui.label("Keep this configuration?").classes("text-caption text-grey-4")
+                post_apply_save_btn = (
+                    ui.button("Save as profile…", icon="save")
+                    .classes("post-apply-save-btn")
+                    .props("color=secondary outline dense")
+                )
+            post_apply_save_row.set_visibility(False)
 
             # Warning strip (issue #101) — the Survey page's amber-card
             # idiom for pre-flight advisories, reused here for Apply's
@@ -1101,23 +1232,71 @@ def gps_config_page() -> None:
             )
             step_log_view = ui.column().classes("step-log q-mt-xs gap-0")
 
-        # ---- Save-as dialog ----
+        # ---- Save-as dialog (issue #106 — the one dialog all three
+        # entry points open) ----
         with ui.dialog() as save_as_dialog, ui.card().classes("q-pa-md"):
             ui.label("Save as new profile").classes("text-h6 text-white")
             ui.separator()
-            save_as_name_input = ui.input("Name").classes("save-as-name w-full q-mt-sm")
+            save_as_name_input = ui.input("Display name").classes(
+                "save-as-name w-full q-mt-sm"
+            )
+            # The derived slug, live (issue #106) — updates on every
+            # keystroke via ``_update_save_as_slug``, so the operator
+            # always knows what the file will actually be called before
+            # they commit to it.
+            save_as_slug_label = ui.label("").classes(
+                "save-as-slug text-caption text-grey-4 q-mt-xs"
+            )
             save_as_from_label = ui.label("").classes(
                 "save-as-from text-caption text-grey-4 q-mt-xs"
             )
+            # Suppression is dropped (issue #106): opening the dialog on
+            # an unmodified copy of the selected profile no longer
+            # blocks anything — it just explains, here, why saving now
+            # would produce a duplicate.
+            save_as_unmodified_label = ui.label("").classes(
+                "save-as-unmodified text-caption text-grey-4 q-mt-xs"
+            )
+            save_as_unmodified_label.set_visibility(False)
             save_as_error_label = ui.label("").classes(
                 "save-as-error text-negative text-caption q-mt-xs"
             )
             save_as_error_label.set_visibility(False)
             with ui.row().classes("justify-end gap-2 q-mt-md"):
                 ui.button("Cancel", on_click=save_as_dialog.close).props("flat")
+                # Revealed only after a collision with an existing
+                # *custom* profile (issue #106) — a collision with a
+                # built-in is rejected outright and never shows this.
+                # Destructive-styled since it overwrites that profile's
+                # saved content.
+                save_as_overwrite_btn = (
+                    ui.button("Overwrite it")
+                    .classes("save-as-overwrite-btn")
+                    .props("color=negative")
+                )
+                save_as_overwrite_btn.set_visibility(False)
                 save_as_confirm_btn = (
                     ui.button("Create")
                     .classes("save-as-confirm-btn")
+                    .props("color=primary")
+                )
+
+        # ---- Save profile dialog (in-place update, issue #106) —
+        # updates the selected custom profile's saved content behind a
+        # small confirm, with no name typing: always the same slug. ----
+        with ui.dialog() as save_profile_dialog, ui.card().classes("q-pa-md"):
+            ui.label("Update profile?").classes("text-h6 text-white")
+            ui.separator()
+            save_profile_confirm_label = ui.label("").classes("q-mt-sm")
+            ui.label(
+                "This overwrites its saved content with the current form. "
+                "The live receiver is untouched."
+            ).classes("text-caption text-grey-4 q-mt-xs")
+            with ui.row().classes("justify-end gap-2 q-mt-md"):
+                ui.button("Cancel", on_click=save_profile_dialog.close).props("flat")
+                save_profile_confirm_btn = (
+                    ui.button("Save profile")
+                    .classes("save-profile-confirm-btn")
                     .props("color=primary")
                 )
 
@@ -1296,9 +1475,15 @@ def gps_config_page() -> None:
             picker_select.update()
 
             # Rename/delete/export act on whichever profile is currently
-            # selected (issue #105) — customs-only, same as before.
-            is_custom_selected = selected_profile is not None and not (
+            # selected (issue #105) — customs-only, same as before. The
+            # in-place "Save profile" control (issue #106) is gated the
+            # same way — hidden, not greyed, for a built-in or nothing
+            # selected.
+            is_builtin_selected = selected_profile is not None and (
                 profile_store.is_builtin(selected_profile.name)
+            )
+            is_custom_selected = (
+                selected_profile is not None and not is_builtin_selected
             )
             for icon in (
                 picker_rename_icon,
@@ -1306,6 +1491,13 @@ def gps_config_page() -> None:
                 picker_export_icon,
             ):
                 icon.set_visibility(is_custom_selected)
+            save_profile_btn.set_visibility(
+                save_profile_visible(selected_profile, is_builtin_selected)
+            )
+
+            # Empty-state guidance (issue #106) — shown only while the
+            # picker has no custom profile at all.
+            no_customs_hint.set_visibility(not has_custom_profiles(entries))
 
         def _select_profile_by_name(name: str | None) -> None:
             """``update:model-value`` handler for the picker dropdown.
@@ -1354,27 +1546,68 @@ def gps_config_page() -> None:
                 info.hardware_confidence if info else None,
             )
 
+        def _update_save_as_slug() -> None:
+            """Live slug preview (issue #106) — recomputed on every
+            keystroke in the display-name input."""
+            slug = slugify_profile_name(save_as_name_input.value or "")
+            save_as_slug_label.text = (
+                f"Will be saved as: {slug}" if slug else "Enter a name to derive a slug"
+            )
+
         def _open_save_as_dialog() -> None:
+            """Open the one Save-as dialog every entry point shares
+            (issue #106): the picker's persistent row, the action row's
+            "Save as new profile…", and the post-apply prompt all call
+            this."""
+            nonlocal pending_overwrite_profile
+            pending_overwrite_profile = None
             identity = _current_identity()
             save_as_name_input.value = suggest_profile_name(
                 selected_profile, identity.target
             )
+            _update_save_as_slug()
             save_as_from_label.text = (
                 f"Forked from: {display_label(selected_profile)}"
                 if selected_profile
                 else ""
             )
             save_as_from_label.set_visibility(selected_profile is not None)
+
+            # Suppression is dropped (issue #106) — an unmodified copy
+            # of the selected profile no longer blocks the dialog, it
+            # just explains itself here.
+            form_request = _current_form_request()
+            note = save_as_unmodified_note(
+                selected_profile,
+                is_modified=(
+                    form_request is None
+                    or is_modified_from_profile(form_request, selected_profile, live)
+                ),
+            )
+            save_as_unmodified_label.text = note or ""
+            save_as_unmodified_label.set_visibility(note is not None)
+
             save_as_error_label.set_visibility(False)
+            save_as_overwrite_btn.set_visibility(False)
             save_as_dialog.open()
 
-        def _confirm_save_as() -> None:
-            nonlocal selected_profile
-            name = (save_as_name_input.value or "").strip()
-            if not name:
+        def _build_pending_save_as_profile() -> Profile | None:
+            """The ``Profile`` a Save-as confirm would persist, or
+            ``None`` with the dialog's error already set when the form
+            or name doesn't currently validate."""
+            display_name = (save_as_name_input.value or "").strip()
+            if not display_name:
                 save_as_error_label.text = "Name is required"
                 save_as_error_label.set_visibility(True)
-                return
+                return None
+
+            slug = slugify_profile_name(display_name)
+            if not slug:
+                save_as_error_label.text = (
+                    "Name must contain at least one letter or digit."
+                )
+                save_as_error_label.set_visibility(True)
+                return None
 
             form_request = _current_form_request()
             if form_request is None:
@@ -1383,22 +1616,123 @@ def gps_config_page() -> None:
                     "matrix / data-link ports before saving."
                 )
                 save_as_error_label.set_visibility(True)
-                return
+                return None
 
             hardware = resolve_save_hardware(selected_profile, _current_identity())
             forked_from = selected_profile.name if selected_profile else None
+            try:
+                return build_saved_profile(
+                    slug, form_request, hardware, forked_from, display_name=display_name
+                )
+            except ValidationError as exc:
+                save_as_error_label.text = str(exc)
+                save_as_error_label.set_visibility(True)
+                return None
+
+        def _finish_save_as(saved: Profile) -> None:
+            nonlocal selected_profile, pending_overwrite_profile
+            selected_profile = saved
+            pending_overwrite_profile = None
+            save_as_dialog.close()
+            ui.notify(f"Saved profile '{display_label(saved)}'", type="positive")
+            _render_picker()
+            _on_form_changed()
+
+        def _confirm_save_as() -> None:
+            """Create-only path. A slug collision is keyed on the store,
+            never guessed from exception text (issue #106): a built-in
+            collision is rejected outright, a custom collision reveals
+            the explicit overwrite button instead of silently
+            overwriting or merely erroring."""
+            nonlocal pending_overwrite_profile
+            profile = _build_pending_save_as_profile()
+            if profile is None:
+                return
+
+            if profile_store.is_builtin(profile.name):
+                save_as_error_label.text = (
+                    f"'{profile.name}' collides with a built-in profile — "
+                    "choose another name."
+                )
+                save_as_error_label.set_visibility(True)
+                save_as_overwrite_btn.set_visibility(False)
+                return
+
+            if profile_store.get_profile(profile.name) is not None:
+                save_as_error_label.text = (
+                    f"A custom profile named '{profile.name}' already exists."
+                )
+                save_as_error_label.set_visibility(True)
+                pending_overwrite_profile = profile
+                save_as_overwrite_btn.set_visibility(True)
+                return
 
             try:
-                profile = build_saved_profile(name, form_request, hardware, forked_from)
                 created = profile_store.create_profile(profile)
-            except (ValidationError, ProfileStoreError) as exc:
+            except ProfileStoreError as exc:
                 save_as_error_label.text = str(exc)
                 save_as_error_label.set_visibility(True)
                 return
+            _finish_save_as(created)
 
-            selected_profile = created
-            save_as_dialog.close()
-            ui.notify(f"Saved profile '{created.name}'", type="positive")
+        def _confirm_overwrite_save_as() -> None:
+            """The explicit, destructive-styled overwrite path (issue
+            #106) — only reachable once ``_confirm_save_as`` has already
+            found a custom-profile collision."""
+            if pending_overwrite_profile is None:
+                return
+            try:
+                updated = profile_store.update_profile(pending_overwrite_profile)
+            except ProfileStoreError as exc:
+                save_as_error_label.text = str(exc)
+                save_as_error_label.set_visibility(True)
+                return
+            _finish_save_as(updated)
+
+        def _open_save_profile_dialog() -> None:
+            """In-place update entry point (issue #106) — no name
+            typing, just a confirm, since it always overwrites the
+            already-selected custom profile's own slug."""
+            if selected_profile is None:
+                return
+            save_profile_confirm_label.text = (
+                f"Update profile '{display_label(selected_profile)}' with the "
+                "current form?"
+            )
+            save_profile_dialog.open()
+
+        def _confirm_save_profile_update() -> None:
+            nonlocal selected_profile
+            if selected_profile is None:
+                save_profile_dialog.close()
+                return
+            form_request = _current_form_request()
+            if form_request is None:
+                save_profile_dialog.close()
+                ui.notify(
+                    "The form doesn't currently validate — fix the RTCM "
+                    "matrix / data-link ports before saving.",
+                    type="negative",
+                )
+                return
+
+            updated = build_saved_profile(
+                selected_profile.name,
+                form_request,
+                selected_profile.hardware,
+                selected_profile.forked_from,
+                display_name=selected_profile.display_name,
+            )
+            try:
+                saved = profile_store.update_profile(updated)
+            except ProfileStoreError as exc:
+                save_profile_dialog.close()
+                ui.notify(str(exc), type="negative")
+                return
+
+            selected_profile = saved
+            save_profile_dialog.close()
+            ui.notify(f"Updated profile '{display_label(saved)}'", type="positive")
             _render_picker()
             _on_form_changed()
 
@@ -1545,6 +1879,12 @@ def gps_config_page() -> None:
         rename_target: str | None = None
         delete_target: str | None = None
         delete_target_label: str = ""
+
+        # The profile a Save-as attempt just collided with (issue #106)
+        # — set only while the dialog's revealed "Overwrite it" button
+        # is showing, and only ever a *custom* collision (a built-in
+        # collision is rejected outright and never populates this).
+        pending_overwrite_profile: Profile | None = None
 
         # Provenance for the three-state badge and inline markers (issue
         # #101): paths that appeared in the *last* Apply's read-back diff
@@ -2040,9 +2380,10 @@ def gps_config_page() -> None:
                 modified_badge.props("color=grey-7 outline")
 
         def _render_save_as_gate() -> None:
-            save_as_btn.set_enabled(
-                save_as_enabled(_current_form_request(), selected_profile, live)
-            )
+            """Save-as is gated on form validity alone (issue #106) — no
+            save control on this page is ever greyed for any other
+            reason."""
+            save_as_btn.set_enabled(save_as_enabled(_current_form_request()))
 
         def _render_throughput_advisory() -> None:
             """The live counterpart to ``_render_advisory`` (issue #102) —
@@ -2087,6 +2428,17 @@ def gps_config_page() -> None:
 
         def _clear_apply_result() -> None:
             apply_result_label.set_visibility(False)
+            post_apply_save_row.set_visibility(False)
+
+        def _render_post_apply_save_prompt(status: Literal["ok", "failed"]) -> None:
+            """Entry point 3 of 3 (issue #106): offered only after a
+            *successful* apply, and only when there's actually something
+            worth offering to keep — the form differs from the selected
+            profile, or none is selected."""
+            offer = status == "ok" and should_offer_save_after_apply(
+                _current_form_request(), selected_profile, live
+            )
+            post_apply_save_row.set_visibility(offer)
 
         def _clear_warning_strip() -> None:
             warning_strip_card.set_visibility(False)
@@ -2153,6 +2505,7 @@ def gps_config_page() -> None:
             """
             nonlocal live
             _clear_warning_strip()
+            post_apply_save_row.set_visibility(False)
 
             try:
                 request = build_apply_request(form, form_data_link_ports)
@@ -2190,6 +2543,7 @@ def gps_config_page() -> None:
 
             headline = apply_headline(result.status, len(warning_lines))
             _set_apply_result(headline, ok=(result.status == "ok"))
+            _render_post_apply_save_prompt(result.status)
             ui.notify(
                 headline,
                 type="positive" if result.status == "ok" else "warning",
@@ -2375,7 +2729,12 @@ def gps_config_page() -> None:
         reload_device_btn.on_click(_reload_device_config)
         apply_btn.on_click(_apply)
         save_as_btn.on_click(_open_save_as_dialog)
+        save_as_name_input.on_value_change(lambda: _update_save_as_slug())
         save_as_confirm_btn.on_click(_confirm_save_as)
+        save_as_overwrite_btn.on_click(_confirm_overwrite_save_as)
+        save_profile_btn.on_click(_open_save_profile_dialog)
+        save_profile_confirm_btn.on_click(_confirm_save_profile_update)
+        post_apply_save_btn.on_click(_open_save_as_dialog)
         rename_confirm_btn.on_click(_confirm_rename)
         delete_confirm_btn.on_click(_confirm_delete)
 

--- a/tests/e2e/test_gps_apply.py
+++ b/tests/e2e/test_gps_apply.py
@@ -112,8 +112,13 @@ def test_factory_receiver_blocks_apply_until_data_link_port_chosen(
     expect(apply_btn).to_be_disabled()
 
     # Turn on 1005 for UART1 so the chosen data-link port has a row on,
-    # then explicitly pick UART1 as the data-link port.
+    # then explicitly pick UART1 as the data-link port. The matrix
+    # toggle rebuilds the data-link checkboxes (``_on_form_changed`` ->
+    # ``_render_data_link_picker``) over the websocket round-trip, so
+    # wait for that edit to settle before clicking the checkbox it
+    # rebuilds — otherwise the second click can race the rebuild.
     page.locator(".rtcm-cell-1005-UART1").click()
+    expect(page.locator(".rtcm-cell-1005-UART1")).to_have_text("✓", timeout=10_000)
     page.locator(".data-link-checkbox-UART1").click()
 
     expect(page.locator(".data-link-blocked")).not_to_be_visible(timeout=10_000)

--- a/tests/e2e/test_gps_profile_save_as.py
+++ b/tests/e2e/test_gps_profile_save_as.py
@@ -1,5 +1,5 @@
 """E2E tests for profile pre-fill, Save-as, and the profile-relation
-indicator (issues #66, #105).
+indicator (issues #66, #105, #106).
 
 Extends the GPS page suite (``test_gps_profile_picker.py`` covers the
 picker dropdown itself, ``test_gps_apply.py`` covers #65's out-of-sync
@@ -11,19 +11,23 @@ writing into the form, plus the *second*, independent indicator:
   badge reads "Matches <name>" immediately after the pick (before any
   further edit) — the sparse-vs-dense matrix representation bug this
   guards against is covered at the unit level
-  (``TestIsModifiedFromProfile``/``TestSaveAsEnabled`` in
-  ``test_gps_config_helpers.py``).
-- Editing the form after a pick flips the badge to "Modified from X"
-  and re-enables Save-as.
-- Save-as is available with no profile selected (the bare-capture
-  usage path) and suppressed only while a selected profile still
-  exactly equals the form.
+  (``TestIsModifiedFromProfile`` in ``test_gps_config_helpers.py``).
+- Editing the form after a pick flips the badge to "Modified from X".
+- Save-as is available whenever the form is valid — no save control on
+  the page is ever greyed (issue #106 dropped the old suppression for
+  an unmodified copy of the selected profile; the dialog now explains
+  that case with a note instead).
 - Saving forks an independent custom profile carrying a
-  ``forked_from`` provenance label; a name collision surfaces inline
-  rather than silently overwriting.
+  ``forked_from`` provenance label; a name collision with a built-in
+  is rejected outright, a collision with a custom profile offers an
+  explicit overwrite.
 - Rename/delete/export are customs-only, and act on whichever profile
   is currently selected in the dropdown (issue #105 moved them from a
   per-row icon set to a single icon trio beside the picker).
+- Issue #106's three save entry points (the picker's persistent row,
+  the action row's "Save as new profile…", the post-apply prompt) all
+  open the same dialog; the in-place "Save profile" control is hidden
+  — not greyed — for a built-in or no selection.
 
 Locators target the stable CSS class hooks the page renders (see
 ``ui/pages/gps_config.py``), matching the existing suite's convention.
@@ -144,21 +148,24 @@ def test_selecting_profile_prefills_matrix_and_matches_immediately(
     expect(modified_badge).to_be_visible()
     expect(modified_badge).to_contain_text(f"Matches {BUILTIN_DISPLAY_NAME}")
 
-    expect(page.locator(".save-as-btn")).to_be_disabled()
+    # Issue #106: suppression is dropped — Save-as stays enabled even
+    # on an unmodified copy of the selected profile. No save control on
+    # this page is ever greyed.
+    expect(page.locator(".save-as-btn")).to_be_enabled()
 
 
 @pytest.mark.e2e
-def test_editing_after_pick_flips_to_modified_and_reenables_save_as(
+def test_editing_after_pick_flips_to_modified_and_save_as_stays_enabled(
     page: Page,
     base_url: str,
     connected_gps: None,
 ) -> None:
-    """The T4 fix this ticket exists for: an edit after a successful pick
-    must not take Save-as away — quite the opposite, it's what re-enables
-    it."""
+    """Issue #106: Save-as is enabled the whole time — before *and* after
+    the edit — while the "modified from X" badge is what actually tracks
+    divergence from the picked profile."""
     _goto_gps_config(page, base_url)
     _select_builtin(page)
-    expect(page.locator(".save-as-btn")).to_be_disabled()
+    expect(page.locator(".save-as-btn")).to_be_enabled()
 
     page.locator(".rtcm-cell-1077-UART1").click()
 
@@ -178,7 +185,9 @@ def test_save_as_stays_enabled_after_a_real_successful_apply(
     actual Apply button/endpoint, not just the pure-helper unit test — the
     approved prototype's bug (gating Save-as off the *receiver* comparison)
     would clear "modified from X" the moment Apply clears "out of sync",
-    since both would be the same indicator."""
+    since both would be the same indicator. Also covers the post-apply
+    save prompt (issue #106): offered because the form still differs from
+    the selected profile."""
     _goto_gps_config(page, base_url)
     _select_builtin(page)
     page.locator(".rtcm-cell-1077-UART1").click()
@@ -195,6 +204,29 @@ def test_save_as_stays_enabled_after_a_real_successful_apply(
     # "modified from X" and Save-as exactly as they were.
     expect(modified_badge).to_contain_text(f"Modified from {BUILTIN_DISPLAY_NAME}")
     expect(page.locator(".save-as-btn")).to_be_enabled()
+    expect(page.locator(".post-apply-save-row")).to_be_visible()
+
+
+@pytest.mark.e2e
+def test_no_post_apply_save_prompt_when_form_matches_selected_profile(
+    page: Page,
+    base_url: str,
+    connected_gps: None,
+) -> None:
+    """AC: the post-apply prompt is offered only when the form differs
+    from the selected profile or none is selected — an unmodified apply
+    of the picked profile has nothing new worth offering to keep."""
+    _goto_gps_config(page, base_url)
+    _select_builtin(page)
+    expect(page.locator(".modified-badge")).to_contain_text(
+        f"Matches {BUILTIN_DISPLAY_NAME}"
+    )
+
+    page.get_by_role("button", name="Apply").click()
+    expect(page.locator(".apply-result")).to_contain_text(
+        "Applied and verified", timeout=10_000
+    )
+    expect(page.locator(".post-apply-save-row")).to_be_hidden()
 
 
 @pytest.mark.e2e
@@ -276,13 +308,39 @@ def test_save_as_bare_capture_has_no_forked_from(
 
 
 @pytest.mark.e2e
-def test_save_as_name_collision_is_rejected_with_a_clear_error(
+def test_save_as_collision_with_a_builtin_is_rejected_outright(
+    page: Page,
+    base_url: str,
+    connected_gps: None,
+) -> None:
+    """AC: "A collision with a built-in profile is rejected outright" —
+    no overwrite offered, since that would let a custom profile shadow a
+    reference configuration."""
+    _goto_gps_config(page, base_url)
+    page.locator(".save-as-btn").click()
+    page.locator(".save-as-name input").fill(BUILTIN_NAME)
+    page.locator(".save-as-confirm-btn").click()
+
+    expect(page.locator(".save-as-error")).to_be_visible(timeout=5_000)
+    expect(page.locator(".save-as-error")).to_contain_text(BUILTIN_NAME)
+    expect(page.locator(".save-as-error")).to_contain_text("built-in")
+    expect(page.locator(".save-as-overwrite-btn")).to_be_hidden()
+    # Rejected, not overwritten — the dialog stays open.
+    expect(page.locator(".save-as-name")).to_be_visible()
+
+
+@pytest.mark.e2e
+def test_save_as_collision_with_a_custom_offers_an_explicit_overwrite(
     page: Page,
     base_url: str,
     api_base_url: str,
     connected_gps: None,
     cleanup_profiles: list[str],
 ) -> None:
+    """AC: "A collision with a custom profile offers an explicit
+    overwrite behind a confirm" — the error names the promise, and the
+    revealed "Overwrite it" button actually replaces its saved content
+    rather than silently failing or duplicating."""
     existing = {
         "name": "e2e-collision",
         "version": 1,
@@ -295,14 +353,30 @@ def test_save_as_name_collision_is_rejected_with_a_clear_error(
     cleanup_profiles.append("e2e-collision")
 
     _goto_gps_config(page, base_url)
+    # 1074 has no live data on any port (see ``_goto_gps_config``'s
+    # sibling docstrings) — a reliable off-to-on edit to verify below.
+    page.locator(".rtcm-cell-1074-UART1").click()
+
     page.locator(".save-as-btn").click()
     page.locator(".save-as-name input").fill("e2e-collision")
     page.locator(".save-as-confirm-btn").click()
 
     expect(page.locator(".save-as-error")).to_be_visible(timeout=5_000)
     expect(page.locator(".save-as-error")).to_contain_text("e2e-collision")
-    # Rejected, not overwritten — the dialog stays open.
-    expect(page.locator(".save-as-name")).to_be_visible()
+    overwrite_btn = page.locator(".save-as-overwrite-btn")
+    expect(overwrite_btn).to_be_visible()
+
+    overwrite_btn.click()
+    expect(page.locator(".save-as-name")).to_be_hidden()  # dialog closed
+
+    resp = httpx.get(f"{api_base_url}/api/profiles/e2e-collision", timeout=5.0)
+    assert resp.status_code == 200, resp.text
+    matrix = resp.json()["profile"]["rtcm_stream"]["matrix"]
+    assert matrix["1074"]["UART1"] is True
+
+    # Overwritten in place, not duplicated — still exactly one option.
+    page.locator(".profile-picker").click()
+    expect(page.locator(".profile-option-e2e-collision")).to_have_count(1)
 
 
 @pytest.mark.e2e
@@ -390,3 +464,229 @@ def test_rename_then_delete_custom_profile(
 
     page.locator(".profile-picker").click()
     expect(page.locator(".profile-option-e2e-rename-me")).to_have_count(0)
+
+
+# ---------------------------------------------------------------------------
+# Issue #106 — three entry points into one dialog, the in-place "Save
+# profile" update, the live-derived slug, the unmodified note, and the
+# picker's empty-state guidance.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.e2e
+def test_picker_row_entry_point_opens_the_save_as_dialog(
+    page: Page,
+    base_url: str,
+    connected_gps: None,
+) -> None:
+    """AC: "All three entry points open the same dialog" — entry point 1,
+    the persistent row at the bottom of the picker."""
+    _goto_gps_config(page, base_url)
+    expect(page.locator(".save-as-picker-row")).to_be_visible()
+    page.locator(".save-as-picker-row").click()
+    expect(page.locator(".save-as-name")).to_be_visible(timeout=5_000)
+
+
+@pytest.mark.e2e
+def test_action_row_entry_point_opens_the_save_as_dialog(
+    page: Page,
+    base_url: str,
+    connected_gps: None,
+) -> None:
+    """Entry point 2: "Save as new profile…" in the action row. Every
+    save control names "profile"."""
+    _goto_gps_config(page, base_url)
+    expect(page.locator(".save-as-btn")).to_contain_text("Save as new profile")
+    page.locator(".save-as-btn").click()
+    expect(page.locator(".save-as-name")).to_be_visible(timeout=5_000)
+
+
+@pytest.mark.e2e
+def test_post_apply_prompt_entry_point_opens_the_save_as_dialog(
+    page: Page,
+    base_url: str,
+    connected_gps: None,
+) -> None:
+    """Entry point 3: the inline prompt in the post-apply result panel."""
+    _goto_gps_config(page, base_url)
+    page.locator(".rtcm-cell-1077-UART1").click()  # diverge from live, so it's offered
+
+    page.get_by_role("button", name="Apply").click()
+    expect(page.locator(".apply-result")).to_contain_text(
+        "Applied and verified", timeout=10_000
+    )
+    expect(page.locator(".post-apply-save-btn")).to_be_visible()
+    page.locator(".post-apply-save-btn").click()
+    expect(page.locator(".save-as-name")).to_be_visible(timeout=5_000)
+
+
+@pytest.mark.e2e
+def test_apply_versus_save_caption_is_present(
+    page: Page,
+    base_url: str,
+    connected_gps: None,
+) -> None:
+    """AC: "the action row carries the Apply-versus-Save caption"."""
+    _goto_gps_config(page, base_url)
+    caption = page.locator(".apply-save-caption")
+    expect(caption).to_be_visible()
+    expect(caption).to_contain_text("Apply writes to the receiver")
+    expect(caption).to_contain_text("Save stores the form as a profile")
+
+
+@pytest.mark.e2e
+def test_save_as_dialog_shows_the_derived_slug_live(
+    page: Page,
+    base_url: str,
+    connected_gps: None,
+) -> None:
+    """AC: "The dialog shows the derived slug live as the operator types
+    a display name"."""
+    _goto_gps_config(page, base_url)
+    page.locator(".save-as-btn").click()
+    name_input = page.locator(".save-as-name input")
+    name_input.fill("My Rooftop Base")
+    expect(page.locator(".save-as-slug")).to_contain_text(
+        "my-rooftop-base", timeout=5_000
+    )
+
+
+@pytest.mark.e2e
+def test_save_as_dialog_shows_unmodified_note_instead_of_blocking(
+    page: Page,
+    base_url: str,
+    connected_gps: None,
+) -> None:
+    """AC: "Opening the dialog on an unmodified copy shows an explanatory
+    note instead of blocking" — the note names the source profile, and
+    the dialog is still fully usable (Create stays enabled)."""
+    _goto_gps_config(page, base_url)
+    _select_builtin(page)
+
+    page.locator(".save-as-btn").click()
+    note = page.locator(".save-as-unmodified")
+    expect(note).to_be_visible(timeout=5_000)
+    expect(note).to_contain_text(BUILTIN_DISPLAY_NAME)
+    expect(page.locator(".save-as-confirm-btn")).to_be_enabled()
+    page.keyboard.press("Escape")
+
+    # Diverge, then reopen — the note goes away, there's nothing to explain.
+    page.locator(".rtcm-cell-1077-UART1").click()
+    page.locator(".save-as-btn").click()
+    expect(page.locator(".save-as-unmodified")).to_be_hidden(timeout=5_000)
+
+
+@pytest.mark.e2e
+def test_save_profile_hidden_not_greyed_for_builtin_or_no_selection(
+    page: Page,
+    base_url: str,
+    api_base_url: str,
+    connected_gps: None,
+    cleanup_profiles: list[str],
+) -> None:
+    """AC: "`Save profile` is hidden, not greyed, when a built-in or
+    nothing is selected"."""
+    custom = {
+        "name": "e2e-save-profile-visibility",
+        "version": 1,
+        "hardware": "any",
+        "data_link_port": ["UART1"],
+        "rtcm_stream": {"matrix": {"1005": {"UART1": True}}},
+    }
+    resp = httpx.post(f"{api_base_url}/api/profiles", json=custom, timeout=5.0)
+    assert resp.status_code in (201, 409), resp.text
+    cleanup_profiles.append("e2e-save-profile-visibility")
+
+    _goto_gps_config(page, base_url)
+    save_profile_btn = page.locator(".save-profile-btn")
+    expect(save_profile_btn).to_be_hidden()  # nothing selected
+
+    _select_builtin(page)
+    expect(save_profile_btn).to_be_hidden()  # built-in selected
+
+    _select_profile_option(page, "e2e-save-profile-visibility")
+    expect(save_profile_btn).to_be_visible()  # custom selected
+
+
+@pytest.mark.e2e
+def test_save_profile_updates_the_selected_custom_in_place(
+    page: Page,
+    base_url: str,
+    api_base_url: str,
+    connected_gps: None,
+    cleanup_profiles: list[str],
+) -> None:
+    """AC: "`Save profile` updates the selected custom in place behind a
+    confirm, without asking for a name" — same slug afterwards, new
+    content, and the "modified from X" badge flips back to "Matches"."""
+    custom = {
+        "name": "e2e-save-profile-inplace",
+        "version": 1,
+        "hardware": "any",
+        "data_link_port": ["UART1"],
+        "rtcm_stream": {"matrix": {"1005": {"UART1": True}}},
+    }
+    resp = httpx.post(f"{api_base_url}/api/profiles", json=custom, timeout=5.0)
+    assert resp.status_code in (201, 409), resp.text
+    cleanup_profiles.append("e2e-save-profile-inplace")
+
+    _goto_gps_config(page, base_url)
+    _select_profile_option(page, "e2e-save-profile-inplace")
+    # Wait for the pick to fully settle before editing — same race
+    # ``_select_builtin`` guards against.
+    expect(page.locator(".modified-badge")).to_contain_text(
+        "Matches e2e-save-profile-inplace", timeout=10_000
+    )
+    page.locator(".rtcm-cell-1077-UART1").click()
+    expect(page.locator(".modified-badge")).to_contain_text(
+        "Modified from e2e-save-profile-inplace"
+    )
+
+    page.locator(".save-profile-btn").click()
+    expect(page.locator(".save-profile-confirm-btn")).to_be_visible(timeout=5_000)
+    page.locator(".save-profile-confirm-btn").click()
+
+    expect(page.locator(".save-profile-confirm-btn")).to_be_hidden(timeout=5_000)
+    expect(page.locator(".modified-badge")).to_contain_text(
+        "Matches e2e-save-profile-inplace"
+    )
+
+    resp = httpx.get(
+        f"{api_base_url}/api/profiles/e2e-save-profile-inplace", timeout=5.0
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["profile"]["rtcm_stream"]["matrix"]["1077"]["UART1"] is True
+
+    # Still exactly one option — an in-place update, not a fork.
+    page.locator(".profile-picker").click()
+    expect(page.locator(".profile-option-e2e-save-profile-inplace")).to_have_count(1)
+
+
+@pytest.mark.e2e
+def test_picker_shows_guidance_when_no_custom_profiles_exist(
+    page: Page,
+    base_url: str,
+    api_base_url: str,
+    connected_gps: None,
+    cleanup_profiles: list[str],
+) -> None:
+    """AC: "The picker shows guidance when no custom profiles exist"."""
+    _goto_gps_config(page, base_url)
+    expect(page.locator(".no-customs-hint")).to_be_visible(timeout=10_000)
+
+    custom = {
+        "name": "e2e-empty-state-guard",
+        "version": 1,
+        "hardware": "any",
+        "data_link_port": ["UART1"],
+        "rtcm_stream": {"matrix": {"1005": {"UART1": True}}},
+    }
+    resp = httpx.post(f"{api_base_url}/api/profiles", json=custom, timeout=5.0)
+    assert resp.status_code in (201, 409), resp.text
+    cleanup_profiles.append("e2e-empty-state-guard")
+
+    page.reload()
+    expect(page.locator("text=Advanced GPS Configuration").first).to_be_visible(
+        timeout=15_000
+    )
+    expect(page.locator(".no-customs-hint")).to_be_hidden(timeout=10_000)

--- a/tests/e2e/test_gps_profile_save_as.py
+++ b/tests/e2e/test_gps_profile_save_as.py
@@ -380,6 +380,49 @@ def test_save_as_collision_with_a_custom_offers_an_explicit_overwrite(
 
 
 @pytest.mark.e2e
+def test_overwrite_button_clears_after_an_invalid_retry(
+    page: Page,
+    base_url: str,
+    api_base_url: str,
+    connected_gps: None,
+    cleanup_profiles: list[str],
+) -> None:
+    """Regression: a custom-name collision reveals "Overwrite it" — but
+    if the operator then edits the name to something that fails
+    validation (blank) and clicks Create again, the stale overwrite
+    button must NOT persist wired to the earlier, no-longer-current
+    colliding profile. Every fresh Create attempt discards whatever
+    overwrite state a previous attempt left behind."""
+    existing = {
+        "name": "e2e-stale-overwrite",
+        "version": 1,
+        "hardware": "any",
+        "data_link_port": ["UART1"],
+        "rtcm_stream": {"matrix": {"1005": {"UART1": True}}},
+    }
+    resp = httpx.post(f"{api_base_url}/api/profiles", json=existing, timeout=5.0)
+    assert resp.status_code in (201, 409), resp.text
+    cleanup_profiles.append("e2e-stale-overwrite")
+
+    _goto_gps_config(page, base_url)
+    page.locator(".save-as-btn").click()
+    page.locator(".save-as-name input").fill("e2e-stale-overwrite")
+    page.locator(".save-as-confirm-btn").click()
+
+    overwrite_btn = page.locator(".save-as-overwrite-btn")
+    expect(overwrite_btn).to_be_visible(timeout=5_000)
+
+    # Edit to a name that fails validation, then retry — the stale
+    # overwrite affordance from the previous attempt must be gone.
+    page.locator(".save-as-name input").fill("")
+    page.locator(".save-as-confirm-btn").click()
+    expect(page.locator(".save-as-error")).to_contain_text(
+        "Name is required", timeout=5_000
+    )
+    expect(overwrite_btn).to_be_hidden()
+
+
+@pytest.mark.e2e
 def test_rename_delete_export_are_customs_only(
     page: Page,
     base_url: str,

--- a/tests/unit/test_gps_config_helpers.py
+++ b/tests/unit/test_gps_config_helpers.py
@@ -51,6 +51,7 @@ from sp_rtk_base.ui.pages.gps_config import (
     MATRIX_PORTS,
     REQUIRED_RTCM_ROW,
     SELECTABLE_TMODE_MODES,
+    ProfilePickerEntry,
     ResultBadgeState,
     apply_blocked_reason,
     apply_headline,
@@ -66,6 +67,7 @@ from sp_rtk_base.ui.pages.gps_config import (
     fixed_position_step_state,
     format_leaf_diff,
     format_step_log_entry,
+    has_custom_profiles,
     i2c_spi_advisory_rows,
     infer_data_link_ports,
     is_modified_from_profile,
@@ -82,6 +84,10 @@ from sp_rtk_base.ui.pages.gps_config import (
     rtcm_config_to_matrix,
     rtcm_diff_path,
     save_as_enabled,
+    save_as_unmodified_note,
+    save_profile_visible,
+    should_offer_save_after_apply,
+    slugify_profile_name,
     suggest_profile_name,
     throughput_advisory_lines,
     tmode_mode_locked,
@@ -555,23 +561,41 @@ class TestIsModifiedFromProfile:
 
 
 class TestSaveAsEnabled:
+    """Issue #106: Save-as is gated on validity alone — no suppression for
+    an unmodified copy of the selected profile any more."""
+
     def test_disabled_when_form_is_invalid(self) -> None:
-        assert not save_as_enabled(None, None, _live_assertion())
+        assert not save_as_enabled(None)
 
     def test_enabled_with_no_profile_selected(self) -> None:
         request = build_apply_request(_minimal_form(), [PortId.UART1])
-        assert save_as_enabled(request, None, _live_assertion())
+        assert save_as_enabled(request)
 
-    def test_suppressed_when_selected_profile_exactly_equals_the_form(self) -> None:
+    def test_enabled_even_when_selected_profile_exactly_equals_the_form(self) -> None:
         profile = _full_profile()
         live = _live_assertion()
         form_request = receiver_config_from_profile(profile, live)
-        assert not save_as_enabled(form_request, profile, live)
+        assert save_as_enabled(form_request)
 
-    def test_enabled_again_once_the_form_diverges_from_the_selected_profile(
-        self,
-    ) -> None:
-        """The #66 fix: applying edits must not take Save-as away again."""
+
+class TestShouldOfferSaveAfterApply:
+    """Issue #106: the post-apply prompt inherits the old suppression
+    logic that used to gate the Save-as button itself."""
+
+    def test_false_when_form_is_invalid(self) -> None:
+        assert not should_offer_save_after_apply(None, None, _live_assertion())
+
+    def test_true_with_no_profile_selected(self) -> None:
+        request = build_apply_request(_minimal_form(), [PortId.UART1])
+        assert should_offer_save_after_apply(request, None, _live_assertion())
+
+    def test_false_when_selected_profile_exactly_equals_the_form(self) -> None:
+        profile = _full_profile()
+        live = _live_assertion()
+        form_request = receiver_config_from_profile(profile, live)
+        assert not should_offer_save_after_apply(form_request, profile, live)
+
+    def test_true_once_the_form_diverges_from_the_selected_profile(self) -> None:
         profile = _full_profile()
         live = _live_assertion()
         form_request = receiver_config_from_profile(profile, live)
@@ -582,7 +606,79 @@ class TestSaveAsEnabled:
                 )
             }
         )
-        assert save_as_enabled(diverged, profile, live)
+        assert should_offer_save_after_apply(diverged, profile, live)
+
+
+class TestSaveAsUnmodifiedNote:
+    def test_none_when_no_profile_selected(self) -> None:
+        assert save_as_unmodified_note(None, is_modified=True) is None
+
+    def test_none_when_form_has_diverged(self) -> None:
+        assert save_as_unmodified_note(_full_profile(), is_modified=True) is None
+
+    def test_names_the_profile_when_unmodified(self) -> None:
+        profile = _full_profile().model_copy(update={"display_name": "My Base"})
+        note = save_as_unmodified_note(profile, is_modified=False)
+        assert note is not None
+        assert "My Base" in note
+
+
+class TestSaveProfileVisible:
+    def test_hidden_when_no_profile_selected(self) -> None:
+        assert not save_profile_visible(None, is_builtin=False)
+
+    def test_hidden_for_a_builtin(self) -> None:
+        assert not save_profile_visible(_full_profile(), is_builtin=True)
+
+    def test_visible_for_a_selected_custom(self) -> None:
+        assert save_profile_visible(_full_profile(), is_builtin=False)
+
+
+def _picker_entry(name: str, *, is_builtin: bool) -> ProfilePickerEntry:
+    return ProfilePickerEntry(
+        profile=_profile(name, HARDWARE_ANY),
+        is_builtin=is_builtin,
+        compatible=True,
+        incompatible_reason=None,
+        is_default=False,
+    )
+
+
+class TestHasCustomProfiles:
+    def test_false_when_every_entry_is_builtin(self) -> None:
+        assert not has_custom_profiles([_picker_entry("builtin-a", is_builtin=True)])
+
+    def test_false_for_an_empty_list(self) -> None:
+        assert not has_custom_profiles([])
+
+    def test_true_when_a_custom_entry_is_present(self) -> None:
+        entries = [
+            _picker_entry("builtin-a", is_builtin=True),
+            _picker_entry("custom-a", is_builtin=False),
+        ]
+        assert has_custom_profiles(entries)
+
+
+class TestSlugifyProfileName:
+    def test_lowercases_and_hyphenates_spaces(self) -> None:
+        assert slugify_profile_name("My Rooftop Base") == "my-rooftop-base"
+
+    def test_collapses_punctuation_runs_into_one_hyphen(self) -> None:
+        assert slugify_profile_name("Base #1 (v2)!!") == "base-1-v2"
+
+    def test_strips_leading_and_trailing_hyphens(self) -> None:
+        assert slugify_profile_name("  -weird-  ") == "weird"
+
+    def test_leaves_an_already_safe_slug_unchanged(self) -> None:
+        assert slugify_profile_name("ublox-f9p-base-standard-copy") == (
+            "ublox-f9p-base-standard-copy"
+        )
+
+    def test_blank_input_derives_an_empty_slug(self) -> None:
+        assert slugify_profile_name("   ") == ""
+
+    def test_pure_punctuation_derives_an_empty_slug(self) -> None:
+        assert slugify_profile_name("###") == ""
 
 
 class TestDisplayLabel:
@@ -647,6 +743,25 @@ class TestBuildSavedProfile:
         request = build_apply_request(_minimal_form(), [PortId.UART1])
         profile = build_saved_profile("captured", request, "ZED-F9P", None)
         assert profile.forked_from is None
+
+    def test_display_name_carries_through_when_distinct_from_the_slug(self) -> None:
+        request = build_apply_request(_minimal_form(), [PortId.UART1])
+        profile = build_saved_profile(
+            "my-base", request, "ZED-F9P", None, display_name="My Base"
+        )
+        assert profile.display_name == "My Base"
+
+    def test_display_name_omitted_when_identical_to_the_slug(self) -> None:
+        request = build_apply_request(_minimal_form(), [PortId.UART1])
+        profile = build_saved_profile(
+            "my-base", request, "ZED-F9P", None, display_name="my-base"
+        )
+        assert profile.display_name is None
+
+    def test_display_name_defaults_to_none(self) -> None:
+        request = build_apply_request(_minimal_form(), [PortId.UART1])
+        profile = build_saved_profile("captured", request, "ZED-F9P", None)
+        assert profile.display_name is None
 
 
 class TestResolvePortsDisplay:


### PR DESCRIPTION
## Summary

Closes #106.

- Three save entry points — a persistent row in the profile picker, "Save as new profile…" in the action row, and an inline post-apply prompt — now all open one Save-as dialog.
- Suppression on an unmodified copy of the selected profile is dropped: no save control is ever greyed. The dialog shows an explanatory note instead of blocking.
- New in-place **Save profile** control, hidden (not greyed) unless a custom profile is selected — updates the selected profile behind a confirm, with no name typing.
- The Save-as dialog takes a human display name and shows the derived slug live.
- Collisions are keyed on the slug: a built-in collision is rejected outright; a custom collision reveals an explicit "Overwrite it" button.
- Empty-state guidance in the picker when no custom profiles exist, and an Apply-vs-Save caption in the action row.

A code review (Standards + Spec, run in parallel) caught a real bug during development: the collision-retry flow could leave a stale "Overwrite it" button wired to a previous, no-longer-current profile if the operator edited the name to something invalid and retried. That's fixed in the second commit, along with simplifying collision detection to route through the store's own `ProfileConflictError` rather than duplicating the check in the UI, plus a regression test for the exact sequence.

## Test plan

- [x] `uv run pytest tests/unit` — 1540 passed, coverage gate met
- [x] `uv run pytest tests/e2e --no-cov` — 92 passed
- [x] `uv run pyright src/` — clean (strict mode)
- [x] `uv run mypy src/sp_rtk_base/ui/pages/gps_config.py` — clean
- [x] `uv run ruff check` / `ruff format --check` — clean
- [x] New unit coverage for the pure helpers (`slugify_profile_name`, `save_as_enabled`, `should_offer_save_after_apply`, `save_as_unmodified_note`, `save_profile_visible`, `has_custom_profiles`, `build_saved_profile`'s `display_name`)
- [x] New e2e coverage: all three entry points, hidden-not-greyed `Save profile`, live slug, unmodified note, built-in-rejected vs. custom-offers-overwrite collisions, in-place update, empty-state guidance, post-apply offer/no-offer
- [x] Fixed one pre-existing flaky e2e test (`test_gps_apply.py`) whose timing race became more likely once the page picked up extra weight

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVYMZRfrCSQF7UHkW46hA6