### PR TITLE
fix(driver): retry RTCM/port-protocol CFG-VALGET polls on timeout

### DIFF
--- a/src/sp_rtk_base/services/drivers/ublox.py
+++ b/src/sp_rtk_base/services/drivers/ublox.py
@@ -826,6 +826,41 @@ class UbloxDriver(GpsReceiverDriver):
 
         raise RuntimeError("No CFG-VALGET response for config keys")
 
+    def _read_cfg_keys_with_retry_locked(
+        self,
+        keys: list[str],
+        layer: int = _CFG_LAYER_RAM,
+        attempts: int = 3,
+    ) -> dict[str, int]:
+        """Poll ``keys`` via ``_read_cfg_keys_locked``, retrying a bare timeout.
+
+        Must hold ``self._lock``. A large poll (dozens of keys, e.g. the
+        60-key RTCM port matrix) racing against RTCM/NAV traffic streamed
+        on the same UART can miss its CFG-VALGET reply within one read
+        budget even though the receiver is healthy and answers on the
+        next attempt (issue #119) — each attempt re-drains and re-polls
+        from scratch, so a miss here is a lost round trip, not a stuck
+        receiver. An explicit ACK-NAK is a different failure shape (the
+        receiver rejected the poll outright) and is never retried — it
+        propagates immediately so it stays distinguishable from a
+        transient timeout.
+        """
+        last_error = RuntimeError("No CFG-VALGET response for config keys")
+        for attempt in range(1, attempts + 1):
+            try:
+                return self._read_cfg_keys_locked(keys, layer=layer)
+            except RuntimeError as exc:
+                if "NAK" in str(exc):
+                    raise
+                last_error = exc
+                logger.warning(
+                    "CFG-VALGET poll for %d keys got no response (attempt %d/%d)",
+                    len(keys),
+                    attempt,
+                    attempts,
+                )
+        raise last_error
+
     def _write_and_verify_locked(
         self, cfg_data: list[tuple[str, int]], layer: int, label: str
     ) -> None:
@@ -944,42 +979,23 @@ class UbloxDriver(GpsReceiverDriver):
 
     def _get_rtcm_port_config_locked(self) -> RtcmPortConfig:
         """Read multi-port RTCM config (must hold self._lock)."""
-        ser, reader = self._require_connection()
-
         # Build key list: 12 rows × 5 ports = 60 keys
-        all_keys: list[str | int] = []
-        for msg_id in _ALL_RTCM_IDS:
-            for port in _RTCM_PORTS:
-                all_keys.append(_rtcm_key(msg_id, port))
-
-        msg = UBXMessage.config_poll(0, 0, all_keys)
-        ser.reset_input_buffer()
-        ser.write(msg.serialize())  # type: ignore[union-attr]
-
-        for _ in range(_MAX_READ_ATTEMPTS):
-            try:
-                raw, parsed = reader.read()  # type: ignore[misc]
-                if parsed is None:
-                    continue
-                identity = getattr(parsed, "identity", "")
-                if identity == "CFG-VALGET":
-                    return self._parse_rtcm_port_valget(parsed)
-            except Exception:
-                continue
-
-        raise RuntimeError("No CFG-VALGET response for RTCM port config")
+        all_keys = [
+            _rtcm_key(msg_id, port) for msg_id in _ALL_RTCM_IDS for port in _RTCM_PORTS
+        ]
+        values = self._read_cfg_keys_with_retry_locked(all_keys)
+        return self._parse_rtcm_port_valget(values)
 
     @staticmethod
-    def _parse_rtcm_port_valget(parsed: object) -> RtcmPortConfig:
-        """Parse a CFG-VALGET response into a multi-port RTCM config."""
+    def _parse_rtcm_port_valget(values: dict[str, int]) -> RtcmPortConfig:
+        """Build a multi-port RTCM config from polled CFG key values."""
         messages: dict[RtcmRowId, dict[str, int]] = {}
 
         for msg_id in _ALL_RTCM_IDS:
             port_rates: dict[str, int] = {}
             for port in _RTCM_PORTS:
                 key = _rtcm_key(msg_id, port)
-                rate = int(getattr(parsed, key, 0))
-                port_rates[port] = rate
+                port_rates[port] = values.get(key, 0)
             messages[msg_id] = port_rates
 
         return RtcmPortConfig(messages=messages)
