### PR TITLE
fix(driver): retry TMODE/ECEF CFG-VALGET polls on timeout

### DIFF
--- a/src/sp_rtk_base/services/drivers/ublox.py
+++ b/src/sp_rtk_base/services/drivers/ublox.py
@@ -1780,33 +1780,13 @@ class UbloxDriver(GpsReceiverDriver):
         Must hold ``self._lock``. Used to verify a fixed-base ECEF
         write actually took effect.
         """
-        ser, reader = self._require_connection()
-
-        keys: list[str | int] = [
-            "CFG_TMODE_ECEF_X",
-            "CFG_TMODE_ECEF_Y",
-            "CFG_TMODE_ECEF_Z",
-        ]
-        msg = UBXMessage.config_poll(0, 0, keys)
-        ser.reset_input_buffer()
-        ser.write(msg.serialize())  # type: ignore[union-attr]
-
-        for _ in range(_MAX_READ_ATTEMPTS):
-            try:
-                raw, parsed = reader.read()  # type: ignore[misc]
-                if parsed is None:
-                    continue
-                identity = getattr(parsed, "identity", "")
-                if identity == "CFG-VALGET":
-                    return (
-                        int(getattr(parsed, "CFG_TMODE_ECEF_X", 0)),
-                        int(getattr(parsed, "CFG_TMODE_ECEF_Y", 0)),
-                        int(getattr(parsed, "CFG_TMODE_ECEF_Z", 0)),
-                    )
-            except Exception:
-                continue
-
-        raise RuntimeError("No CFG-VALGET response for ECEF position")
+        keys = ["CFG_TMODE_ECEF_X", "CFG_TMODE_ECEF_Y", "CFG_TMODE_ECEF_Z"]
+        values = self._read_cfg_keys_with_retry_locked(keys)
+        return (
+            values.get("CFG_TMODE_ECEF_X", 0),
+            values.get("CFG_TMODE_ECEF_Y", 0),
+            values.get("CFG_TMODE_ECEF_Z", 0),
+        )
 
     @staticmethod
     def extract_svin_position(parsed: object) -> tuple[float, float, float]:
@@ -1850,9 +1830,6 @@ class UbloxDriver(GpsReceiverDriver):
 
     def _get_base_config_locked(self) -> CurrentBaseConfig:
         """Read base config (must hold self._lock)."""
-        ser, reader = self._require_connection()
-
-        # Poll configuration values (layer 0 = RAM)
         # Request both LLH and ECEF fields — the receiver populates
         # whichever set matches POS_TYPE.
         keys = [
@@ -1869,54 +1846,35 @@ class UbloxDriver(GpsReceiverDriver):
             "CFG_TMODE_ECEF_Z_HP",
             "CFG_TMODE_FIXED_POS_ACC",
         ]
-        keys_any: list[str | int] = list(keys)
-        msg = UBXMessage.config_poll(0, 0, keys_any)
-        ser.reset_input_buffer()
-        ser.write(msg.serialize())  # type: ignore[union-attr]
-
-        # Read response — may take a few reads
-        for i in range(_MAX_READ_ATTEMPTS):
-            try:
-                raw, parsed = reader.read()  # type: ignore[misc]
-                if parsed is None:
-                    logger.debug("get_base_config read %d: None", i)
-                    continue
-                identity = getattr(parsed, "identity", "")
-                logger.debug("get_base_config read %d: %s", i, identity)
-                if identity == "CFG-VALGET":
-                    return self._parse_cfg_tmode(parsed)
-            except Exception as exc:
-                logger.debug("get_base_config read %d: exception %s", i, exc)
-                continue
-
-        raise RuntimeError("No CFG-VALGET response for TMODE config")
+        values = self._read_cfg_keys_with_retry_locked(keys)
+        return self._parse_cfg_tmode(values)
 
     @staticmethod
-    def _parse_cfg_tmode(parsed: object) -> CurrentBaseConfig:
-        """Parse CFG-VALGET TMODE response into CurrentBaseConfig.
+    def _parse_cfg_tmode(values: dict[str, int]) -> CurrentBaseConfig:
+        """Build a CurrentBaseConfig from polled TMODE CFG key values.
 
         Handles both position storage formats:
         - POS_TYPE=0 (ECEF): reads ECEF_X/Y/Z + HP, converts to LLH
         - POS_TYPE=1 (LLH): reads LAT/LON/HEIGHT directly
         """
