### PR TITLE
build(deps): bump sp_rtk_base_relay to >=3.0.0 and fix the broken call site

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "pyserial>=3.5",
     "pyubx2>=1.2.43",
     "pyyaml>=6.0.3",
-    "sp_rtk_base_relay>=2.1.3",
+    "sp_rtk_base_relay>=3.0.0",
 
     "uvicorn>=0.42.0",
 ]

--- a/src/sp_rtk_base/ui/pages/input.py
+++ b/src/sp_rtk_base/ui/pages/input.py
@@ -424,6 +424,7 @@ def input_page() -> None:
                     async def _test_bluetooth_connection() -> None:
                         """Test pair + trust + RFCOMM discovery."""
                         mac = str(addr_input.value or "").strip()
+                        pin = str(pin_input.value or "").strip() or "0000"
                         if not mac:
                             ui.notify(
                                 "Enter a device address first",
@@ -445,11 +446,17 @@ def input_page() -> None:
                                 )
                                 bt_state["bt_manager"] = mgr
 
-                            # ensure_device_ready: pair + trust + RFCOMM
+                            # ensure_device_ready: pair + trust + RFCOMM.
+                            # Keyword-only: relay v3.0.0 made ``pin`` the
+                            # first required positional, so the previous
+                            # positional ``(None, mac)`` call would now
+                            # bind ``pin=None, device_name=<the MAC>``
+                            # and name-scan for a MAC string.
                             result_mac, channel = await asyncio.to_thread(
                                 mgr.ensure_device_ready,  # type: ignore[union-attr]
-                                None,  # device_name
-                                mac,  # mac_address
+                                pin=pin,
+                                device_name=None,
+                                mac_address=mac,
                             )
 
                             # Auto-fill channel

--- a/uv.lock
+++ b/uv.lock
@@ -2748,7 +2748,7 @@ requires-dist = [
     { name = "pyserial", specifier = ">=3.5" },
     { name = "pyubx2", specifier = ">=1.2.43" },
     { name = "pyyaml", specifier = ">=6.0.3" },
-    { name = "sp-rtk-base-relay", specifier = ">=2.1.3" },
+    { name = "sp-rtk-base-relay", specifier = ">=3.0.0" },
     { name = "uvicorn", specifier = ">=0.42.0" },
 ]
 
@@ -2771,7 +2771,7 @@ dev = [
 
 [[package]]
 name = "sp-rtk-base-relay"
-version = "2.1.3"
+version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dbus-fast" },
@@ -2779,9 +2779,9 @@ dependencies = [
     { name = "pyserial" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2c/b2/4edfcd2ba9c0be4f5493b0b0b7ef5a594c7f79964f78056afa57e05aa44f/sp_rtk_base_relay-2.1.3.tar.gz", hash = "sha256:b4eaadadf1f5c859e2961733f1269f0565442400a7a5fbd492afe6b6fa89e338", size = 91294, upload-time = "2026-05-29T00:07:10.355Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/97/03/a3426873f3e57bec7e15813767e836655f394eb906e0003982451d2c3628/sp_rtk_base_relay-3.0.0.tar.gz", hash = "sha256:90cb692391efe8cb99c4381d53b22ed4930e230baba974182aaeef9e65bce3df", size = 99553, upload-time = "2026-09-03T16:26:00.315Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/9d/b7b93c5f2f3ee7c95f18c707e26dcff2748da309fd1fa6b2257521757bca/sp_rtk_base_relay-2.1.3-py3-none-any.whl", hash = "sha256:a16e7f3eb01d9c473476c85e34a423094e53d64031004a4d191afc6cf6bbce87", size = 108157, upload-time = "2026-05-29T00:07:08.944Z" },
+    { url = "https://files.pythonhosted.org/packages/60/09/9171b5776e66c982fe6734f753a4e352c78f590356c6a9aa3f5fa7875f2f/sp_rtk_base_relay-3.0.0-py3-none-any.whl", hash = "sha256:5a80b777d101c1504d6cebaccce8ac70ab1ecddea3c329360163224261e58283", size = 111796, upload-time = "2026-09-03T16:25:58.894Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps `sp_rtk_base_relay` to `>=3.0.0` and repairs the call site that the bump breaks. First ticket of wayfinder map #125, working toward #124.

## Why these two changes can't be separated

relay v3.0.0 made `pin` the **first required positional** argument:

```python
ensure_device_ready(self, pin: str, device_name: str | None = None,
                    mac_address: str | None = None, scan_timeout: int = 30)
```

The Bluetooth "Test Connection" handler called it positionally as `(None, mac)`. Under 2.1.3 that meant `device_name=None, mac_address=<MAC>`. Under 3.0.0 the same line binds `pin=None, device_name=<the MAC>` — so it would name-scan for a MAC-address string and never look at the MAC field at all. Bumping without the call-site fix breaks Test Connection; fixing the call site without the bump doesn't compile against 2.1.3's signature.

## What this does *not* fix

Test Connection still lies, exactly as much as it did before. `pair_device`'s `if paired: return True` fast path still short-circuits before the PIN is consulted, so an already-bonded device reports success for any configured PIN. That's the subject of #124 and the remaining tickets on map #125. This PR is deliberately scoped to **same behaviour, new library**, so the dependency move is reviewable on its own.

## Sweep

`ensure_device_ready` appears exactly once across `src/`, `tests/` and `tools/`. No caller of `pair_device`, `trust_device` or `force_repair` exists in this repo yet.

The only other `BluetoothManager` construction is `services/__init__.py:220` (`_release_stale_bluetooth_handle`), which takes no arguments so the signature change misses it. Verified — not assumed — that it closes its manager in a `finally`: under 3.0.0, construction registers a default `org.bluez.Agent1`, and a leaked manager would steal BlueZ's default agent from a running relay and make its reconnect pairing fail. Filed upstream as rodenj1/sp-rtk-base-relay#22.

## Known follow-up (not fixed here)

`_save_input` persists an empty string when the PIN field is blank, while the relay's `BluetoothConfig.pin` default is `"0000"` and the test path here falls back to `"0000"`. Test and Save can therefore send different PINs for the same form state. Out of scope for a behaviour-preserving bump; tracked on #127.

## Verification

- `uv run ruff check src/ tests/` — clean
- `uv run ruff format --check` — 140 files already formatted
- `uv run pyright src/` — 0 errors (1 pre-existing `reportDeprecated` warning in `ui/layout.py`, unrelated)
- `uv run mypy src/` — clean, 57 files
- `uv run pytest` — **1567 passed, 95.16% coverage**
- All pre-commit hooks passed at commit time

Suite re-run after branching onto `origin/main` to confirm the result held on the new base.

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVYMZRfrCSQF7UHkW46hA6
