### PR TITLE
fix(profiles): provision the custom-profiles dir so appliance installs don't 500

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -197,6 +197,12 @@ log "Creating directories…"
 install -d -m 0755 -o root            -g root            "$INSTALL_PREFIX"
 install -d -m 0750 -o "$SERVICE_USER" -g "$SERVICE_USER" "$CONFIG_DIR"
 install -d -m 0750 -o "$SERVICE_USER" -g "$SERVICE_USER" "$STATE_DIR"
+# Custom GPS profiles dir (issue #81) — the unit points
+# SP_RTK_BASE_PROFILES_DIR here (see sp-rtk-base.service) since
+# ProtectHome=true hides ~/.config/sp-rtk-base/profiles, ProfileStore's
+# default, from the service user. Provision it up front so a fresh
+# install's first /api/profiles call doesn't need manual intervention.
+install -d -m 0750 -o "$SERVICE_USER" -g "$SERVICE_USER" "${STATE_DIR}/profiles"
 # Heal pre-existing installs whose CONFIG_DIR was created root:sp-rtk-base
 # (the original v0.2.x installer) — the service user needs ownership so
 # atomic-rename saves and write_text() on config.yaml both succeed.

--- a/deploy/sp-rtk-base.service
+++ b/deploy/sp-rtk-base.service
@@ -20,6 +20,11 @@ Environment=SP_RTK_BASE_CONFIG=/etc/sp-rtk-base/config.yaml
 # doesn't exist for this homeless system user, and every /api/network/*
 # call 502s.
 Environment=SP_RTK_BASE_NET_CONFIG=/etc/sp-rtk-base/net_provision.yaml
+# Same story for custom GPS profiles (issue #81): ProfileStore's default
+# ~/.config path is unreachable under ProtectHome=true below (the service
+# user's home is hidden/read-only), so every /api/profiles call 500s.
+# /var/lib/sp-rtk-base is already in ReadWritePaths, so redirect there.
+Environment=SP_RTK_BASE_PROFILES_DIR=/var/lib/sp-rtk-base/profiles
 ExecStart=/opt/sp-rtk-base/venv/bin/sp-rtk-base
 Restart=on-failure
 RestartSec=5

--- a/src/sp_rtk_base/api/profiles.py
+++ b/src/sp_rtk_base/api/profiles.py
@@ -37,6 +37,7 @@ from sp_rtk_base.services.profile_store import (
     ProfileNotFoundError,
     ProfileStore,
     ProfileStoreError,
+    ProfileStoreUnavailableError,
 )
 
 logger = logging.getLogger(__name__)
@@ -51,6 +52,7 @@ _STATUS_BY_ERROR: dict[type[ProfileStoreError], int] = {
     ProfileImmutableError: 403,
     ProfileConflictError: 409,
     ProfileBusinessRuleError: 400,
+    ProfileStoreUnavailableError: 503,
 }
 
 
@@ -71,7 +73,7 @@ def _detail(store: ProfileStore, profile: Profile) -> ProfileDetailResponse:
 async def list_profiles(
     store: ProfileStore = Depends(get_profile_store),
     device: DeviceService = Depends(get_device_service),
-) -> ProfileListResponse:
+) -> ProfileListResponse | JSONResponse:
     """List every profile, built-ins before customs, alphabetical within each.
 
     Tags each profile with its compatibility against the connected
@@ -84,7 +86,10 @@ async def list_profiles(
         info.hardware_confidence if info else HardwareConfidence.UNKNOWN,
     )
 
-    profiles = store.list_profiles()
+    try:
+        profiles = store.list_profiles()
+    except ProfileStoreError as exc:
+        return _error_response(exc)
     items = [
         ProfileListItem(
             profile=p,
@@ -111,7 +116,10 @@ async def get_profile(
     store: ProfileStore = Depends(get_profile_store),
 ) -> ProfileDetailResponse | JSONResponse:
     """Get a single profile by name."""
-    profile = store.get_profile(name)
+    try:
+        profile = store.get_profile(name)
+    except ProfileStoreError as exc:
+        return _error_response(exc)
     if profile is None:
         return _error_response(ProfileNotFoundError(f"Profile '{name}' not found"))
     return _detail(store, profile)
@@ -125,7 +133,7 @@ async def export_profile(
     """Export a profile in the shape ``POST /api/profiles/import`` accepts."""
     try:
         return store.export_profile(name)
-    except ProfileNotFoundError as exc:
+    except ProfileStoreError as exc:
         return _error_response(exc)
 
 

--- a/src/sp_rtk_base/services/profile_store.py
+++ b/src/sp_rtk_base/services/profile_store.py
@@ -58,6 +58,15 @@ class ProfileBusinessRuleError(ProfileStoreError):
     """Raised for a business-rule rejection that isn't a schema violation."""
 
 
