### PR TITLE
fix(gps): stop e2e hardware-fields race dropping the SPI click

### DIFF
--- a/tests/e2e/test_gps_hardware_fields.py
+++ b/tests/e2e/test_gps_hardware_fields.py
@@ -108,18 +108,30 @@ def test_hardware_extras_are_editable_and_apply(
     sync_badge = page.locator(".sync-badge")
     expect(sync_badge).to_have_text("In sync", timeout=10_000)
 
+    # Every hardware-field handler (`_set_meas_period_ms`,
+    # `_set_dyn_model`, `_set_elevation_mask`, `_toggle_spi`) rebuilds
+    # the *entire* hw-extras section — including recreating the SPI
+    # checkbox as a fresh DOM node — over a websocket round-trip. So
+    # each edit below waits for its own rebuild to land (mirroring
+    # ``test_gps_apply.py``'s matrix-rebuild wait) before the next one
+    # fires; otherwise a later click can race a still-in-flight rebuild
+    # from the prior edit and land on a node that's about to be torn
+    # down, silently dropping the click.
     meas_rate = page.locator(".hw-field-meas-rate-input input")
     expect(meas_rate).to_have_value("1000")
     meas_rate.fill("500")
     meas_rate.blur()
+    expect(meas_rate).to_have_value("500", timeout=10_000)
 
     dyn_model = page.locator(".hw-field-dyn-model-select")
     dyn_model.click()
     page.get_by_role("option", name="stationary", exact=True).click()
+    expect(dyn_model).to_contain_text("stationary", timeout=10_000)
 
     elevation = page.locator(".hw-field-elevation-mask-input input")
     elevation.fill("10")
     elevation.blur()
+    expect(elevation).to_have_value("10", timeout=10_000)
 
     spi = page.locator(".hw-field-spi-checkbox")
     _expect_checked(spi, checked=True)  # on by default on the fake driver


### PR DESCRIPTION
## Summary
- Investigated issue #106 (PR #116, merged) — the feature itself is fine; all of its own tests passed in every CI run.
- The CI red X came from an unrelated, pre-existing test: `test_gps_hardware_fields.py::test_hardware_extras_are_editable_and_apply`, which failed on 3 of the last 4 runs (the #106 branch push, the `main` merge, and a follow-up PR's branch) but passed locally and on the latest `main` run — the signature of a flaky race, not a functional regression.
- Root cause: every hardware-field edit handler (`_set_meas_period_ms`, `_set_dyn_model`, `_set_elevation_mask`, `_toggle_spi`) fully rebuilds the hw-extras section — including recreating the SPI checkbox as a new DOM node — over a websocket round-trip. The test fired four edits back-to-back with no wait between them, so a click could land mid-rebuild and get silently dropped, leaving `spi_enabled` unchanged and the checkbox stuck showing its original `true` state after Apply.
- Fix: wait for each edit's rebuild to settle before the next fires, mirroring the same fix `test_gps_apply.py` already applies to its RTCM-matrix rebuild race.

## Test plan
- [x] `uv run pytest tests/e2e/test_gps_hardware_fields.py --no-cov -q` — 8/8 passed
- [x] `uv run pytest tests/e2e --no-cov -q` — 92/92 passed
- [x] `uv run ruff check` / `ruff format --check` on the changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVYMZRfrCSQF7UHkW46hA6