### PR TITLE
build(deps): bump sp_rtk_base_relay to >=3.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "pyserial>=3.5",
     "pyubx2>=1.2.43",
     "pyyaml>=6.0.3",
-    "sp_rtk_base_relay>=3.0.0",
+    "sp_rtk_base_relay>=3.1.1",
 
     "uvicorn>=0.42.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -2748,7 +2748,7 @@ requires-dist = [
     { name = "pyserial", specifier = ">=3.5" },
     { name = "pyubx2", specifier = ">=1.2.43" },
     { name = "pyyaml", specifier = ">=6.0.3" },
-    { name = "sp-rtk-base-relay", specifier = ">=3.0.0" },
+    { name = "sp-rtk-base-relay", specifier = ">=3.1.1" },
     { name = "uvicorn", specifier = ">=0.42.0" },
 ]
 
@@ -2771,7 +2771,7 @@ dev = [
 
 [[package]]
 name = "sp-rtk-base-relay"
-version = "3.0.0"
+version = "3.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dbus-fast" },
@@ -2779,9 +2779,9 @@ dependencies = [
     { name = "pyserial" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/97/03/a3426873f3e57bec7e15813767e836655f394eb906e0003982451d2c3628/sp_rtk_base_relay-3.0.0.tar.gz", hash = "sha256:90cb692391efe8cb99c4381d53b22ed4930e230baba974182aaeef9e65bce3df", size = 99553, upload-time = "2026-09-03T16:26:00.315Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/85/068801ad2071c478521ee1d18df9efa34f38b2cbb06f0eb247c68c509170/sp_rtk_base_relay-3.1.1.tar.gz", hash = "sha256:2678676f4e0698d7cac508f3fb99d32d88c883b2f40dcda215d39ab5a5d065a9", size = 103002, upload-time = "2026-09-04T05:20:52.065Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/09/9171b5776e66c982fe6734f753a4e352c78f590356c6a9aa3f5fa7875f2f/sp_rtk_base_relay-3.0.0-py3-none-any.whl", hash = "sha256:5a80b777d101c1504d6cebaccce8ac70ab1ecddea3c329360163224261e58283", size = 111796, upload-time = "2026-09-03T16:25:58.894Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/15/0b40e7f097d359c5f74b240807d6462fc1c56640ad25a07425848b4d13e7/sp_rtk_base_relay-3.1.1-py3-none-any.whl", hash = "sha256:cfeee6cdb026100dd297dccd23f460a480aa3d9c7f5b97493ed6d0e8ed5cb252", size = 115273, upload-time = "2026-09-04T05:20:50.586Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps the relay constraint `>=3.0.0` → `>=3.1.1` and re-locks.

## Why this is not a routine bump

**3.1.1 is the first release in which automatic Bluetooth pairing actually works.** `Properties.Get` answers with a `dbus_fast` `Variant`, which defines no `__bool__` and is therefore always truthy — including one wrapping `False`. `_async_pair_device` branched on that raw read, so the "already paired" fast path was taken unconditionally and `Device1.Pair()` was never reached. That was equally true of v3.0.0 and v3.1.0 (relay issue #39); all of v3.0.0's pairing work — the Agent1, the PIN threading, `force_repair` — sat downstream of a branch that never executed.

For this app that is the difference between the Verification working and being theatre. On `>=3.0.0`, `force_repair` returned success **without ever exercising the PIN**, so a Verification would have gone **Green for a wrong PIN** — exactly the bug #124 exists to kill, one layer down. The wrong-PIN-goes-red acceptance case in #132 could not have passed, and the failure would have looked like a defect in the verification service.

## What else rides along

3.1.1 carries 3.1.0's `claim_default_agent` change: a `BluetoothManager` no longer seizes BlueZ's system-wide default pairing agent on construction, opting in only where the relay wants it. Our short-lived verification manager wants the new default of `False`, so **no call-site change is needed** — and the app-side guarantees already in `main` (refuse while the relay is running, close the manager on every path) become belt-and-braces rather than the only protection against the collision. That collision was listed as *out of scope* on the map in #125; the relay has now fixed it at source.

## Verified before bumping

Installed the relay checkout as an editable dependency and ran the full suite against it, so this was not a bump-and-hope:

- The API surface we drive is unchanged: `ensure_device_ready`, `force_repair`, `find_device_by_mac`, `discover_rfcomm_channel`, `disconnect_device`, `close`.
- `force_repair` still raises `force_repair: {stage} stage failed:`, which our exact stage attribution parses — so Stranded detection still works.
- `pair_device` still short-circuits on an existing bond (its return value merely gains meaning: `True` = created the bond, `False` = already bonded, failure raises). So #128's load-bearing premise — *a Bond carries the connection whatever the configured PIN says* — still holds, and the force-repair safety policy needs no redesign.

## Gates

1709 unit tests, 95.53% coverage (gate 90%); 97 e2e; pyright strict and mypy strict clean, all on 3.1.1.

Hardware acceptance remains #132 — and should now be run against this, not against `main` as it stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVYMZRfrCSQF7UHkW46hA6