@@ -1023,35 +1039,18 @@ class UbloxDriver(GpsReceiverDriver):
 
     def _get_port_protocols_locked(self) -> PortProtocolConfig:
         """Read port protocol config for all ports (must hold self._lock)."""
-        ser, reader = self._require_connection()
-
-        all_keys: list[str | int] = [
+        all_keys = [
             _protocol_key(port, direction, protocol)
             for port in PortId
             for direction in _PROTOCOL_DIRECTIONS
             for protocol in UbxProtocol
         ]
-
-        msg = UBXMessage.config_poll(0, 0, all_keys)
-        ser.reset_input_buffer()
-        ser.write(msg.serialize())  # type: ignore[union-attr]
-
-        for _ in range(_MAX_READ_ATTEMPTS):
-            try:
-                raw, parsed = reader.read()  # type: ignore[misc]
-                if parsed is None:
-                    continue
-                identity = getattr(parsed, "identity", "")
-                if identity == "CFG-VALGET":
-                    return self._parse_port_protocols_valget(parsed)
-            except Exception:
-                continue
-
-        raise RuntimeError("No CFG-VALGET response for port protocol config")
+        values = self._read_cfg_keys_with_retry_locked(all_keys)
+        return self._parse_port_protocols_valget(values)
 
     @staticmethod
-    def _parse_port_protocols_valget(parsed: object) -> PortProtocolConfig:
-        """Parse a CFG-VALGET response into a port protocol config."""
+    def _parse_port_protocols_valget(values: dict[str, int]) -> PortProtocolConfig:
+        """Build a port protocol config from polled CFG key values."""
         in_protocols: dict[PortId, list[UbxProtocol]] = {}
         out_protocols: dict[PortId, list[UbxProtocol]] = {}
 
@@ -1059,12 +1058,12 @@ class UbloxDriver(GpsReceiverDriver):
             in_protocols[port] = [
                 protocol
                 for protocol in UbxProtocol
-                if int(getattr(parsed, _protocol_key(port, "IN", protocol), 0)) == 1
+                if values.get(_protocol_key(port, "IN", protocol), 0) == 1
             ]
             out_protocols[port] = [
                 protocol
                 for protocol in UbxProtocol
-                if int(getattr(parsed, _protocol_key(port, "OUT", protocol), 0)) == 1
+                if values.get(_protocol_key(port, "OUT", protocol), 0) == 1
             ]
 
         return PortProtocolConfig(

--- a/tests/unit/test_port_protocols.py
+++ b/tests/unit/test_port_protocols.py
@@ -9,7 +9,7 @@ API endpoints for ``GET /api/device/rtcm-ports`` and
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -131,8 +131,7 @@ class TestParsePortProtocolsValget:
     """Tests for UbloxDriver._parse_port_protocols_valget."""
 
     def test_parse_all_zero(self) -> None:
-        parsed = _FakeValget()
-        config = UbloxDriver._parse_port_protocols_valget(parsed)
+        config = UbloxDriver._parse_port_protocols_valget({})
         assert isinstance(config, PortProtocolConfig)
         for port in PortId:
             assert config.enabled_in(port) == []
@@ -141,23 +140,21 @@ class TestParsePortProtocolsValget:
     def test_parse_reference_receiver_uart_profile(self) -> None:
         """Acceptance criterion: UART1 in [UBX, NMEA, RTCM3] / out
         [RTCM3], UART2 in [UBX, RTCM3] / out [RTCM3]."""
-        parsed = _FakeValget(
-            {
-                "CFG_UART1INPROT_UBX": 1,
-                "CFG_UART1INPROT_NMEA": 1,
-                "CFG_UART1INPROT_RTCM3X": 1,
-                "CFG_UART1OUTPROT_UBX": 0,
-                "CFG_UART1OUTPROT_NMEA": 0,
-                "CFG_UART1OUTPROT_RTCM3X": 1,
-                "CFG_UART2INPROT_UBX": 1,
-                "CFG_UART2INPROT_NMEA": 0,
-                "CFG_UART2INPROT_RTCM3X": 1,
-                "CFG_UART2OUTPROT_UBX": 0,
-                "CFG_UART2OUTPROT_NMEA": 0,
-                "CFG_UART2OUTPROT_RTCM3X": 1,
-            }
-        )
-        config = UbloxDriver._parse_port_protocols_valget(parsed)
+        values = {
+            "CFG_UART1INPROT_UBX": 1,
+            "CFG_UART1INPROT_NMEA": 1,
+            "CFG_UART1INPROT_RTCM3X": 1,
+            "CFG_UART1OUTPROT_UBX": 0,
+            "CFG_UART1OUTPROT_NMEA": 0,
+            "CFG_UART1OUTPROT_RTCM3X": 1,
+            "CFG_UART2INPROT_UBX": 1,
+            "CFG_UART2INPROT_NMEA": 0,
+            "CFG_UART2INPROT_RTCM3X": 1,
+            "CFG_UART2OUTPROT_UBX": 0,
+            "CFG_UART2OUTPROT_NMEA": 0,
+            "CFG_UART2OUTPROT_RTCM3X": 1,
+        }
+        config = UbloxDriver._parse_port_protocols_valget(values)
 
         assert config.enabled_in(PortId.UART1) == [
             UbxProtocol.UBX,
@@ -169,17 +166,15 @@ class TestParsePortProtocolsValget:
         assert config.enabled_out(PortId.UART2) == [UbxProtocol.RTCM3X]
 
     def test_parse_usb_covered(self) -> None:
-        parsed = _FakeValget(
-            {
-                "CFG_USBINPROT_UBX": 1,
-                "CFG_USBINPROT_NMEA": 1,
-                "CFG_USBINPROT_RTCM3X": 1,
-                "CFG_USBOUTPROT_UBX": 1,
-                "CFG_USBOUTPROT_NMEA": 0,
-                "CFG_USBOUTPROT_RTCM3X": 0,
-            }
-        )
-        config = UbloxDriver._parse_port_protocols_valget(parsed)
+        values = {
+            "CFG_USBINPROT_UBX": 1,
+            "CFG_USBINPROT_NMEA": 1,
+            "CFG_USBINPROT_RTCM3X": 1,
+            "CFG_USBOUTPROT_UBX": 1,
+            "CFG_USBOUTPROT_NMEA": 0,
+            "CFG_USBOUTPROT_RTCM3X": 0,
+        }
+        config = UbloxDriver._parse_port_protocols_valget(values)
         assert config.enabled_in(PortId.USB) == [
             UbxProtocol.UBX,
             UbxProtocol.NMEA,
@@ -188,8 +183,7 @@ class TestParsePortProtocolsValget:
         assert config.enabled_out(PortId.USB) == [UbxProtocol.UBX]
 
     def test_all_ports_present_even_when_disabled(self) -> None:
-        parsed = _FakeValget()
-        config = UbloxDriver._parse_port_protocols_valget(parsed)
+        config = UbloxDriver._parse_port_protocols_valget({})
         assert set(config.in_protocols.keys()) == set(PortId)
         assert set(config.out_protocols.keys()) == set(PortId)
 
@@ -231,6 +225,50 @@ class TestUbloxGetPortProtocols:
         connected_driver._reader.read.side_effect = Exception("timeout")
         with pytest.raises(RuntimeError, match="No CFG-VALGET response"):
             connected_driver.get_port_protocols()
+
+    def test_get_port_protocols_retries_on_timeout_then_succeeds(
+        self, connected_driver: UbloxDriver
+    ) -> None:
+        """A CFG-VALGET reply missed once (busy receiver) doesn't fail
+        the whole read — the poll is re-issued (issue #119)."""
+        with patch.object(
+            UbloxDriver, "_read_cfg_keys_locked", autospec=True
+        ) as mock_read:
+            mock_read.side_effect = [
+                RuntimeError("No CFG-VALGET response for config keys"),
+                {},
+            ]
+            config = connected_driver.get_port_protocols()
+            assert isinstance(config, PortProtocolConfig)
+            assert mock_read.call_count == 2
+
+    def test_get_port_protocols_gives_up_after_three_attempts(
+        self, connected_driver: UbloxDriver
+    ) -> None:
+        with patch.object(
+            UbloxDriver, "_read_cfg_keys_locked", autospec=True
+        ) as mock_read:
+            mock_read.side_effect = RuntimeError(
+                "No CFG-VALGET response for config keys"
+            )
+            with pytest.raises(RuntimeError, match="No CFG-VALGET response"):
+                connected_driver.get_port_protocols()
+            assert mock_read.call_count == 3
+
+    def test_get_port_protocols_nak_is_not_retried(
+        self, connected_driver: UbloxDriver
+    ) -> None:
+        """A genuine NAK is a distinct, definitive rejection — it must
+        propagate immediately, not be masked by the timeout retry."""
+        with patch.object(
+            UbloxDriver, "_read_cfg_keys_locked", autospec=True
+        ) as mock_read:
+            mock_read.side_effect = RuntimeError(
+                "Device rejected CFG-VALGET poll for [...] (NAK)"
+            )
+            with pytest.raises(RuntimeError, match="NAK"):
+                connected_driver.get_port_protocols()
+            assert mock_read.call_count == 1
 
     def test_get_port_protocols_not_connected(self) -> None:
         driver = UbloxDriver()

--- a/tests/unit/test_rtcm_port_config.py
+++ b/tests/unit/test_rtcm_port_config.py
@@ -16,6 +16,7 @@ from sp_rtk_base.models.device_models import (
     RtcmPortConfig,
     RtcmRowId,
 )
+from sp_rtk_base.services.drivers.ublox import UbloxDriver
 
 # ---------------------------------------------------------------------------
 # Model tests
@@ -207,9 +208,7 @@ class TestParseRtcmPortValget:
     def test_parse_all_zero(self) -> None:
         from sp_rtk_base.services.drivers.ublox import UbloxDriver
 
-        parsed = _FakeValget()  # All defaults to 0
-
-        config = UbloxDriver._parse_rtcm_port_valget(parsed)
+        config = UbloxDriver._parse_rtcm_port_valget({})
         assert isinstance(config, RtcmPortConfig)
         # All messages should be present
         assert len(config.messages) == len(ALL_RTCM_MESSAGE_IDS)
@@ -221,15 +220,13 @@ class TestParseRtcmPortValget:
     def test_parse_some_enabled(self) -> None:
         from sp_rtk_base.services.drivers.ublox import UbloxDriver, _rtcm_key
 
-        parsed = _FakeValget(
-            {
-                _rtcm_key(RtcmRowId.RTCM_1005, "USB"): 1,
-                _rtcm_key(RtcmRowId.RTCM_1005, "UART1"): 2,
-                _rtcm_key(RtcmRowId.RTCM_1077, "USB"): 1,
-            }
-        )
+        values = {
+            _rtcm_key(RtcmRowId.RTCM_1005, "USB"): 1,
+            _rtcm_key(RtcmRowId.RTCM_1005, "UART1"): 2,
+            _rtcm_key(RtcmRowId.RTCM_1077, "USB"): 1,
+        }
 
-        config = UbloxDriver._parse_rtcm_port_valget(parsed)
+        config = UbloxDriver._parse_rtcm_port_valget(values)
         assert config.is_enabled(RtcmRowId.RTCM_1005, RtcmOutputPort.USB)
         assert config.rate(RtcmRowId.RTCM_1005, RtcmOutputPort.UART1) == 2
         assert config.is_enabled(RtcmRowId.RTCM_1077, RtcmOutputPort.USB)
@@ -240,17 +237,95 @@ class TestParseRtcmPortValget:
         with 4072.0 and 4072.1 controllable independently."""
         from sp_rtk_base.services.drivers.ublox import UbloxDriver, _rtcm_key
 
-        parsed = _FakeValget(
-            {
-                _rtcm_key(RtcmRowId.RTCM_4072_0, "USB"): 1,
-                _rtcm_key(RtcmRowId.RTCM_4072_1, "USB"): 0,
-            }
-        )
+        values = {
+            _rtcm_key(RtcmRowId.RTCM_4072_0, "USB"): 1,
+            _rtcm_key(RtcmRowId.RTCM_4072_1, "USB"): 0,
+        }
 
-        config = UbloxDriver._parse_rtcm_port_valget(parsed)
+        config = UbloxDriver._parse_rtcm_port_valget(values)
         assert set(config.messages.keys()) == set(ALL_RTCM_MESSAGE_IDS)
         assert config.is_enabled(RtcmRowId.RTCM_4072_0, RtcmOutputPort.USB)
         assert not config.is_enabled(RtcmRowId.RTCM_4072_1, RtcmOutputPort.USB)
+
+
+# ---------------------------------------------------------------------------
+# Driver get_rtcm_port_config read tests
+# ---------------------------------------------------------------------------
+
+
+class TestUbloxGetRtcmPortConfig:
+    """Tests for UbloxDriver.get_rtcm_port_config (issue #119)."""
+
+    @pytest.fixture()
+    def connected_driver(self) -> UbloxDriver:
+        driver = UbloxDriver()
+        mock_serial = MagicMock()
+        mock_serial.is_open = True
+        mock_reader = MagicMock()
+        driver._serial = mock_serial
+        driver._reader = mock_reader
+        return driver
+
+    def test_get_rtcm_port_config_success(self, connected_driver: UbloxDriver) -> None:
+        from sp_rtk_base.services.drivers.ublox import _rtcm_key
+
+        response = _FakeValget(
+            {
+                _rtcm_key(RtcmRowId.RTCM_1005, "USB"): 1,
+            }
+        )
+        connected_driver._reader.read.return_value = (b"", response)
+        config = connected_driver.get_rtcm_port_config()
+        assert config.is_enabled(RtcmRowId.RTCM_1005, RtcmOutputPort.USB)
+
+    def test_get_rtcm_port_config_retries_on_timeout_then_succeeds(
+        self, connected_driver: UbloxDriver
+    ) -> None:
+        """A CFG-VALGET reply missed once (busy receiver) doesn't fail
+        the whole read — the poll is re-issued (issue #119)."""
+        with patch.object(
+            UbloxDriver, "_read_cfg_keys_locked", autospec=True
+        ) as mock_read:
+            mock_read.side_effect = [
+                RuntimeError("No CFG-VALGET response for config keys"),
+                {},
+            ]
+            config = connected_driver.get_rtcm_port_config()
+            assert isinstance(config, RtcmPortConfig)
+            assert mock_read.call_count == 2
+
+    def test_get_rtcm_port_config_gives_up_after_three_attempts(
+        self, connected_driver: UbloxDriver
+    ) -> None:
+        with patch.object(
+            UbloxDriver, "_read_cfg_keys_locked", autospec=True
+        ) as mock_read:
+            mock_read.side_effect = RuntimeError(
+                "No CFG-VALGET response for config keys"
+            )
+            with pytest.raises(RuntimeError, match="No CFG-VALGET response"):
+                connected_driver.get_rtcm_port_config()
+            assert mock_read.call_count == 3
+
+    def test_get_rtcm_port_config_nak_is_not_retried(
+        self, connected_driver: UbloxDriver
+    ) -> None:
+        """A genuine NAK is a distinct, definitive rejection — it must
+        propagate immediately, not be masked by the timeout retry."""
+        with patch.object(
+            UbloxDriver, "_read_cfg_keys_locked", autospec=True
+        ) as mock_read:
+            mock_read.side_effect = RuntimeError(
+                "Device rejected CFG-VALGET poll for [...] (NAK)"
+            )
+            with pytest.raises(RuntimeError, match="NAK"):
+                connected_driver.get_rtcm_port_config()
+            assert mock_read.call_count == 1
+
+    def test_get_rtcm_port_config_not_connected(self) -> None:
+        driver = UbloxDriver()
+        with pytest.raises(ConnectionError):
+            driver.get_rtcm_port_config()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `get_rtcm_port_config` and `get_port_protocols` each hand-rolled their own CFG-VALGET read loop with no retry and no NAK/timeout distinction. A single missed reply — likely when the receiver is streaming RTCM on the data-link UARTs during `apply_receiver_config`'s pre-write read — aborted the whole Apply before any write, and 409'd `GET /api/device/rtcm-ports`.
- Both now route through the driver's existing `_read_cfg_keys_locked` helper (which already distinguishes ACK-NAK from a bare timeout) via a new `_read_cfg_keys_with_retry_locked` wrapper: retries a timeout up to 3 attempts, re-raises a NAK immediately, uncaught.
- `get_gnss_config` has the same hand-rolled pattern but isn't in `apply_receiver_config`'s pre-write read path, so it's left untouched — out of scope for this fix.

Fixes #119.

## Test plan

- [x] `uv run pytest` — 1558 passed, 94.5% coverage (gate: 90%)
- [x] `uv run pyright src/` — 0 errors
- [x] `uv run mypy src/sp_rtk_base/services/drivers/ublox.py` — clean
- [x] `uv run ruff check` / `ruff format --check` — clean
- [x] New tests: `TestUbloxGetRtcmPortConfig` (parity with existing `TestUbloxGetPortProtocols`) covering success, retry-then-succeed, exhausted-retries, and NAK-not-retried; three equivalent new tests added to `TestUbloxGetPortProtocols`
- [ ] Hardware verification on vaio-base (ZED-F9P, fixed-base mode, RTCM streaming) — not done by this PR, recommend before closing #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVYMZRfrCSQF7UHkW46hA6