### PR TITLE
test(e2e): wait for the picker options to have a layout box

### DIFF
--- a/tests/e2e/test_gps_profile_picker.py
+++ b/tests/e2e/test_gps_profile_picker.py
@@ -32,11 +32,12 @@ every test that inspects an option opens the picker first via
 from __future__ import annotations
 
 import re
+import time
 from collections.abc import Iterator
 
 import httpx
 import pytest
-from playwright.sync_api import Page, expect
+from playwright.sync_api import Locator, Page, expect
 
 from sp_rtk_base.services.drivers.fake import FAKE_UNKNOWN_HW_PORT
 
@@ -119,6 +120,43 @@ def _open_picker(page: Page) -> None:
     page.locator(".profile-picker").click()
 
 
+def _settled_bounding_box(
+    locator: Locator, timeout_ms: int = 10_000
+) -> dict[str, float]:
+    """Return *locator*'s box once it has one, not whatever is there now.
+
+    ``bounding_box()`` is a plain read. Unlike ``expect()`` it does not
+    auto-wait, and it answers ``None`` for an element that is attached
+    but has no layout box yet. The Quasar ``q-menu`` mounts its options
+    and *then* animates open, and NiceGUI can re-render a node inside
+    that window — so an option can satisfy ``to_be_visible()`` and still
+    have no box a moment later when we ask for geometry.
+
+    That window is narrow enough never to lose on a developer machine
+    and wide enough to lose on a loaded CI runner, which is exactly how
+    it showed up: green locally on every run, red on GitHub Actions.
+
+    Args:
+        locator: The element to measure.
+        timeout_ms: How long to keep asking before giving up.
+
+    Returns:
+        The element's bounding box.
+
+    Raises:
+        AssertionError: If no box appears within *timeout_ms*.
+    """
+    deadline = time.monotonic() + timeout_ms / 1000
+    box = locator.bounding_box()
+    while box is None and time.monotonic() < deadline:
+        locator.page.wait_for_timeout(50)
+        box = locator.bounding_box()
+    assert box is not None, (
+        f"{locator} never produced a layout box within {timeout_ms} ms"
+    )
+    return box
+
+
 @pytest.mark.e2e
 def test_form_seeds_matrix_and_gnss_from_live_receiver(
     page: Page,
@@ -198,9 +236,8 @@ def test_picker_is_a_dropdown_listing_builtin_before_custom(
     expect(builtin_option).to_be_visible(timeout=10_000)
     expect(custom_option).to_be_visible(timeout=10_000)
 
-    builtin_box = builtin_option.bounding_box()
-    custom_box = custom_option.bounding_box()
-    assert builtin_box is not None and custom_box is not None
+    builtin_box = _settled_bounding_box(builtin_option)
+    custom_box = _settled_bounding_box(custom_option)
     assert builtin_box["y"] < custom_box["y"], (
         "built-in profile should render above the custom profile"
     )


### PR DESCRIPTION
Fixes the intermittent E2E failure that went red on #135.

## What failed

`test_gps_profile_picker.py::test_picker_is_a_dropdown_listing_builtin_before_custom`, with:

```
assert builtin_box is not None and custom_box is not None
E  assert (None is not None)
```

`bounding_box()` answered `None` for an option that had just satisfied `to_be_visible()` on the line above.

## Why

`bounding_box()` is a plain read. Unlike `expect()` it does **not** auto-wait, and it answers `None` for an element that is attached but has no layout box yet. The Quasar `q-menu` mounts its options and *then* animates open, and NiceGUI can re-render a node inside that window — so an option can be visible one moment and boxless the next.

That window is narrow enough never to lose on a developer machine and wide enough to lose on a loaded runner. It presented exactly that way: green locally on every run (I ran it 3× back to back), red on GitHub Actions, then **green again on a re-run of the same commit** — which is what confirms a race rather than a real defect.

## The fix

Geometry now goes through `_settled_bounding_box`, which keeps asking until a box appears.

The assertion itself is unchanged. This test is about *visual* ordering, so it still compares real geometry rather than retreating to DOM order — which would keep passing even if CSS reordered the list, quietly weakening what the test proves.

## Note

This is the second failure of this shape in this suite, after `6dd1025` (the SPI checkbox, where a click was waited on with an assertion three earlier edits had already satisfied). Both have the same root: **a step that reads state without waiting for the state it is about to assert.** Worth keeping in mind when adding to this suite — `expect()` auto-waits, but direct reads like `bounding_box()`, `input_value()` and `text_content()` do not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVYMZRfrCSQF7UHkW46hA6