+class ProfileStoreUnavailableError(ProfileStoreError):
+    """Raised when the profiles dir can't be read or written.
+
+    Surfaces filesystem failures (e.g. a systemd ``ProtectHome=true``
+    unit hiding ``~``) as one actionable message instead of a raw
+    ``PermissionError`` traceback reaching the API layer.
+    """
+
+
 def _get_profiles_dir() -> Path:
     """Resolve the custom-profiles directory.
 
@@ -85,6 +94,20 @@ class ProfileStore:
 
     def __init__(self, profiles_dir: Path | None = None) -> None:
         self._profiles_dir = profiles_dir or _get_profiles_dir()
+        # Non-fatal startup probe (issue #81): surface an inaccessible
+        # profiles dir in the log at construction time — the singleton is
+        # built at import time, before the first /api/profiles request —
+        # rather than leaving the first caller to discover it as a 503.
+        try:
+            self._profiles_dir.exists()
+        except OSError as exc:
+            logger.warning(
+                "profiles dir '%s' is not accessible (%s); set %s to a "
+                "writable location",
+                self._profiles_dir,
+                exc.strerror or exc,
+                ENV_PROFILES_DIR,
+            )
 
     @property
     def profiles_dir(self) -> Path:
@@ -101,6 +124,9 @@ class ProfileStore:
         Returns:
             Built-in profiles sorted by name, followed by custom
             profiles sorted by name.
+
+        Raises:
+            ProfileStoreUnavailableError: The profiles dir can't be read.
         """
         customs = self._load_customs()
         builtins_sorted = sorted(BUILTIN_PROFILES.values(), key=lambda p: p.name)
@@ -116,6 +142,9 @@ class ProfileStore:
         Returns:
             The matching profile, or None if no built-in or custom
             profile has that name.
+
+        Raises:
+            ProfileStoreUnavailableError: The profiles dir can't be read.
         """
         builtin = BUILTIN_PROFILES.get(name)
         if builtin is not None:
@@ -143,6 +172,8 @@ class ProfileStore:
             ProfileBusinessRuleError: The name isn't filesystem-safe.
             ProfileConflictError: The name collides with a built-in or
                 an existing custom profile.
+            ProfileStoreUnavailableError: The profiles dir can't be
+                read or written.
         """
         self._validate_name_is_safe(profile.name)
         if profile.name in BUILTIN_PROFILES:
@@ -178,6 +209,8 @@ class ProfileStore:
             ProfileImmutableError: *name* identifies a built-in.
             ProfileNotFoundError: No custom profile named *name* exists.
             ProfileBusinessRuleError: *new_display_name* is blank.