-        mode_raw = int(getattr(parsed, "CFG_TMODE_MODE", 0))
+        mode_raw = values.get("CFG_TMODE_MODE", 0)
         mode = _TMODE_MODE_NAMES.get(mode_raw, BaseMode.DISABLED)
 
-        pos_type_raw = int(getattr(parsed, "CFG_TMODE_POS_TYPE", 1))
+        pos_type_raw = values.get("CFG_TMODE_POS_TYPE", 1)
         # CFG_TMODE_FIXED_POS_ACC is in 0.1 mm units on the wire —
         # divide by 10 to surface mm at the Python API boundary
         # (matches CurrentBaseConfig.accuracy_mm units).
-        acc_raw = int(getattr(parsed, "CFG_TMODE_FIXED_POS_ACC", 0))
+        acc_raw = values.get("CFG_TMODE_FIXED_POS_ACC", 0)
         acc_mm = acc_raw // 10
 
         if pos_type_raw == 0:
             # ECEF mode — convert to LLH for display
-            ecef_x_cm = int(getattr(parsed, "CFG_TMODE_ECEF_X", 0))
-            ecef_y_cm = int(getattr(parsed, "CFG_TMODE_ECEF_Y", 0))
-            ecef_z_cm = int(getattr(parsed, "CFG_TMODE_ECEF_Z", 0))
-            ecef_x_hp = int(getattr(parsed, "CFG_TMODE_ECEF_X_HP", 0))
-            ecef_y_hp = int(getattr(parsed, "CFG_TMODE_ECEF_Y_HP", 0))
-            ecef_z_hp = int(getattr(parsed, "CFG_TMODE_ECEF_Z_HP", 0))
+            ecef_x_cm = values.get("CFG_TMODE_ECEF_X", 0)
+            ecef_y_cm = values.get("CFG_TMODE_ECEF_Y", 0)
+            ecef_z_cm = values.get("CFG_TMODE_ECEF_Z", 0)
+            ecef_x_hp = values.get("CFG_TMODE_ECEF_X_HP", 0)
+            ecef_y_hp = values.get("CFG_TMODE_ECEF_Y_HP", 0)
+            ecef_z_hp = values.get("CFG_TMODE_ECEF_Z_HP", 0)
 
             # cm → m, HP is in 0.1mm = 0.0001m
             x_m = ecef_x_cm / 100.0 + ecef_x_hp * 0.0001
@@ -1927,9 +1885,9 @@ class UbloxDriver(GpsReceiverDriver):
             pos_type = "ecef"
         else:
             # LLH mode — direct lat/lon/height
-            lat_raw = int(getattr(parsed, "CFG_TMODE_LAT", 0))
-            lon_raw = int(getattr(parsed, "CFG_TMODE_LON", 0))
-            height_cm = int(getattr(parsed, "CFG_TMODE_HEIGHT", 0))
+            lat_raw = values.get("CFG_TMODE_LAT", 0)
+            lon_raw = values.get("CFG_TMODE_LON", 0)
+            height_cm = values.get("CFG_TMODE_HEIGHT", 0)
             lat = lat_raw * 1e-7
             lon = lon_raw * 1e-7
             alt_m = height_cm / 100.0

--- a/src/sp_rtk_base/ui/pages/survey.py
+++ b/src/sp_rtk_base/ui/pages/survey.py
@@ -705,7 +705,7 @@ def survey_page() -> None:
             except Exception as exc:
                 fb_mode_badge.text = "Error"
                 fb_mode_badge.props("color=negative")
