### PR TITLE
test(e2e): fix the two intermittent E2E races

### DIFF
--- a/tests/e2e/test_gps_hardware_fields.py
+++ b/tests/e2e/test_gps_hardware_fields.py
@@ -21,6 +21,8 @@ don't see these) — see :func:`_expect_checked`/:func:`_expect_disabled`.
 
 from __future__ import annotations
 
+import time
+
 import httpx
 import pytest
 from playwright.sync_api import Locator, Page, expect
@@ -35,6 +37,65 @@ def _goto_gps_config(page: Page, base_url: str) -> None:
 
 def _expect_checked(checkbox: Locator, *, checked: bool) -> None:
     expect(checkbox).to_have_attribute("aria-checked", "true" if checked else "false")
+
+
+def _wait_for_hw_section_settled(
+    page: Page,
+    probe: Locator,
+    quiet_ms: int = 750,
+    timeout_ms: int = 15_000,
+) -> None:
+    """Wait until the hw-extras section stops being re-rendered.
+
+    Every hardware-field handler re-renders the *entire* section over a
+    websocket round trip, replacing each node in it with a fresh one.
+    Waiting on a text input cannot detect that: ``fill()`` sets the
+    value client-side, so ``to_have_value("10")`` is satisfied before
+    the server has even heard about the edit, let alone re-rendered.
+
+    A click that lands inside that window is simply lost — the incoming
+    node is rendered from state that never saw it — and Playwright's
+    actionability checks cannot help, because the node it clicks is
+    attached, visible and stable right up until the moment it is
+    replaced. Asserting the toggle afterwards only *detects* the loss.
+
+    So the section's churn is watched directly. NiceGUI gives each
+    element a fresh ``id`` on re-render, so an id that holds still for
+    *quiet_ms* means no further rebuild is in flight.
+
+    Args:
+        page: The page under test.
+        probe: Any element inside the section; its ``id`` is the signal.
+        quiet_ms: How long the id must hold still to count as settled.
+        timeout_ms: How long to wait for that to happen.
+
+    Raises:
+        AssertionError: If the section never settles in *timeout_ms*.
+    """
+    deadline = time.monotonic() + timeout_ms / 1000
+    last_id: str | None = None
+    unchanged_since: float | None = None
+
+    while time.monotonic() < deadline:
+        try:
+            current = probe.get_attribute("id", timeout=1_000)
+        except Exception:  # mid-rebuild the node can briefly vanish
+            current = None
+
+        if current is not None and current == last_id:
+            if unchanged_since is None:
+                unchanged_since = time.monotonic()
+            elif (time.monotonic() - unchanged_since) * 1000 >= quiet_ms:
+                return
+        else:
+            last_id = current
+            unchanged_since = None
+
+        page.wait_for_timeout(100)
+
+    raise AssertionError(
+        f"hw-extras section was still re-rendering after {timeout_ms} ms"
+    )
 
 
 def _expect_disabled(checkbox: Locator, *, disabled: bool) -> None:
@@ -134,18 +195,24 @@ def test_hardware_extras_are_editable_and_apply(
     expect(elevation).to_have_value("10", timeout=10_000)
 
     spi = page.locator(".hw-field-spi-checkbox")
+
+    # The elevation edit above re-renders this whole section, and
+    # `to_have_value("10")` did not wait for that — `fill()` satisfies
+    # it client-side. Clicking now would race the incoming re-render and
+    # the toggle would be discarded with the outgoing node, so wait for
+    # the churn to stop first. Observed on CI as the checkbox's id
+    # changing from c412 to c438 mid-assertion, the replacement arriving
+    # still checked.
+    _wait_for_hw_section_settled(page, spi)
+
     _expect_checked(spi, checked=True)  # on by default on the fake driver
     spi.click()
 
-    # Wait for *this* edit's own effect, exactly as the three edits
-    # above do.  The obvious wait — the sync badge going dirty — is a
-    # no-op here: the meas-rate, dyn-model and elevation edits already
-    # made it say "unapplied change", so it is satisfied the instant it
-    # is evaluated and proves nothing about whether the SPI click
-    # landed.  That left the click racing the elevation edit's still
-    # in-flight section rebuild, and on a slow runner it lost: the
-    # click hit a node about to be torn down, SPI stayed on, and the
-    # post-Apply assertion below saw `true`.
+    # Assert this edit's own effect, as the three edits above do. The
+    # obvious wait — the sync badge going dirty — is a no-op here: the
+    # meas-rate, dyn-model and elevation edits already made it say
+    # "unapplied change", so it is satisfied the instant it is evaluated
+    # and says nothing about whether the SPI click landed.
     _expect_checked(spi, checked=False)
     expect(sync_badge).to_contain_text("unapplied change")
 

--- a/tests/e2e/test_gps_profile_picker.py
+++ b/tests/e2e/test_gps_profile_picker.py
@@ -32,11 +32,12 @@ every test that inspects an option opens the picker first via
 from __future__ import annotations
 
 import re
+import time
 from collections.abc import Iterator
 
 import httpx
 import pytest
-from playwright.sync_api import Page, expect
+from playwright.sync_api import Locator, Page, expect
 
 from sp_rtk_base.services.drivers.fake import FAKE_UNKNOWN_HW_PORT
 
@@ -119,6 +120,43 @@ def _open_picker(page: Page) -> None:
     page.locator(".profile-picker").click()
 
 
+def _settled_bounding_box(
+    locator: Locator, timeout_ms: int = 10_000
+) -> dict[str, float]:
+    """Return *locator*'s box once it has one, not whatever is there now.
+
+    ``bounding_box()`` is a plain read. Unlike ``expect()`` it does not
+    auto-wait, and it answers ``None`` for an element that is attached
+    but has no layout box yet. The Quasar ``q-menu`` mounts its options
+    and *then* animates open, and NiceGUI can re-render a node inside
+    that window — so an option can satisfy ``to_be_visible()`` and still
+    have no box a moment later when we ask for geometry.
+
+    That window is narrow enough never to lose on a developer machine
+    and wide enough to lose on a loaded CI runner, which is exactly how
+    it showed up: green locally on every run, red on GitHub Actions.
+
+    Args:
+        locator: The element to measure.
+        timeout_ms: How long to keep asking before giving up.
+
+    Returns:
+        The element's bounding box.
+
+    Raises:
+        AssertionError: If no box appears within *timeout_ms*.
+    """
+    deadline = time.monotonic() + timeout_ms / 1000
+    box = locator.bounding_box()
+    while box is None and time.monotonic() < deadline:
+        locator.page.wait_for_timeout(50)
+        box = locator.bounding_box()
+    assert box is not None, (
+        f"{locator} never produced a layout box within {timeout_ms} ms"
+    )
+    return box
+
+
 @pytest.mark.e2e
 def test_form_seeds_matrix_and_gnss_from_live_receiver(
     page: Page,
@@ -198,9 +236,8 @@ def test_picker_is_a_dropdown_listing_builtin_before_custom(
     expect(builtin_option).to_be_visible(timeout=10_000)
     expect(custom_option).to_be_visible(timeout=10_000)
 
-    builtin_box = builtin_option.bounding_box()
-    custom_box = custom_option.bounding_box()
-    assert builtin_box is not None and custom_box is not None
+    builtin_box = _settled_bounding_box(builtin_option)
+    custom_box = _settled_bounding_box(custom_option)
     assert builtin_box["y"] < custom_box["y"], (
         "built-in profile should render above the custom profile"
     )


### PR DESCRIPTION
Fixes both intermittent E2E failures. They're together because each was blocking the other's PR from going green. **Supersedes #136**, whose picker fix is included here.

## 1. SPI checkbox — my earlier fix was insufficient

`6dd1025` asserted the toggle's own effect *after* the click. That correctly **detected** the dropped click but did nothing to prevent it, so CI simply failed one line earlier — and in doing so said exactly what was happening:

```
2  × locator resolved to <div id="c412" ... aria-checked="true">
12 × locator resolved to <div id="c438" ... aria-checked="true">
```

The node was replaced mid-assertion, and the replacement arrived still checked.

**The cause is the edit before it.** Every hardware-field handler re-renders the whole hw-extras section over a websocket round trip, and `expect(elevation).to_have_value("10")` does not wait for that — `fill()` satisfies it *client-side*, before the server has heard about the edit at all. So the SPI click landed inside the incoming re-render and was discarded along with the outgoing node.

Playwright's actionability checks cannot help: the node it clicks is attached, visible and stable right up until the moment it is replaced.

`_wait_for_hw_section_settled` now watches the section's churn directly — NiceGUI gives each element a fresh `id` on re-render, so an id that holds still means no rebuild is in flight — and the click waits for quiet before firing. The post-click assertion stays, now as a check rather than the whole defence.

## 2. Profile picker

`bounding_box()` is a plain read: unlike `expect()` it does not auto-wait, and answers `None` for an element that is attached but has no layout box yet. The Quasar `q-menu` mounts its options and *then* animates open, so an option can satisfy `to_be_visible()` and be boxless a moment later.

Geometry now goes through `_settled_bounding_box`. The assertion is unchanged — this test is about *visual* ordering, so it still compares real geometry rather than retreating to DOM order, which would keep passing even if CSS reordered the list.

## The pattern

Both failures are the same shape: **a step that reads state without waiting for the state it is about to assert.** `expect()` auto-waits; direct reads like `bounding_box()`, `get_attribute()` and `input_value()` do not. Worth remembering when adding to this suite.

## Caveat on verification

Both are green locally on every run — they always were; that is the nature of the bug. **CI is the only place either failure reproduces**, so CI on this PR is the real test of the fix. I've verified the full suite (97 e2e) passes locally and that the mechanism matches the CI evidence quoted above, but I'd treat a green run here as the confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVYMZRfrCSQF7UHkW46hA6




## Closes #123

#123 filed this race and suggested exactly the fix `6dd1025` made — a post-click `_expect_checked(spi, checked=False)`. That suggestion turns out to be **necessary but not sufficient**, and this PR records why: the settle-wait it proposed detects a dropped click but cannot prevent one, because the click was already lost to the *preceding* edit's in-flight re-render.

#123's own acceptance note asked for the suite to be looped before closing "since this is a timing race that passed locally for #118 despite the underlying gap". That caution was well placed — it held true a second time, and locally is still not where either race reproduces.

Closes #123