+            ProfileStoreUnavailableError: The profiles dir can't be
+                read or written.
         """
         if name in BUILTIN_PROFILES:
             raise ProfileImmutableError(f"'{name}' is a built-in and cannot be renamed")
@@ -213,6 +246,8 @@ class ProfileStore:
             ProfileImmutableError: *profile.name* identifies a built-in.
             ProfileNotFoundError: No custom profile named *profile.name*
                 exists yet — use :meth:`create_profile` instead.
+            ProfileStoreUnavailableError: The profiles dir can't be
+                read or written.
         """
         if profile.name in BUILTIN_PROFILES:
             raise ProfileImmutableError(
@@ -234,12 +269,17 @@ class ProfileStore:
         Raises:
             ProfileImmutableError: *name* identifies a built-in.
             ProfileNotFoundError: No custom profile named *name* exists.
+            ProfileStoreUnavailableError: The profiles dir can't be
+                read, or the file can't be removed.
         """
         if name in BUILTIN_PROFILES:
             raise ProfileImmutableError(f"'{name}' is a built-in and cannot be deleted")
         if name not in self._load_customs():
             raise ProfileNotFoundError(f"No profile named '{name}'")
-        self._custom_path(name).unlink()
+        try:
+            self._custom_path(name).unlink()
+        except OSError as exc:
+            raise self._unavailable_error(exc) from exc
         logger.info("Deleted custom profile: %s", name)
 
     def export_profile(self, name: str) -> Profile:
@@ -253,6 +293,7 @@ class ProfileStore:
 
         Raises:
             ProfileNotFoundError: No profile named *name* exists.
+            ProfileStoreUnavailableError: The profiles dir can't be read.
         """
         profile = self.get_profile(name)
         if profile is None:
@@ -291,11 +332,22 @@ class ProfileStore:
     def _custom_path(self, name: str) -> Path:
         return self._profiles_dir / f"{name}.yaml"
 
+    def _unavailable_error(self, exc: OSError) -> ProfileStoreUnavailableError:
+        return ProfileStoreUnavailableError(
+            f"profiles dir '{self._profiles_dir}' is not accessible "
+            f"({exc.strerror or exc}); set {ENV_PROFILES_DIR} to a writable "
+            "location"
+        )
+
     def _load_customs(self) -> dict[str, Profile]:
         profiles: dict[str, Profile] = {}
-        if not self._profiles_dir.exists():
-            return profiles
-        for path in sorted(self._profiles_dir.glob("*.yaml")):
+        try:
+            if not self._profiles_dir.exists():
+                return profiles
+            paths = sorted(self._profiles_dir.glob("*.yaml"))
+        except OSError as exc:
+            raise self._unavailable_error(exc) from exc
+        for path in paths:
             try:
                 data = yaml.safe_load(path.read_text(encoding="utf-8"))
                 profile = Profile.model_validate(data)
@@ -306,7 +358,10 @@ class ProfileStore:
         return profiles
 
     def _write_custom(self, profile: Profile) -> None:
-        self._profiles_dir.mkdir(parents=True, exist_ok=True)
-        data = profile.model_dump(mode="json", exclude_none=True)
-        yaml_text = yaml.dump(data, default_flow_style=False, sort_keys=False)
-        self._custom_path(profile.name).write_text(yaml_text, encoding="utf-8")
+        try:
+            self._profiles_dir.mkdir(parents=True, exist_ok=True)
+            data = profile.model_dump(mode="json", exclude_none=True)
+            yaml_text = yaml.dump(data, default_flow_style=False, sort_keys=False)
+            self._custom_path(profile.name).write_text(yaml_text, encoding="utf-8")
+        except OSError as exc:
+            raise self._unavailable_error(exc) from exc

--- a/tests/unit/test_api_profiles.py
+++ b/tests/unit/test_api_profiles.py
@@ -15,7 +15,10 @@ from sp_rtk_base.services import get_device_service, get_profile_store
 from sp_rtk_base.services.config_service import ConfigService
 from sp_rtk_base.services.device_service import DeviceService
 from sp_rtk_base.services.metrics_service import MetricsService
-from sp_rtk_base.services.profile_store import ProfileStore
+from sp_rtk_base.services.profile_store import (
+    ProfileStore,
+    ProfileStoreUnavailableError,
+)
 
 BUILTIN_NAME = "ublox-f9p-base-standard"
 
@@ -51,6 +54,44 @@ def api_client_with_device(
     app.dependency_overrides[get_event_bridge] = lambda: mock_event_bridge
     app.dependency_overrides[get_metrics_service] = lambda: mock_metrics_service
     app.dependency_overrides[get_profile_store] = lambda: mock_profile_store
+    app.dependency_overrides[get_device_service] = lambda: mock_device_service
+    return TestClient(app)
+
+
+@pytest.fixture()
+def api_client_with_unavailable_store(
+    mock_config_service: ConfigService,
+    mock_relay_service: MagicMock,
+    mock_event_bridge: MagicMock,
+    mock_metrics_service: MetricsService,
+    mock_device_service: DeviceService,
+) -> TestClient:
+    """``api_client_with_services`` but the profile store can't touch disk —
+    issue #81 (``ProtectHome=true`` hiding ``~`` on appliance installs)."""
+    from sp_rtk_base.services import (
+        get_config_service,
+        get_event_bridge,
+        get_metrics_service,
+        get_relay_service,
+    )
+
+    unavailable_store = MagicMock(spec=ProfileStore)
+    unavailable_error = ProfileStoreUnavailableError(
+        "profiles dir '/home/sp-rtk-base/.config/sp-rtk-base/profiles' is not "
+        "accessible (Permission denied); set SP_RTK_BASE_PROFILES_DIR to a "
+        "writable location"
+    )
+    unavailable_store.list_profiles.side_effect = unavailable_error
+    unavailable_store.get_profile.side_effect = unavailable_error
+    unavailable_store.export_profile.side_effect = unavailable_error
+    unavailable_store.create_profile.side_effect = unavailable_error
+
+    app = create_api_app()
+    app.dependency_overrides[get_config_service] = lambda: mock_config_service
+    app.dependency_overrides[get_relay_service] = lambda: mock_relay_service
+    app.dependency_overrides[get_event_bridge] = lambda: mock_event_bridge
+    app.dependency_overrides[get_metrics_service] = lambda: mock_metrics_service
+    app.dependency_overrides[get_profile_store] = lambda: unavailable_store
     app.dependency_overrides[get_device_service] = lambda: mock_device_service
     return TestClient(app)
 
@@ -271,6 +312,41 @@ class TestMalformedCustomFileDoesNotBreakListing:
         names = [item["profile"]["name"] for item in resp.json()["profiles"]]
         assert "good" in names
         assert len(names) == 2  # builtin + good; corrupt.yaml silently skipped
+
+
+class TestProfileStoreUnavailable:
+    """Issue #81: an inaccessible profiles dir must surface as a clear
+    5xx with an actionable message, not an unhandled ``PermissionError``
+    traceback (e.g. appliance installs with ``ProtectHome=true``)."""
+
+    def test_list_returns_503_with_actionable_message(
+        self, api_client_with_unavailable_store: TestClient
+    ) -> None:
+        resp = api_client_with_unavailable_store.get("/api/profiles")
+        assert resp.status_code == 503
+        assert "SP_RTK_BASE_PROFILES_DIR" in resp.json()["message"]
+
+    def test_get_returns_503(
+        self, api_client_with_unavailable_store: TestClient
+    ) -> None:
+        resp = api_client_with_unavailable_store.get(f"/api/profiles/{BUILTIN_NAME}")
+        assert resp.status_code == 503
+
+    def test_export_returns_503(
+        self, api_client_with_unavailable_store: TestClient
+    ) -> None:
+        resp = api_client_with_unavailable_store.get(
+            f"/api/profiles/{BUILTIN_NAME}/export"
+        )
+        assert resp.status_code == 503
+
+    def test_create_returns_503(
+        self, api_client_with_unavailable_store: TestClient
+    ) -> None:
+        resp = api_client_with_unavailable_store.post(
+            "/api/profiles", json=_profile_payload()
+        )
+        assert resp.status_code == 503
 
 
 class TestHardwareIdentityInListing:

--- a/tests/unit/test_install_default_config.py
+++ b/tests/unit/test_install_default_config.py
@@ -229,3 +229,58 @@ class TestInstallerConfigPermissions:
             "'install -d' line so a re-run heals pre-existing installs "
             "whose CONFIG_DIR was created root-owned."
         )
+
+
+class TestProfilesDirProvisioned:
+    """Regression: the installer must provision a writable custom-profiles
+    directory up front, and the app unit must point ``ProfileStore`` at it.
+
+    Background (issue #81): ``ProfileStore``'s default profiles dir is
+    ``~/.config/sp-rtk-base/profiles``. On appliance installs the systemd
+    unit sets ``ProtectHome=true``, which makes ``~`` for the
+    ``sp-rtk-base`` service user inaccessible — every ``/api/profiles``
+    call 500'd with an unhandled ``PermissionError``, even after manually
+    pre-creating the directory as root. The fix mirrors the existing
+    ``SP_RTK_BASE_NET_CONFIG`` pattern (see
+    :class:`TestMainAppServiceHasNetProvisionEnv` in
+    ``test_install_net_provision.py``): redirect ``ProfileStore`` to a
+    ``ReadWritePaths`` location via ``SP_RTK_BASE_PROFILES_DIR``, and have
+    the installer create that directory up front.
+    """
+
+    _PROFILES_DIR_INSTALL_RE = re.compile(
+        r'install\s+-d\s+-m\s+0750\s+-o\s+"\$SERVICE_USER"\s+-g\s+"\$SERVICE_USER"\s+'
+        r'"\$\{STATE_DIR\}/profiles"'
+    )
+
+    def test_installer_creates_profiles_dir_owned_by_service_user(
+        self, install_script_text: str
+    ) -> None:
+        assert self._PROFILES_DIR_INSTALL_RE.search(install_script_text), (
+            "deploy/install.sh must create ${STATE_DIR}/profiles owned by "
+            '"$SERVICE_USER":"$SERVICE_USER", e.g.\n'
+            '    install -d -m 0750 -o "$SERVICE_USER" -g "$SERVICE_USER" '
+            '"${STATE_DIR}/profiles"'
+        )
+
+    def test_app_service_unit_redirects_profiles_dir_into_read_write_paths(
+        self,
+    ) -> None:
+        unit = REPO_ROOT / "deploy" / "sp-rtk-base.service"
+        assert unit.is_file(), f"unit file not found: {unit}"
+        text = unit.read_text(encoding="utf-8")
+        assert (
+            "Environment=SP_RTK_BASE_PROFILES_DIR=/var/lib/sp-rtk-base/profiles" in text
+        ), (
+            "deploy/sp-rtk-base.service must set SP_RTK_BASE_PROFILES_DIR to "
+            "a location inside ReadWritePaths (/var/lib/sp-rtk-base), or "
+            "ProfileStore falls back to the ProtectHome-hidden ~/.config "
+            "default and every /api/profiles call 500s."
+        )
+        assert (
+            "/var/lib/sp-rtk-base"
+            in text.split("ReadWritePaths=", 1)[1].split("\n", 1)[0]
+        ), (
+            "SP_RTK_BASE_PROFILES_DIR points inside /var/lib/sp-rtk-base, "
+            "which must stay listed in ReadWritePaths."
+        )

--- a/tests/unit/test_profile_store.py
+++ b/tests/unit/test_profile_store.py
@@ -17,6 +17,7 @@ from sp_rtk_base.services.profile_store import (
     ProfileImmutableError,
     ProfileNotFoundError,
     ProfileStore,
+    ProfileStoreUnavailableError,
 )
 
 BUILTIN_NAME = "ublox-f9p-base-standard"
@@ -316,3 +317,73 @@ class TestPathResolutionPrecedence:
 
         store = ProfileStore()
         assert store.profiles_dir == DEFAULT_PROFILES_DIR
+
+
+class TestUnavailableProfilesDir:
+    """Issue #81: an inaccessible profiles dir (e.g. ``ProtectHome=true``
+    hiding ``~`` on appliance installs) must raise a clear, actionable
+    error rather than let a raw ``PermissionError`` reach the caller."""
+
+    def test_construction_warns_when_dir_is_inaccessible(
+        self,
+        profiles_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """The store is built as a module-level singleton at import time
+        (before the first request), so a startup-time warning gives an
+        operator a log line to find instead of only a 503 on first use.
+        """
+
+        def _denied(self: Path) -> bool:
+            raise PermissionError(13, "Permission denied")
+
+        monkeypatch.setattr(Path, "exists", _denied)
+        with caplog.at_level("WARNING"):
+            ProfileStore(profiles_dir=profiles_dir)
+
+        assert "SP_RTK_BASE_PROFILES_DIR" in caplog.text
+        assert str(profiles_dir) in caplog.text
+
+    def test_listing_an_unreadable_dir_raises_actionable_error(
+        self,
+        store: ProfileStore,
+        profiles_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        profiles_dir.mkdir(parents=True, exist_ok=True)
+
+        def _denied(self: Path, pattern: str) -> list[Path]:
+            raise PermissionError(13, "Permission denied")
+
+        monkeypatch.setattr(Path, "glob", _denied)
+        with pytest.raises(
+            ProfileStoreUnavailableError, match="SP_RTK_BASE_PROFILES_DIR"
+        ):
+            store.list_profiles()
+
+    def test_delete_raises_actionable_error_when_file_cannot_be_unlinked(
+        self, store: ProfileStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        store.create_profile(_custom())
+
+        def _denied(self: Path) -> None:
+            raise PermissionError(13, "Permission denied")
+
+        monkeypatch.setattr(Path, "unlink", _denied)
+        with pytest.raises(
+            ProfileStoreUnavailableError, match="SP_RTK_BASE_PROFILES_DIR"
+        ):
+            store.delete_profile("my-custom")
+
+    def test_create_raises_actionable_error_when_dir_cannot_be_made(
+        self, store: ProfileStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _denied(self: Path, **kwargs: object) -> None:
+            raise PermissionError(13, "Permission denied")
+
+        monkeypatch.setattr(Path, "mkdir", _denied)
+        with pytest.raises(
+            ProfileStoreUnavailableError, match="SP_RTK_BASE_PROFILES_DIR"
+        ):
+            store.create_profile(_custom())


### PR DESCRIPTION
## Summary

- `ProfileStore`'s default profiles dir (`~/.config/sp-rtk-base/profiles`) is unreachable under the appliance unit's `ProtectHome=true` (the service user's home is hidden/read-only), so every `/api/profiles` call 500'd with an unhandled `PermissionError` — even after manually pre-creating the directory as root.
- `ProfileStore` now raises a clear `ProfileStoreUnavailableError` (mapped to HTTP 503) when the profiles dir can't be read or written, instead of letting a raw `PermissionError` reach the API layer, and logs a non-fatal startup warning when the singleton is constructed.
- The previously-unguarded `GET /api/profiles`, `GET /api/profiles/{name}`, and `GET /api/profiles/{name}/export` endpoints now catch `ProfileStoreError` the same way the mutating endpoints already did.
- `deploy/sp-rtk-base.service` sets `SP_RTK_BASE_PROFILES_DIR=/var/lib/sp-rtk-base/profiles` (already in `ReadWritePaths`), mirroring the existing `SP_RTK_BASE_NET_CONFIG` fix for the same `ProtectHome` class of bug.
- `deploy/install.sh` provisions that directory up front so a fresh appliance install works without manual intervention.

Closes #81

## Test plan

- [x] `uv run pytest` — 1550 passed, coverage gate (90%) met at 93.84%
- [x] `uv run pyright src/` — strict, clean
- [x] `uv run mypy` on touched files — clean
- [x] `uv run ruff check` / `ruff format --check` — clean
- [x] New unit tests cover: `ProfileStoreUnavailableError` raised from list/create/delete when the dir is unreadable/unwritable, the startup warning log, all four affected API endpoints returning 503 with an actionable message, and installer/unit-file regression tests asserting `deploy/install.sh` provisions `${STATE_DIR}/profiles` and `deploy/sp-rtk-base.service` sets `SP_RTK_BASE_PROFILES_DIR`
- [x] Reviewed via `/code-review` (parallel standards + spec sub-agents against issue #81's acceptance criteria) before committing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVYMZRfrCSQF7UHkW46hA6