-                logger.debug("Failed to read base config: %s", exc)
+                logger.warning("Failed to read base config: %s", exc)
 
         async def _commit_fixed_base(
             lat: float, lon: float, alt: float, acc: int

--- a/tests/unit/test_ublox_driver.py
+++ b/tests/unit/test_ublox_driver.py
@@ -1164,21 +1164,21 @@ class TestParseCfgTmode:
 
     def test_parse_llh_pos_type(self) -> None:  # pyright: ignore[reportPrivateUsage]
         """POS_TYPE=1 (LLH) reads LAT/LON/HEIGHT directly."""
-        parsed = SimpleNamespace(
-            CFG_TMODE_MODE=2,  # FIXED
-            CFG_TMODE_POS_TYPE=1,  # LLH
-            CFG_TMODE_LAT=473977000,  # 47.3977° × 1e7
-            CFG_TMODE_LON=85456000,  # 8.5456° × 1e7
-            CFG_TMODE_HEIGHT=40800,  # 408.00m in cm
-            CFG_TMODE_ECEF_X=0,
-            CFG_TMODE_ECEF_Y=0,
-            CFG_TMODE_ECEF_Z=0,
-            CFG_TMODE_ECEF_X_HP=0,
-            CFG_TMODE_ECEF_Y_HP=0,
-            CFG_TMODE_ECEF_Z_HP=0,
-            CFG_TMODE_FIXED_POS_ACC=5000,  # 0.1 mm units = 500 mm
-        )
-        result = UbloxDriver._parse_cfg_tmode(parsed)  # pyright: ignore[reportPrivateUsage]
+        values = {
+            "CFG_TMODE_MODE": 2,  # FIXED
+            "CFG_TMODE_POS_TYPE": 1,  # LLH
+            "CFG_TMODE_LAT": 473977000,  # 47.3977° × 1e7
+            "CFG_TMODE_LON": 85456000,  # 8.5456° × 1e7
+            "CFG_TMODE_HEIGHT": 40800,  # 408.00m in cm
+            "CFG_TMODE_ECEF_X": 0,
+            "CFG_TMODE_ECEF_Y": 0,
+            "CFG_TMODE_ECEF_Z": 0,
+            "CFG_TMODE_ECEF_X_HP": 0,
+            "CFG_TMODE_ECEF_Y_HP": 0,
+            "CFG_TMODE_ECEF_Z_HP": 0,
+            "CFG_TMODE_FIXED_POS_ACC": 5000,  # 0.1 mm units = 500 mm
+        }
+        result = UbloxDriver._parse_cfg_tmode(values)  # pyright: ignore[reportPrivateUsage]
         assert result.mode.value == "fixed"
         assert result.pos_type == "llh"
         assert abs(result.latitude - 47.3977) < 0.0001
@@ -1190,21 +1190,21 @@ class TestParseCfgTmode:
     def test_parse_ecef_pos_type(self) -> None:  # pyright: ignore[reportPrivateUsage]
         """POS_TYPE=0 (ECEF) reads ECEF_X/Y/Z and converts to LLH."""
         # Real values from u-center: a point near Portland, OR area
-        parsed = SimpleNamespace(
-            CFG_TMODE_MODE=2,  # FIXED
-            CFG_TMODE_POS_TYPE=0,  # ECEF
-            CFG_TMODE_LAT=0,  # unused in ECEF mode
-            CFG_TMODE_LON=0,  # unused
-            CFG_TMODE_HEIGHT=0,  # unused
-            CFG_TMODE_ECEF_X=-245790204,  # cm
-            CFG_TMODE_ECEF_Y=-477512066,  # cm
-            CFG_TMODE_ECEF_Z=342909332,  # cm
-            CFG_TMODE_ECEF_X_HP=0,
-            CFG_TMODE_ECEF_Y_HP=0,
-            CFG_TMODE_ECEF_Z_HP=0,
-            CFG_TMODE_FIXED_POS_ACC=47308,  # 0.1 mm units = 4730 mm
-        )
-        result = UbloxDriver._parse_cfg_tmode(parsed)  # pyright: ignore[reportPrivateUsage]
+        values = {
+            "CFG_TMODE_MODE": 2,  # FIXED
+            "CFG_TMODE_POS_TYPE": 0,  # ECEF
+            "CFG_TMODE_LAT": 0,  # unused in ECEF mode
+            "CFG_TMODE_LON": 0,  # unused
+            "CFG_TMODE_HEIGHT": 0,  # unused
+            "CFG_TMODE_ECEF_X": -245790204,  # cm
+            "CFG_TMODE_ECEF_Y": -477512066,  # cm
+            "CFG_TMODE_ECEF_Z": 342909332,  # cm
+            "CFG_TMODE_ECEF_X_HP": 0,
+            "CFG_TMODE_ECEF_Y_HP": 0,
+            "CFG_TMODE_ECEF_Z_HP": 0,
+            "CFG_TMODE_FIXED_POS_ACC": 47308,  # 0.1 mm units = 4730 mm
+        }
+        result = UbloxDriver._parse_cfg_tmode(values)  # pyright: ignore[reportPrivateUsage]
         assert result.mode.value == "fixed"
         assert result.pos_type == "ecef"
         # Should produce valid WGS84 coordinates (not zeros)
@@ -1219,43 +1219,195 @@ class TestParseCfgTmode:
 
     def test_parse_ecef_disabled_mode(self) -> None:  # pyright: ignore[reportPrivateUsage]
         """DISABLED mode with ECEF pos_type still parses."""
-        parsed = SimpleNamespace(
-            CFG_TMODE_MODE=0,  # DISABLED
-            CFG_TMODE_POS_TYPE=0,  # ECEF
-            CFG_TMODE_LAT=0,
-            CFG_TMODE_LON=0,
-            CFG_TMODE_HEIGHT=0,
-            CFG_TMODE_ECEF_X=0,
-            CFG_TMODE_ECEF_Y=0,
-            CFG_TMODE_ECEF_Z=0,
-            CFG_TMODE_ECEF_X_HP=0,
-            CFG_TMODE_ECEF_Y_HP=0,
-            CFG_TMODE_ECEF_Z_HP=0,
-            CFG_TMODE_FIXED_POS_ACC=0,
-        )
-        result = UbloxDriver._parse_cfg_tmode(parsed)  # pyright: ignore[reportPrivateUsage]
+        values = {
+            "CFG_TMODE_MODE": 0,  # DISABLED
+            "CFG_TMODE_POS_TYPE": 0,  # ECEF
+            "CFG_TMODE_LAT": 0,
+            "CFG_TMODE_LON": 0,
+            "CFG_TMODE_HEIGHT": 0,
+            "CFG_TMODE_ECEF_X": 0,
+            "CFG_TMODE_ECEF_Y": 0,
+            "CFG_TMODE_ECEF_Z": 0,
+            "CFG_TMODE_ECEF_X_HP": 0,
+            "CFG_TMODE_ECEF_Y_HP": 0,
+            "CFG_TMODE_ECEF_Z_HP": 0,
+            "CFG_TMODE_FIXED_POS_ACC": 0,
+        }
+        result = UbloxDriver._parse_cfg_tmode(values)  # pyright: ignore[reportPrivateUsage]
         assert result.mode.value == "disabled"
         assert result.pos_type == "ecef"
 
     def test_parse_survey_in_mode(self) -> None:  # pyright: ignore[reportPrivateUsage]
         """Survey-in mode with LLH pos_type."""
-        parsed = SimpleNamespace(
-            CFG_TMODE_MODE=1,  # SURVEY_IN
-            CFG_TMODE_POS_TYPE=1,  # LLH
-            CFG_TMODE_LAT=0,
-            CFG_TMODE_LON=0,
-            CFG_TMODE_HEIGHT=0,
-            CFG_TMODE_ECEF_X=0,
-            CFG_TMODE_ECEF_Y=0,
-            CFG_TMODE_ECEF_Z=0,
-            CFG_TMODE_ECEF_X_HP=0,
-            CFG_TMODE_ECEF_Y_HP=0,
-            CFG_TMODE_ECEF_Z_HP=0,
-            CFG_TMODE_FIXED_POS_ACC=0,
-        )
-        result = UbloxDriver._parse_cfg_tmode(parsed)  # pyright: ignore[reportPrivateUsage]
+        values = {
+            "CFG_TMODE_MODE": 1,  # SURVEY_IN
+            "CFG_TMODE_POS_TYPE": 1,  # LLH
+            "CFG_TMODE_LAT": 0,
+            "CFG_TMODE_LON": 0,
+            "CFG_TMODE_HEIGHT": 0,
+            "CFG_TMODE_ECEF_X": 0,
+            "CFG_TMODE_ECEF_Y": 0,
+            "CFG_TMODE_ECEF_Z": 0,
+            "CFG_TMODE_ECEF_X_HP": 0,
+            "CFG_TMODE_ECEF_Y_HP": 0,
+            "CFG_TMODE_ECEF_Z_HP": 0,
+            "CFG_TMODE_FIXED_POS_ACC": 0,
+        }
+        result = UbloxDriver._parse_cfg_tmode(values)  # pyright: ignore[reportPrivateUsage]
         assert result.mode.value == "survey_in"
         assert result.pos_type == "llh"
+
+
+# ---------------------------------------------------------------------------
+# Driver get_base_config / _read_ecef_locked retry tests (issue #121)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def connected_driver() -> UbloxDriver:
+    driver = UbloxDriver()
+    mock_serial = MagicMock()
+    mock_serial.is_open = True
+    mock_reader = MagicMock()
+    driver._serial = mock_serial  # pyright: ignore[reportPrivateUsage]
+    driver._reader = mock_reader  # pyright: ignore[reportPrivateUsage]
+    return driver
+
+
+class TestUbloxGetBaseConfig:
+    """Tests for UbloxDriver.get_base_config (issue #121)."""
+
+    def test_get_base_config_success(self, connected_driver: UbloxDriver) -> None:
+        response = SimpleNamespace(
+            identity="CFG-VALGET",
+            CFG_TMODE_MODE=2,
+            CFG_TMODE_POS_TYPE=1,
+            CFG_TMODE_LAT=473977000,
+            CFG_TMODE_LON=85456000,
+            CFG_TMODE_HEIGHT=40800,
+            CFG_TMODE_FIXED_POS_ACC=5000,
+        )
+        connected_driver._reader.read.return_value = (  # pyright: ignore[reportPrivateUsage]
+            b"",
+            response,
+        )
+        config = connected_driver.get_base_config()
+        assert config.mode.value == "fixed"
+        assert config.pos_type == "llh"
+
+    def test_get_base_config_retries_on_timeout_then_succeeds(
+        self, connected_driver: UbloxDriver
+    ) -> None:
+        """A CFG-VALGET reply missed once (busy receiver) doesn't fail
+        the whole read — the poll is re-issued (issue #121, follow-up
+        to #119/#120)."""
+        with patch.object(
+            UbloxDriver, "_read_cfg_keys_locked", autospec=True
+        ) as mock_read:
+            mock_read.side_effect = [
+                RuntimeError("No CFG-VALGET response for config keys"),
+                {"CFG_TMODE_MODE": 0, "CFG_TMODE_POS_TYPE": 1},
+            ]
+            config = connected_driver.get_base_config()
+            assert config.mode.value == "disabled"
+            assert mock_read.call_count == 2
+
+    def test_get_base_config_gives_up_after_three_attempts(
+        self, connected_driver: UbloxDriver
+    ) -> None:
+        with patch.object(
+            UbloxDriver, "_read_cfg_keys_locked", autospec=True
+        ) as mock_read:
+            mock_read.side_effect = RuntimeError(
+                "No CFG-VALGET response for config keys"
+            )
+            with pytest.raises(RuntimeError, match="No CFG-VALGET response"):
+                connected_driver.get_base_config()
+            assert mock_read.call_count == 3
+
+    def test_get_base_config_nak_is_not_retried(
+        self, connected_driver: UbloxDriver
+    ) -> None:
+        """A genuine NAK is a distinct, definitive rejection — it must
+        propagate immediately, not be masked by the timeout retry."""
+        with patch.object(
+            UbloxDriver, "_read_cfg_keys_locked", autospec=True
+        ) as mock_read:
+            mock_read.side_effect = RuntimeError(
+                "Device rejected CFG-VALGET poll for [...] (NAK)"
+            )
+            with pytest.raises(RuntimeError, match="NAK"):
+                connected_driver.get_base_config()
+            assert mock_read.call_count == 1
+
+    def test_get_base_config_not_connected(self) -> None:
+        driver = UbloxDriver()
+        with pytest.raises(ConnectionError):
+            driver.get_base_config()
+
+
+class TestUbloxReadEcef:
+    """Tests for UbloxDriver._read_ecef_locked (issue #121)."""
+
+    def test_read_ecef_success(self, connected_driver: UbloxDriver) -> None:
+        response = SimpleNamespace(
+            identity="CFG-VALGET",
+            CFG_TMODE_ECEF_X=-245790204,
+            CFG_TMODE_ECEF_Y=-477512066,
+            CFG_TMODE_ECEF_Z=342909332,
+        )
+        connected_driver._reader.read.return_value = (  # pyright: ignore[reportPrivateUsage]
+            b"",
+            response,
+        )
+        with connected_driver._lock:  # pyright: ignore[reportPrivateUsage]
+            result = connected_driver._read_ecef_locked()  # pyright: ignore[reportPrivateUsage]
+        assert result == (-245790204, -477512066, 342909332)
+
+    def test_read_ecef_retries_on_timeout_then_succeeds(
+        self, connected_driver: UbloxDriver
+    ) -> None:
+        with patch.object(
+            UbloxDriver, "_read_cfg_keys_locked", autospec=True
+        ) as mock_read:
+            mock_read.side_effect = [
+                RuntimeError("No CFG-VALGET response for config keys"),
+                {
+                    "CFG_TMODE_ECEF_X": 1,
+                    "CFG_TMODE_ECEF_Y": 2,
+                    "CFG_TMODE_ECEF_Z": 3,
+                },
+            ]
+            with connected_driver._lock:  # pyright: ignore[reportPrivateUsage]
+                result = connected_driver._read_ecef_locked()  # pyright: ignore[reportPrivateUsage]
+            assert result == (1, 2, 3)
+            assert mock_read.call_count == 2
+
+    def test_read_ecef_gives_up_after_three_attempts(
+        self, connected_driver: UbloxDriver
+    ) -> None:
+        with patch.object(
+            UbloxDriver, "_read_cfg_keys_locked", autospec=True
+        ) as mock_read:
+            mock_read.side_effect = RuntimeError(
+                "No CFG-VALGET response for config keys"
+            )
+            with pytest.raises(RuntimeError, match="No CFG-VALGET response"):
+                with connected_driver._lock:  # pyright: ignore[reportPrivateUsage]
+                    connected_driver._read_ecef_locked()  # pyright: ignore[reportPrivateUsage]
+            assert mock_read.call_count == 3
+
+    def test_read_ecef_nak_is_not_retried(self, connected_driver: UbloxDriver) -> None:
+        with patch.object(
+            UbloxDriver, "_read_cfg_keys_locked", autospec=True
+        ) as mock_read:
+            mock_read.side_effect = RuntimeError(
+                "Device rejected CFG-VALGET poll for [...] (NAK)"
+            )
+            with pytest.raises(RuntimeError, match="NAK"):
+                with connected_driver._lock:  # pyright: ignore[reportPrivateUsage]
+                    connected_driver._read_ecef_locked()  # pyright: ignore[reportPrivateUsage]
+            assert mock_read.call_count == 1
 
 
 class TestEcefToLlh:


### PR DESCRIPTION
## Summary

Follow-up to #119/#120. PR #120 added `_read_cfg_keys_with_retry_locked` and routed `get_rtcm_port_config`/`get_port_protocols` through it, but missed two sibling CFG-VALGET readers that still hand-rolled their own no-retry read loop and fail the exact same way:

- `_get_base_config_locked` — the TMODE/base-config read behind the Fixed Base Position box (`survey.py`), which was intermittently showing a red **Error** badge on a fixed-base receiver streaming RTCM.
- `_read_ecef_locked` — the ECEF read-back used to verify a fixed-base write actually took effect.

Both now route through the existing `_read_cfg_keys_with_retry_locked` wrapper (retry a bare timeout up to 3×, re-raise an ACK-NAK immediately, unchanged from #120). `_parse_cfg_tmode` is adapted to take the wrapper's `dict[str, int]` instead of a raw parsed object, mirroring the #120 pattern for the RTCM/port-protocol parsers.

Also bumps a `logger.debug` → `logger.warning` in `ui/pages/survey.py` at the line that swallows a base-config read failure into a bare "Error" badge with no journal trace, per the issue's "Also fix the logging" section.

Fixes #121.

## Test plan

- [x] `uv run pytest` — 1567 passed, 95.16% coverage (gate: 90%)
- [x] `uv run pyright src/` — 0 errors
- [x] `uv run mypy` on touched files — clean
- [x] `uv run ruff check` / `ruff format --check` — clean
- [x] New tests: `TestUbloxGetBaseConfig` / `TestUbloxReadEcef` (success, retry-then-succeed, exhausted-retries, NAK-not-retried); `TestParseCfgTmode` updated to dict-based inputs
- [x] Two-axis code review (Standards + Spec) — 0 hard violations, 0 spec gaps; see PR discussion for the two minor judgment-call notes
- [ ] Hardware verification on vaio-base (ZED-F9P, fixed-base mode, RTCM streaming) — not done by this PR, recommend before closing #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVYMZRfrCSQF7UHkW46hA6